### PR TITLE
Remove dependencies that are no longer used.

### DIFF
--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
@@ -12,8 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Node.js.redist" Version="8.9.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.5.0-rc1" />
     <PackageReference Include="Amazon.JSII.JsonModel" Version="$(JsiiVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
These dependencies were required early in development when `node` was bundled with the Amazon.JSII.Runtime. Now that we use the installed version of node, they are no longer needed.