### PR TITLE
Fix `npm run lint` for `jsii-ruby-runtime`.

### DIFF
--- a/packages/jsii-ruby-runtime/project/.rubocop.yml
+++ b/packages/jsii-ruby-runtime/project/.rubocop.yml
@@ -15,3 +15,7 @@ Style/IfUnlessModifier:
 
 Metrics/AbcSize:
   Enabled: false
+
+AllCops:
+  TargetRubyVersion: 2.2
+


### PR DESCRIPTION
Currently, `npm run lint` fails because `rubolint` uses `2.1` as the default `TargetRubyVersion`, which does not match `s.required_ruby_version = '>= 2.2'` from `jsii_runtime.gemspec`. This changeset fixes that issue by specifying a `TargetRubyVersion` in `.rubocop.yml`.