### PR TITLE
Make the parsing of npm pack output more robust

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -183,7 +183,8 @@ async function npmPack(packageDir: string, tmpdir: string): Promise<string> {
         args.push('--loglevel=verbose');
     }
     const out = await shell('npm', args, { cwd: tmpdir });
-    return path.resolve(tmpdir, out.trim());
+    const lines = out.trim().split(os.EOL);
+    return path.resolve(tmpdir, lines[lines.length - 1].trim());
 }
 
 async function updateNpmIgnore(packageDir: string, excludeOutdir: string | undefined) {


### PR DESCRIPTION
npm pack may have additional output with it and when we send all
of that output to path.resolve() it results in including a bunch of
other output that's not needed.

This changes makes us only take the last line of that output which should have the tarball name there.

We may want to be a little more clever and not rely on output parsing. (package name + version .tgz instead)

Fixes #172

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
