### PR TITLE
BREAKING CHANGE: Reduce duplication of information in jsii assemblies

### DIFF
--- a/packages/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/jsii-calc-base-of-base/test/assembly.jsii
@@ -48,8 +48,7 @@
           }
         }
       ],
-      "name": "Very",
-      "namespace": "@scope/jsii-calc-base-of-base"
+      "name": "Very"
     },
     "@scope/jsii-calc-base-of-base.VeryBaseProps": {
       "assembly": "@scope/jsii-calc-base-of-base",
@@ -57,7 +56,6 @@
       "fqn": "@scope/jsii-calc-base-of-base.VeryBaseProps",
       "kind": "interface",
       "name": "VeryBaseProps",
-      "namespace": "@scope/jsii-calc-base-of-base",
       "properties": [
         {
           "name": "foo",
@@ -69,5 +67,5 @@
     }
   },
   "version": "0.6.4",
-  "fingerprint": "2YF/qObQgbuJSs52vT9/Z7sgEO0mc2zP0jCuFWGUM4w="
+  "fingerprint": "BYFoYeCugh6Ij5+JFgLKdiVReNDIC0o3t1BJkBqlN10="
 }

--- a/packages/jsii-calc-base/test/assembly.jsii
+++ b/packages/jsii-calc-base/test/assembly.jsii
@@ -76,8 +76,7 @@
           }
         }
       ],
-      "name": "Base",
-      "namespace": "@scope/jsii-calc-base"
+      "name": "Base"
     },
     "@scope/jsii-calc-base.BaseProps": {
       "assembly": "@scope/jsii-calc-base",
@@ -90,7 +89,6 @@
       ],
       "kind": "interface",
       "name": "BaseProps",
-      "namespace": "@scope/jsii-calc-base",
       "properties": [
         {
           "name": "bar",
@@ -102,5 +100,5 @@
     }
   },
   "version": "0.6.4",
-  "fingerprint": "3lcys0/Cd5ZbPR/CXccsL3Fdb66mNsVBs8jb+ySL0oU="
+  "fingerprint": "3AQHE+SKelQy94tarTiCYoSyQkfZyWyqSY/QU1fDmdE="
 }

--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -90,8 +90,7 @@
           "name": "Value2"
         }
       ],
-      "name": "EnumFromScopedModule",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "EnumFromScopedModule"
     },
     "@scope/jsii-calc-lib.IFriendly": {
       "assembly": "@scope/jsii-calc-lib",
@@ -111,8 +110,7 @@
           }
         }
       ],
-      "name": "IFriendly",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "IFriendly"
     },
     "@scope/jsii-calc-lib.MyFirstStruct": {
       "assembly": "@scope/jsii-calc-lib",
@@ -123,7 +121,6 @@
       "fqn": "@scope/jsii-calc-lib.MyFirstStruct",
       "kind": "interface",
       "name": "MyFirstStruct",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -185,7 +182,6 @@
       },
       "kind": "class",
       "name": "Number",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -203,6 +199,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -230,13 +229,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
-      "name": "Operation",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "Operation"
     },
     "@scope/jsii-calc-lib.StructWithOnlyOptionals": {
       "assembly": "@scope/jsii-calc-lib",
@@ -247,7 +248,6 @@
       "fqn": "@scope/jsii-calc-lib.StructWithOnlyOptionals",
       "kind": "interface",
       "name": "StructWithOnlyOptionals",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -301,7 +301,6 @@
         }
       ],
       "name": "Value",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "abstract": true,
@@ -318,5 +317,5 @@
     }
   },
   "version": "0.6.4",
-  "fingerprint": "jA30G5c81DZXD/7DMYLvdlY8XwEevVQAMAwkUBmPE64="
+  "fingerprint": "OLAA8NNlr68J5/yK8t4MB/T0+9GLicN/w/JsSqop/fA="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -207,13 +207,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Add",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -221,6 +223,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -254,7 +259,6 @@
         }
       ],
       "name": "AllTypes",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -459,8 +463,7 @@
           "name": "ThisIsGreat"
         }
       ],
-      "name": "AllTypesEnum",
-      "namespace": "jsii-calc"
+      "name": "AllTypesEnum"
     },
     "jsii-calc.AllowedMethodNames": {
       "assembly": "jsii-calc",
@@ -548,8 +551,7 @@
           ]
         }
       ],
-      "name": "AllowedMethodNames",
-      "namespace": "jsii-calc"
+      "name": "AllowedMethodNames"
     },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
@@ -615,8 +617,7 @@
           }
         }
       ],
-      "name": "AsyncVirtualMethods",
-      "namespace": "jsii-calc"
+      "name": "AsyncVirtualMethods"
     },
     "jsii-calc.BinaryOperation": {
       "abstract": true,
@@ -666,13 +667,15 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "BinaryOperation",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -784,7 +787,6 @@
         }
       ],
       "name": "Calculator",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -792,6 +794,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -883,7 +888,6 @@
       "fqn": "jsii-calc.CalculatorProps",
       "kind": "interface",
       "name": "CalculatorProps",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "initialValue",
@@ -909,7 +913,7 @@
       },
       "kind": "class",
       "name": "Base",
-      "namespace": "jsii-calc.DerivedClassHasNoProperties",
+      "namespace": "DerivedClassHasNoProperties",
       "properties": [
         {
           "name": "prop",
@@ -930,7 +934,7 @@
       },
       "kind": "class",
       "name": "Derived",
-      "namespace": "jsii-calc.DerivedClassHasNoProperties"
+      "namespace": "DerivedClassHasNoProperties"
     },
     "jsii-calc.DerivedStruct": {
       "assembly": "jsii-calc",
@@ -946,7 +950,6 @@
       ],
       "kind": "interface",
       "name": "DerivedStruct",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "anotherRequired",
@@ -1016,6 +1019,9 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1025,13 +1031,15 @@
             "comment": "Returns another random number."
           },
           "name": "next",
+          "overrides": {
+            "fqn": "jsii-calc.IRandomNumberGenerator"
+          },
           "returns": {
             "primitive": "number"
           }
         }
       ],
-      "name": "DoubleTrouble",
-      "namespace": "jsii-calc"
+      "name": "DoubleTrouble"
     },
     "jsii-calc.GiveMeStructs": {
       "assembly": "jsii-calc",
@@ -1094,7 +1102,6 @@
         }
       ],
       "name": "GiveMeStructs",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -1138,8 +1145,7 @@
           }
         }
       ],
-      "name": "IFriendlier",
-      "namespace": "jsii-calc"
+      "name": "IFriendlier"
     },
     "jsii-calc.IFriendlyRandomGenerator": {
       "assembly": "jsii-calc",
@@ -1153,8 +1159,7 @@
         }
       ],
       "kind": "interface",
-      "name": "IFriendlyRandomGenerator",
-      "namespace": "jsii-calc"
+      "name": "IFriendlyRandomGenerator"
     },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
@@ -1162,7 +1167,6 @@
       "fqn": "jsii-calc.IInterfaceWithProperties",
       "kind": "interface",
       "name": "IInterfaceWithProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -1190,7 +1194,6 @@
       ],
       "kind": "interface",
       "name": "IInterfaceWithPropertiesExtension",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "foo",
@@ -1219,8 +1222,7 @@
           }
         }
       ],
-      "name": "IRandomNumberGenerator",
-      "namespace": "jsii-calc"
+      "name": "IRandomNumberGenerator"
     },
     "jsii-calc.ImplictBaseOfBase": {
       "assembly": "jsii-calc",
@@ -1233,7 +1235,6 @@
       ],
       "kind": "interface",
       "name": "ImplictBaseOfBase",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "goo",
@@ -1264,8 +1265,7 @@
           }
         }
       ],
-      "name": "JSObjectLiteralForInterface",
-      "namespace": "jsii-calc"
+      "name": "JSObjectLiteralForInterface"
     },
     "jsii-calc.JSObjectLiteralToNative": {
       "assembly": "jsii-calc",
@@ -1282,8 +1282,7 @@
           }
         }
       ],
-      "name": "JSObjectLiteralToNative",
-      "namespace": "jsii-calc"
+      "name": "JSObjectLiteralToNative"
     },
     "jsii-calc.JSObjectLiteralToNativeClass": {
       "assembly": "jsii-calc",
@@ -1293,7 +1292,6 @@
       },
       "kind": "class",
       "name": "JSObjectLiteralToNativeClass",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "propA",
@@ -1475,7 +1473,6 @@
         }
       ],
       "name": "JavaReservedWords",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "while",
@@ -1535,6 +1532,9 @@
             "comment": "Say farewell."
           },
           "name": "farewell",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1544,6 +1544,9 @@
             "comment": "Say goodbye."
           },
           "name": "goodbye",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1553,6 +1556,9 @@
             "comment": "Returns another random number."
           },
           "name": "next",
+          "overrides": {
+            "fqn": "jsii-calc.IRandomNumberGenerator"
+          },
           "returns": {
             "primitive": "number"
           }
@@ -1562,13 +1568,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Multiply",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1576,6 +1584,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -1614,6 +1625,9 @@
             "comment": "Say farewell."
           },
           "name": "farewell",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1623,6 +1637,9 @@
             "comment": "Say goodbye."
           },
           "name": "goodbye",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1632,6 +1649,9 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1641,13 +1661,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Negate",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1655,6 +1677,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -1705,7 +1730,6 @@
         }
       ],
       "name": "NodeStandardLibrary",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1760,7 +1784,6 @@
         }
       ],
       "name": "NumberGenerator",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "generator",
@@ -1826,8 +1849,7 @@
           }
         }
       ],
-      "name": "ObjectRefsInCollections",
-      "namespace": "jsii-calc"
+      "name": "ObjectRefsInCollections"
     },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
@@ -1852,8 +1874,7 @@
           }
         }
       ],
-      "name": "OverrideReturnsObject",
-      "namespace": "jsii-calc"
+      "name": "OverrideReturnsObject"
     },
     "jsii-calc.Polymorphism": {
       "assembly": "jsii-calc",
@@ -1878,8 +1899,7 @@
           }
         }
       ],
-      "name": "Polymorphism",
-      "namespace": "jsii-calc"
+      "name": "Polymorphism"
     },
     "jsii-calc.Power": {
       "assembly": "jsii-calc",
@@ -1918,7 +1938,6 @@
       },
       "kind": "class",
       "name": "Power",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1936,6 +1955,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -1983,7 +2005,6 @@
         }
       ],
       "name": "ReferenceEnumFromScopedPackage",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "foo",
@@ -2007,7 +2028,6 @@
         }
       ],
       "name": "ReturnsNumber",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2054,8 +2074,7 @@
           ]
         }
       ],
-      "name": "RuntimeTypeChecking",
-      "namespace": "jsii-calc"
+      "name": "RuntimeTypeChecking"
     },
     "jsii-calc.Statics": {
       "assembly": "jsii-calc",
@@ -2102,7 +2121,6 @@
         }
       ],
       "name": "Statics",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "const": true,
@@ -2195,8 +2213,7 @@
           "name": "C"
         }
       ],
-      "name": "StringEnum",
-      "namespace": "jsii-calc"
+      "name": "StringEnum"
     },
     "jsii-calc.Sum": {
       "assembly": "jsii-calc",
@@ -2212,7 +2229,6 @@
       },
       "kind": "class",
       "name": "Sum",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -2220,6 +2236,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -2334,7 +2353,6 @@
         }
       ],
       "name": "SyncVirtualMethods",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2387,8 +2405,7 @@
           "name": "throwError"
         }
       ],
-      "name": "Thrower",
-      "namespace": "jsii-calc"
+      "name": "Thrower"
     },
     "jsii-calc.UnaryOperation": {
       "abstract": true,
@@ -2413,7 +2430,6 @@
       },
       "kind": "class",
       "name": "UnaryOperation",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2430,7 +2446,6 @@
       "fqn": "jsii-calc.UnionProperties",
       "kind": "interface",
       "name": "UnionProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2484,8 +2499,7 @@
           }
         }
       ],
-      "name": "UseBundledDependency",
-      "namespace": "jsii-calc"
+      "name": "UseBundledDependency"
     },
     "jsii-calc.UseCalcBase": {
       "assembly": "jsii-calc",
@@ -2505,8 +2519,7 @@
           }
         }
       ],
-      "name": "UseCalcBase",
-      "namespace": "jsii-calc"
+      "name": "UseCalcBase"
     },
     "jsii-calc.UsesInterfaceWithProperties": {
       "assembly": "jsii-calc",
@@ -2560,7 +2573,6 @@
         }
       ],
       "name": "UsesInterfaceWithProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2626,8 +2638,7 @@
           "variadic": true
         }
       ],
-      "name": "VariadicMethod",
-      "namespace": "jsii-calc"
+      "name": "VariadicMethod"
     },
     "jsii-calc.VirtualMethodPlayground": {
       "assembly": "jsii-calc",
@@ -2711,8 +2722,7 @@
           }
         }
       ],
-      "name": "VirtualMethodPlayground",
-      "namespace": "jsii-calc"
+      "name": "VirtualMethodPlayground"
     },
     "jsii-calc.composition.CompositeOperation": {
       "abstract": true,
@@ -2734,13 +2744,16 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "CompositeOperation",
-      "namespace": "jsii-calc.composition",
+      "namespace": "composition",
       "properties": [
         {
           "abstract": true,
@@ -2759,6 +2772,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -2800,9 +2816,6 @@
             "fqn": "jsii-calc.composition.CompositeOperation.CompositionStringStyle"
           }
         }
-      ],
-      "subtypes": [
-        "jsii-calc.composition.CompositeOperation.CompositionStringStyle"
       ]
     },
     "jsii-calc.composition.CompositeOperation.CompositionStringStyle": {
@@ -2821,10 +2834,9 @@
         }
       ],
       "name": "CompositionStringStyle",
-      "namespace": "jsii-calc.composition.CompositeOperation",
-      "parenttype": "jsii-calc.composition.CompositeOperation"
+      "namespace": "composition.CompositeOperation"
     }
   },
   "version": "0.6.4",
-  "fingerprint": "gKUNI8uBG+ge5Ccbk0ay+JZ+j4C/4hPATR3jvtVm0Po="
+  "fingerprint": "w6KwhZtZH4/dMIvQlPb9nAIbic1GnqUVTSxVuf7TKbU="
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/AssemblyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/AssemblyGeneratorTests.cs
@@ -65,7 +65,6 @@ namespace Amazon.JSII.Generator.UnitTests
             ""kind"": ""class"",
             ""fqn"": ""jsii$aws_cdk_cx_api$.MissingContext"",
             ""assembly"": ""jsii$aws_cdk_cx_api$"",
-            ""namespace"": ""jsii$aws_cdk_cx_api$"",
             ""name"": ""MissingContext"",
             ""initializer"": {
                 ""initializer"": true
@@ -448,7 +447,6 @@ namespace Amazon.JSII.Generator.UnitTests
             ""kind"": ""class"",
             ""fqn"": ""jsii$aws_cdk_cx_api$.MissingContext"",
             ""assembly"": ""jsii$aws_cdk_cx_api$"",
-            ""namespace"": ""jsii$aws_cdk_cx_api$"",
             ""name"": ""MissingContext"",
             ""initializer"": {
                 ""initializer"": true

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassGeneratorTests.cs
@@ -12,11 +12,11 @@ namespace Amazon.JSII.Generator.UnitTests.Class
 
         string Render(ClassType classType)
         {
-            Symbols.MapTypeToPackage("myFqn", "myPackage");
-            Symbols.MapNamespace("myNamespace", "MyNamespace");
+            Symbols.MapTypeToPackage("myFqn", classType.Assembly);
+            Symbols.MapNamespace(classType.QualifiedNamespace, "MyNamespace");
             Symbols.MapTypeName("myFqn", "MyClass", JsonModel.Spec.TypeKind.Class);
 
-            ClassGenerator generator = new ClassGenerator("myPackage", classType, Symbols, Namespaces);
+            ClassGenerator generator = new ClassGenerator(classType.Assembly, classType, Symbols, Namespaces);
 
             SyntaxTree syntaxTree = generator.CreateSyntaxTree();
             return syntaxTree.ToString();
@@ -27,11 +27,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false)
             );
 
@@ -63,11 +62,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                true,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: true,
                 initializer: new Method(true, false, false)
             );
 
@@ -100,11 +98,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
             // Docs are not currently generated as part of the C# code.
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false),
                 docs: new Docs { { "foo", "bar" } }
             );
@@ -138,11 +135,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false),
                 properties: new[]
                 {
@@ -195,11 +191,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false),
                 methods: new[]
                 {
@@ -249,11 +244,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false),
                 @base: new TypeReference("myBaseTypeFqn")
             );
@@ -288,11 +282,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myFqn",
-                "myPackage",
-                "myClass",
-                "myNamespace",
-                false,
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: false,
                 initializer: new Method(true, false, false),
                 interfaces: new[]
                 {

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassMethodGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassMethodGeneratorTests.cs
@@ -14,11 +14,10 @@ namespace Amazon.JSII.Generator.UnitTests.Class
         {
             ClassType classType = new ClassType
             (
-                "myClassFqn",
-                "myModule",
-                "myClass",
-                "myNamespace",
-                true,
+                fullyQualifiedName: "myClassFqn",
+                assembly: "myModule",
+                name: "myClass",
+                isAbstract: true,
                 initializer: new Method(true, false, false),
                 methods: new[] { method }
             );

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Enum/EnumGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Enum/EnumGeneratorTests.cs
@@ -12,11 +12,11 @@ namespace Amazon.JSII.Generator.UnitTests.Enum
 
         string Render(EnumType enumType)
         {
-            Symbols.MapTypeToPackage("myEnumFqn", "myPackage");
-            Symbols.MapNamespace("myNamespace", "MyNamespace");
+            Symbols.MapTypeToPackage("myEnumFqn", enumType.Assembly);
+            Symbols.MapNamespace(enumType.QualifiedNamespace, "MyNamespace");
             Symbols.MapTypeName("myEnumFqn", "MyEnum", JsonModel.Spec.TypeKind.Enum);
 
-            EnumGenerator generator = new EnumGenerator("myPackage", enumType, Symbols, Namespaces);
+            EnumGenerator generator = new EnumGenerator(enumType.Assembly, enumType, Symbols, Namespaces);
 
             SyntaxTree syntaxTree = generator.CreateSyntaxTree();
             return syntaxTree.ToString();
@@ -27,8 +27,10 @@ namespace Amazon.JSII.Generator.UnitTests.Enum
         {
             EnumType enumType = new EnumType
             (
-                "myEnumFqn", "myPackage", "myEnum", "myNamespace",
-                new EnumMember[] { }
+                fullyQualifiedName: "myEnumFqn", 
+                assembly: "myPackage", 
+                name: "myEnum",
+                members: new EnumMember[] { }
             );
 
             string actual = Render(enumType);
@@ -48,8 +50,10 @@ namespace Amazon.JSII.Generator.UnitTests.Enum
         {
             EnumType enumType = new EnumType
             (
-                "myEnumFqn", "myPackage", "myEnum", "myNamespace",
-                new EnumMember[]
+                fullyQualifiedName: "myEnumFqn", 
+                assembly: "myPackage", 
+                name: "myEnum",
+                members: new EnumMember[]
                 {
                     new EnumMember("member1"),
                     new EnumMember("member2"),
@@ -80,9 +84,11 @@ namespace Amazon.JSII.Generator.UnitTests.Enum
         {
             EnumType enumType = new EnumType
             (
-                "myEnumFqn", "myPackage", "myEnum", "myNamespace",
-                new EnumMember[] { },
-                new Docs
+                fullyQualifiedName: "myEnumFqn",
+                assembly: "myPackage",
+                name: "myEnum",
+                members: new EnumMember[] { },
+                docs: new Docs
                 {
                     { "foo", "bar" }
                 }
@@ -106,8 +112,10 @@ namespace Amazon.JSII.Generator.UnitTests.Enum
         {
             EnumType enumType = new EnumType
             (
-                "myEnumFqn", "myPackage", "myEnum", "myNamespace",
-                new EnumMember[]
+                fullyQualifiedName: "myEnumFqn",
+                assembly: "myPackage",
+                name: "myEnum",
+                members: new EnumMember[]
                 {
                     new EnumMember("member1", new Docs { { "foo", "bar" } }),
                     new EnumMember("member2", new Docs { { "foo", "bar" } }),

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceGeneratorTests.cs
@@ -11,11 +11,11 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
         string Render(InterfaceType interfaceType)
         {
-            Symbols.MapTypeToPackage("myInterfaceFqn", "myPackage");
-            Symbols.MapNamespace("myNamespace", "MyNamespace");
+            Symbols.MapTypeToPackage("myInterfaceFqn", interfaceType.Assembly);
+            Symbols.MapNamespace(interfaceType.QualifiedNamespace, "MyNamespace");
             Symbols.MapTypeName("myInterfaceFqn", "MyInterface", kind: JsonModel.Spec.TypeKind.Interface);
 
-            InterfaceGenerator generator = new InterfaceGenerator("myPackage", interfaceType, Symbols, Namespaces);
+            InterfaceGenerator generator = new InterfaceGenerator(interfaceType.Assembly, interfaceType, Symbols, Namespaces);
 
             SyntaxTree syntaxTree = generator.CreateSyntaxTree();
             return syntaxTree.ToString();
@@ -26,10 +26,9 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         {
             InterfaceType interfaceType = new InterfaceType
             (
-                "myInterfaceFqn",
-                "myPackage",
-                "MyInterface",
-                "myNamespace"
+                fullyQualifiedName: "myInterfaceFqn",
+                assembly: "myPackage",
+                name: "MyInterface"
             );
 
             string actual = Render(interfaceType);
@@ -49,10 +48,9 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         {
             InterfaceType interfaceType = new InterfaceType
             (
-                "myInterfaceFqn",
-                "myPackage",
-                "MyInterface",
-                "myNamespace",
+                fullyQualifiedName: "myInterfaceFqn",
+                assembly: "myPackage",
+                name: "MyInterface",
                 interfaces: new[]
                 {
                     new TypeReference(fullyQualifiedName: "myBaseFqn1"),
@@ -80,10 +78,9 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         {
             InterfaceType interfaceType = new InterfaceType
             (
-                "myInterfaceFqn",
-                "",
-                "MyInterface",
-                "myNamespace",
+                fullyQualifiedName: "myInterfaceFqn",
+                assembly: "",
+                name: "MyInterface",
                 methods: new Method[] { new Method(false, false, false, name: "myMethod") }
             );
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
@@ -13,7 +13,8 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         string Render(InterfaceType interfaceType, string package = "myPackage", string @namespace = "MyNamespace", string typeName = "MyInterface")
         {
             Symbols.MapTypeToPackage(interfaceType.FullyQualifiedName, package);
-            Symbols.MapNamespace(interfaceType.Namespace, @namespace);
+            string suffix = interfaceType.Namespace != null ? "." + interfaceType.Namespace : "";
+            Symbols.MapNamespace(interfaceType.Assembly + suffix, @namespace);
             Symbols.MapTypeName(interfaceType.FullyQualifiedName, typeName, JsonModel.Spec.TypeKind.Interface);
 
             var generator = new InterfaceProxyGenerator(package, interfaceType, Symbols, Namespaces);

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
@@ -22,7 +22,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             );
 
             Symbols.MapTypeToPackage("myInterfaceFqn", "myPackage");
-            Symbols.MapNamespace("myNamespace", "MyNamespace");
+            Symbols.MapNamespace("", "MyNamespace");
             Symbols.MapTypeName("myInterfaceFqn", "MyInterface", JsonModel.Spec.TypeKind.Interface);
 
             var generator = new InterfaceProxyMethodGenerator(interfaceType, method, Symbols, Namespaces);

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/MethodExtensionsTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/MethodExtensionsTests.cs
@@ -67,19 +67,17 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 Type paramType1 = new EnumType
                 (
-                    "myParamTypeFqn1",
-                    "myPackage",
-                    "myParamType",
-                    "myNamespace1",
-                    new EnumMember[] { }
+                    fullyQualifiedName: "myParamTypeFqn1",
+                    assembly: "myPackage",
+                    name: "myParamType",
+                    members: new EnumMember[] { }
                 );
                 Type paramType2 = new EnumType
                 (
-                    "myParamTypeFqn2",
-                    "myPackage",
-                    "myParamType",
-                    "myNamespace2",
-                    new EnumMember[] { }
+                    fullyQualifiedName: "myParamTypeFqn2",
+                    assembly: "myPackage",
+                    name: "myParamType",
+                    members: new EnumMember[] { }
                 );
                 Method method = new Method
                 (

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
@@ -30,14 +30,13 @@ namespace Amazon.JSII.Generator.UnitTests
         {
             EnumType type = new EnumType
             (
-                "myEnumFqn",
-                "myModule",
-                "myEnum",
-                "myNamespace",
-                new EnumMember[] { }
+                fullyQualifiedName: "myEnumFqn",
+                assembly: "myModule",
+                name: "myEnum",
+                members: new EnumMember[] { }
             );
 
-            Symbols.MapNamespace("myNamespace", "MyNamespace");
+            Symbols.MapNamespace(type.QualifiedNamespace, "MyNamespace");
 
             NamespaceSet namespaces = new NamespaceSet(Symbols, SF.ParseName("MyCurrentNamespace"));
             namespaces.Add(type);

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
@@ -134,13 +134,13 @@ namespace Amazon.JSII.Generator.UnitTests
         public static void MapNamespace(this ISymbolMap symbols, string jsiiNamespace, string frameworkNamespace)
         {
             symbols
-                .GetNamespace(Arg.Is<Type>(t => t.Namespace == jsiiNamespace))
+                .GetNamespace(Arg.Is<Type>(t => t.QualifiedNamespace == jsiiNamespace))
                 .Returns(frameworkNamespace);
             symbols
-                .GetNamespaceSyntaxToken(Arg.Is<Type>(t => t.Namespace == jsiiNamespace))
+                .GetNamespaceSyntaxToken(Arg.Is<Type>(t => t.QualifiedNamespace == jsiiNamespace))
                 .Returns(SF.ParseToken(frameworkNamespace));
             symbols
-                .GetNamespaceSyntax(Arg.Is<Type>(t => t.Namespace == jsiiNamespace))
+                .GetNamespaceSyntax(Arg.Is<Type>(t => t.QualifiedNamespace == jsiiNamespace))
                 .Returns(SF.ParseName(frameworkNamespace));
         }
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
@@ -60,7 +60,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package",
                     name: "MyType",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
                 Type type2 = new ClassType
@@ -68,7 +67,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package",
                     name: "myType2",
-                    @namespace: "my-package.MyType",
+                    @namespace: "MyType",
                     isAbstract: false
                 );
 
@@ -108,7 +107,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     properties: new[]
                     {
@@ -156,7 +154,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "jsii$my_assembly$",
                     members: new EnumMember[] { }
                 );
 
@@ -177,7 +174,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -185,7 +181,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -260,7 +255,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType1",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -268,7 +262,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType2",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -343,7 +336,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -351,7 +343,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -433,7 +424,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "jsii$my_assembly$",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -460,7 +450,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     properties: new[] { property }
                 );
@@ -480,7 +469,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     members: new[] { member }
                 );
 
@@ -507,7 +495,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -531,7 +518,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     members: new EnumMember[] { }
                 );
 
@@ -552,7 +538,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -560,7 +545,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -635,7 +619,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType1",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -643,7 +626,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType2",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -718,7 +700,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -726,7 +707,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -808,7 +788,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -835,7 +814,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     properties: new[] { property }
                 );
@@ -855,7 +833,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     members: new[] { member }
                 );
 
@@ -882,7 +859,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -906,7 +882,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     members: new EnumMember[] { }
                 );
 
@@ -927,7 +902,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -935,7 +909,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -1010,7 +983,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType1",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -1018,7 +990,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType2",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -1093,7 +1064,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package-1",
                     name: "myType",
-                    @namespace: "my-package-1",
                     members: new EnumMember[] { }
                 );
                 Type type2 = new EnumType
@@ -1101,7 +1071,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package-2",
                     name: "myType",
-                    @namespace: "my-package-2",
                     members: new EnumMember[] { }
                 );
 
@@ -1183,7 +1152,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -1210,7 +1178,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     properties: new[] { property }
                 );
@@ -1230,7 +1197,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     members: new[] { member }
                 );
 
@@ -1257,7 +1223,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myType",
-                    @namespace: "my-package",
                     isAbstract: false,
                     methods: new[] { method }
                 );
@@ -1281,7 +1246,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1299,7 +1263,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1322,7 +1285,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1340,7 +1302,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1363,7 +1324,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1381,7 +1341,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1404,7 +1363,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1422,7 +1380,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1445,7 +1402,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1463,7 +1419,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1486,7 +1441,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1504,7 +1458,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1592,7 +1545,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 
@@ -1616,7 +1568,6 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "my-package",
                     name: "myName",
-                    @namespace: "my-package",
                     isAbstract: false
                 );
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeExtensionsTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeExtensionsTests.cs
@@ -21,11 +21,10 @@ namespace Amazon.JSII.Generator.UnitTests
                 {
                     grandParentType = new ClassType
                     (
-                        "myGrandParentTypeFqn",
-                        "myPackage",
-                        "myGrandParentType",
-                        "myNamespace",
-                        false
+                        fullyQualifiedName: "myGrandParentTypeFqn",
+                        assembly: "myPackage",
+                        name: "myGrandParentType",
+                        isAbstract: false
                     );
 
                     Symbols.MapFullyQualifiedNameToType("myGrandParentTypeFqn", grandParentType);
@@ -36,11 +35,10 @@ namespace Amazon.JSII.Generator.UnitTests
                 {
                     parentType = new ClassType
                     (
-                        "myParentTypeFqn",
-                        "myPackage",
-                        "myParentType",
-                        "myNamespace",
-                        false,
+                        fullyQualifiedName: "myParentTypeFqn",
+                        assembly: "myPackage",
+                        name: "myParentType",
+                        isAbstract: false,
                         @base: includeGrandparent ? new TypeReference("myGrandParentTypeFqn") : null
                     );
                     Symbols.MapFullyQualifiedNameToType("myParentTypeFqn", parentType);
@@ -48,11 +46,10 @@ namespace Amazon.JSII.Generator.UnitTests
 
                 ClassType classType = new ClassType
                 (
-                    "myClassFqn",
-                    "myPackage",
-                    "myClass",
-                    "myNamespace",
-                    false,
+                    fullyQualifiedName: "myClassFqn",
+                    assembly: "myPackage",
+                    name: "myClass",
+                    isAbstract: false,
                     @base: includeParent ? new TypeReference("myParentTypeFqn") : null
                 );
                 Symbols.MapFullyQualifiedNameToType("myClassFqn", classType);
@@ -110,20 +107,18 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceType interfaceType = new InterfaceType
                 (
-                    "myInterfaceFqn",
-                    "myPackage",
-                    "myInterface",
-                    "myNamespace"
+                    fullyQualifiedName: "myInterfaceFqn",
+                    assembly: "myPackage",
+                    name: "myInterface"
                 );
                 Symbols.MapFullyQualifiedNameToType("myInterfaceFqn", interfaceType);
 
                 ClassType classType = new ClassType
                 (
-                    "myClassFqn",
-                    "myPackage",
-                    "myClass",
-                    "myNamespace",
-                    false,
+                    fullyQualifiedName: "myClassFqn",
+                    assembly: "myPackage",
+                    name: "myClass",
+                    isAbstract: false,
                     interfaces: new[] { new TypeReference("myInterfaceFqn") }
                 );
                 Symbols.MapFullyQualifiedNameToType("myClassFqn", classType);

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeMetadataTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeMetadataTests.cs
@@ -47,7 +47,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myModule_myNamespace",
+                @namespace: "myNamespace",
                 isAbstract: false
             );
 
@@ -78,7 +78,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 ClassTypeMetadata metadata = new ClassTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace.MyName", metadata.FrameworkFullyQualifiedName);
+                Assert.Equal("myPackageNativeName.myNamespace.MyName", metadata.FrameworkFullyQualifiedName);
             }
 
             [Fact(DisplayName = _Prefix + nameof(SetsPackage))]
@@ -94,7 +94,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 ClassTypeMetadata metadata = new ClassTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace", metadata.Namespace);
+                Assert.Equal("myPackageNativeName.myNamespace", metadata.Namespace);
             }
 
             [Fact(DisplayName = _Prefix + nameof(DisambiguatesNamespaceConflicts))]
@@ -102,7 +102,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 ClassTypeMetadata metadata = new ClassTypeMetadata(_type, _assembly);
                 metadata.ResolveTypeNameConflicts(new HashSet<string>(new[] {
-                    "myPackageNativeName_myNamespace.MyName"
+                    "myPackageNativeName.myNamespace.MyName"
                 }));
 
                 Assert.Equal("MyName_", metadata.Name);
@@ -115,7 +115,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
                     name: "myName",
-                    @namespace: "myModule_myNamespace",
+                    @namespace: "myNamespace",
                     isAbstract: false,
                     properties: new[] {
                         new Property(
@@ -138,7 +138,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
                     name: "myName",
-                    @namespace: "myModule_myNamespace",
+                    @namespace: "myNamespace",
                     isAbstract: false,
                     methods: new[] {
                         new Method(
@@ -195,7 +195,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myModule_myNamespace",
+                @namespace: "myNamespace",
                 members: new EnumMember[] { }
             );
 
@@ -226,7 +226,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 EnumTypeMetadata metadata = new EnumTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace.MyName", metadata.FrameworkFullyQualifiedName);
+                Assert.Equal("myPackageNativeName.myNamespace.MyName", metadata.FrameworkFullyQualifiedName);
             }
 
             [Fact(DisplayName = _Prefix + nameof(SetsPackage))]
@@ -242,7 +242,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 EnumTypeMetadata metadata = new EnumTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace", metadata.Namespace);
+                Assert.Equal("myPackageNativeName.myNamespace", metadata.Namespace);
             }
 
             [Fact(DisplayName = _Prefix + nameof(DisambiguatesNamespaceConflicts))]
@@ -250,7 +250,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 EnumTypeMetadata metadata = new EnumTypeMetadata(_type, _assembly);
                 metadata.ResolveTypeNameConflicts(new HashSet<string>(new[] {
-                    "myPackageNativeName_myNamespace.MyName"
+                    "myPackageNativeName.myNamespace.MyName"
                 }));
 
                 Assert.Equal("MyName_", metadata.Name);
@@ -263,7 +263,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
                     name: "myName",
-                    @namespace: "myModule_myNamespace",
+                    @namespace: "myNamespace",
                     members: new[] {
                         new EnumMember("myName")
                     }
@@ -313,7 +313,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myModule_myNamespace",
+                @namespace: "myNamespace",
                 isDataType: true
             );
 
@@ -367,7 +367,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace.IMyName", metadata.FrameworkFullyQualifiedName);
+                Assert.Equal("myPackageNativeName.myNamespace.IMyName", metadata.FrameworkFullyQualifiedName);
             }
 
             [Fact(DisplayName = _Prefix + nameof(SetsFrameworkFullyQualifiedProxyName))]
@@ -375,7 +375,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace.MyNameProxy", metadata.FrameworkFullyQualifiedProxyName);
+                Assert.Equal("myPackageNativeName.myNamespace.MyNameProxy", metadata.FrameworkFullyQualifiedProxyName);
             }
 
             [Fact(DisplayName = _Prefix + nameof(SetsFrameworkFullyQualifiedDefaultName))]
@@ -383,7 +383,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace.MyName", metadata.FrameworkFullyQualifiedDefaultName);
+                Assert.Equal("myPackageNativeName.myNamespace.MyName", metadata.FrameworkFullyQualifiedDefaultName);
             }
 
             [Fact(DisplayName = _Prefix + nameof(SetsPackage))]
@@ -399,7 +399,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(_type, _assembly);
 
-                Assert.Equal("myPackageNativeName_myNamespace", metadata.Namespace);
+                Assert.Equal("myPackageNativeName.myNamespace", metadata.Namespace);
             }
 
             [Fact(DisplayName = _Prefix + nameof(DisambiguatesNamespaceConflicts))]
@@ -407,7 +407,7 @@ namespace Amazon.JSII.Generator.UnitTests
             {
                 InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(_type, _assembly);
                 metadata.ResolveTypeNameConflicts(new HashSet<string>(new[] {
-                    "myPackageNativeName_myNamespace.IMyName"
+                    "myPackageNativeName.myNamespace.IMyName"
                 }));
 
                 Assert.Equal("IMyName_", metadata.Name);
@@ -420,7 +420,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
                     name: "myName",
-                    @namespace: "myModule_myNamespace",
+                    @namespace: "myNamespace",
                     properties: new[] {
                         new Property(
                             name: "iMyName",
@@ -442,7 +442,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
                     name: "myName",
-                    @namespace: "myModule_myNamespace",
+                    @namespace: "myNamespace",
                     methods: new[] {
                         new Method(
                             isInitializer: false,

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
@@ -273,7 +273,7 @@ namespace Amazon.JSII.Generator
         {
             string fullyQualifiedName = (type ?? throw new ArgumentNullException(nameof(type))).FullyQualifiedName;
 
-            return _types[fullyQualifiedName].Namespace;
+            return _types[fullyQualifiedName].Namespace ?? "";
         }
 
         public string GetNamespace(string fullyQualifiedName)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
@@ -16,7 +16,8 @@ namespace Amazon.JSII.Generator
 
             Package = type.Assembly;
 
-            Namespace = $"{assembly.GetNativeNamespace(Package)}{type.Namespace.Substring(Package.Length)}";
+            string suffix = type.Namespace != null ? $".{type.Namespace}" : "";
+            Namespace = $"{assembly.GetNativeNamespace(Package)}{suffix}";
         }
 
         public virtual void ResolveTypeNameConflicts(ISet<string> namespaceNames)

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel.UnitTests/Spec/ClassTypeTests.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel.UnitTests/Spec/ClassTypeTests.cs
@@ -113,10 +113,10 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                 ));
             }
 
-            [Fact(DisplayName = Prefix + nameof(ShouldThrowOnMissingNamespace))]
-            public void ShouldThrowOnMissingNamespace()
+            [Fact(DisplayName = Prefix + nameof(ShouldNotSerializeMissingNamespace))]
+            public void ShouldNotSerializeMissingNamespace()
             {
-                Assert.Throws<ArgumentNullException>(() => new ClassType
+                ClassType classType = new ClassType
                 (
                     fullyQualifiedName: "myFqn",
                     assembly: "myModule",
@@ -129,7 +129,28 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                     @base: new TypeReference("myBaseFqn"),
                     initializer: new Method(true, false, false),
                     interfaces: new TypeReference[] { }
-                ));
+                );
+                string actual = JsonConvert.SerializeObject(classType, Formatting.Indented);
+                const string expected = @"{
+  ""abstract"": true,
+  ""base"": {
+    ""fqn"": ""myBaseFqn""
+  },
+  ""initializer"": {
+    ""initializer"": true,
+    ""protected"": false,
+    ""abstract"": false
+  },
+  ""properties"": [],
+  ""methods"": [],
+  ""interfaces"": [],
+  ""fqn"": ""myFqn"",
+  ""assembly"": ""myModule"",
+  ""name"": ""myName"",
+  ""kind"": ""class"",
+  ""docs"": {}
+}";
+                Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
             }
 
             [Fact(DisplayName = Prefix + nameof(ShouldNotSerializeMissingDocs))]
@@ -495,8 +516,8 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                 Assert.Throws<ArgumentNullException>(() => JsonConvert.DeserializeObject<ClassType>(json));
             }
 
-            [Fact(DisplayName = Prefix + nameof(ShouldThrowOnMissingNamespace))]
-            public void ShouldThrowOnMissingNamespace()
+            [Fact(DisplayName = Prefix + nameof(ShouldNotDeserializeMissingNamespace))]
+            public void ShouldNotDeserializeMissingNamespace()
             {
                 const string json = @"{
   ""abstract"": true,
@@ -518,7 +539,8 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
   ""docs"": {}
 }";
 
-                Assert.Throws<ArgumentNullException>(() => JsonConvert.DeserializeObject<ClassType>(json));
+                ClassType actual = JsonConvert.DeserializeObject<ClassType>(json);
+                Assert.Null(actual.Namespace);
             }
 
             [Fact(DisplayName = Prefix + nameof(ShouldNotDeserializeMissingDocs))]

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/ClassType.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/ClassType.cs
@@ -12,11 +12,11 @@ namespace Amazon.JSII.JsonModel.Spec
             string fullyQualifiedName,
             string assembly,
             string name,
-            string @namespace,
 
             // ClassType properties
             bool isAbstract,
 
+            string @namespace = null,
             // Type properties
             Docs docs = null,
 

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/EnumType.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/EnumType.cs
@@ -12,11 +12,11 @@ namespace Amazon.JSII.JsonModel.Spec
             string fullyQualifiedName,
             string assembly,
             string name,
-            string @namespace,
 
             // EnumType properties
             EnumMember[] members,
 
+            string @namespace = null,
             // Type properties
             Docs docs = null
         )

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/IOverridable.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/IOverridable.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Amazon.JSII.JsonModel.Spec
+{
+    public interface IOverridable
+    {
+        UserTypeReference Overrides { get;  }
+    }
+}

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/InterfaceType.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/InterfaceType.cs
@@ -12,7 +12,7 @@ namespace Amazon.JSII.JsonModel.Spec
             string fullyQualifiedName,
             string assembly,
             string name,
-            string @namespace,
+            string @namespace = null,
 
             // Type properties
             Docs docs = null,

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
@@ -4,7 +4,7 @@ using System;
 namespace Amazon.JSII.JsonModel.Spec
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    public class Method : IDocumentable
+    public class Method : IDocumentable, IOverridable
     {
         public Method
         (
@@ -16,7 +16,8 @@ namespace Amazon.JSII.JsonModel.Spec
             string name = null,
             TypeReference returns = null,
             bool? isVariadic = null,
-            bool? isStatic = null
+            bool? isStatic = null,
+            UserTypeReference overrides = null
         )
         {
             IsInitializer = isInitializer;
@@ -28,6 +29,7 @@ namespace Amazon.JSII.JsonModel.Spec
             Returns = returns;
             IsVariadic = isVariadic;
             IsStatic = isStatic;
+            Overrides = overrides;
         }
 
 
@@ -57,5 +59,8 @@ namespace Amazon.JSII.JsonModel.Spec
 
         [JsonProperty("static", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsStatic { get; }
+
+        [JsonProperty("overrides", NullValueHandling = NullValueHandling.Ignore)]
+        public UserTypeReference Overrides { get; }
     }
 }

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Property.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Property.cs
@@ -4,7 +4,7 @@ using System;
 namespace Amazon.JSII.JsonModel.Spec
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    public class Property : IDocumentable
+    public class Property : IDocumentable, IOverridable
     {
         public Property
         (
@@ -15,7 +15,8 @@ namespace Amazon.JSII.JsonModel.Spec
             bool? isAbstract = null,
             Docs docs = null,
             bool? isStatic = null,
-            bool? isConstant = null
+            bool? isConstant = null,
+            UserTypeReference overrides = null
         )
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -26,6 +27,7 @@ namespace Amazon.JSII.JsonModel.Spec
             Docs = docs;
             IsStatic = isStatic;
             IsConstant = isConstant;
+            Overrides = overrides;
         }
 
         [JsonProperty("name")]
@@ -51,5 +53,8 @@ namespace Amazon.JSII.JsonModel.Spec
 
         [JsonProperty("const", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsConstant { get; }
+
+        [JsonProperty("overrides", NullValueHandling = NullValueHandling.Ignore)]
+        public UserTypeReference Overrides { get; }
     }
 }

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Type.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Type.cs
@@ -19,7 +19,7 @@ namespace Amazon.JSII.JsonModel.Spec
             FullyQualifiedName = fullyQualifiedName ?? throw new ArgumentNullException(nameof(fullyQualifiedName));
             Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
+            Namespace = @namespace;
             Kind = kind;
             Docs = docs;
         }
@@ -33,7 +33,7 @@ namespace Amazon.JSII.JsonModel.Spec
         [JsonProperty("name")]
         public string Name { get; }
 
-        [JsonProperty("namespace")]
+        [JsonProperty("namespace", NullValueHandling = NullValueHandling.Ignore)]
         public string Namespace { get; }
 
         [JsonProperty("kind")]
@@ -41,5 +41,8 @@ namespace Amazon.JSII.JsonModel.Spec
 
         [JsonProperty("docs", NullValueHandling = NullValueHandling.Ignore)]
         public Docs Docs { get; }
+
+        [JsonIgnore]
+        public string QualifiedNamespace => this.Assembly + (this.Namespace != null ? $".{this.Namespace}" : "");
     }
 }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1056,7 +1056,9 @@ class JavaGenerator extends Generator {
     private toNativeFqn(fqn: string): string {
         const [mod, ...name] = fqn.split('.');
         const depMod = this.findModule(mod);
-        // Make sure any type that's used from a dependency is listed as a direct dependency of the POM.
+        // Make sure any dependency (direct or transitive) of which any type is explicitly referenced by the generated
+        // code is included in the generated POM's dependencies section (protecting the artifact from changes in the
+        // dependencies' dependency structure).
         if (mod !== this.assembly.name) {
             this.referencedModules[mod] = depMod;
         }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -182,10 +182,11 @@ class JavaGenerator extends Generator {
             implementsExpr = ' implements ' + cls.interfaces.map(x => this.toNativeFqn(x.fqn!));
         }
 
-        const inner = cls.parenttype ? ' static' : '';
+        const nested = this.isNested(cls);
+        const inner = nested ? ' static' : '';
         const absPrefix = abstract ? ' abstract' : '';
 
-        if (!cls.parenttype) { this.emitGeneratedAnnotation(); }
+        if (!nested) { this.emitGeneratedAnnotation(); }
         this.code.line(`@software.amazon.jsii.Jsii(module = ${this.moduleClass}.class, fqn = "${cls.fqn}")`);
         this.code.openBlock(`public${inner}${absPrefix} class ${cls.name}${extendsExpression}${implementsExpr}`);
 
@@ -255,7 +256,7 @@ class JavaGenerator extends Generator {
     protected onBeginEnum(enm: spec.EnumType) {
         this.openFileIfNeeded(enm);
         this.addJavaDocs(enm);
-        if (!enm.parenttype) { this.emitGeneratedAnnotation(); }
+        if (!this.isNested(enm)) { this.emitGeneratedAnnotation(); }
         this.code.line(`@software.amazon.jsii.Jsii(module = ${this.moduleClass}.class, fqn = "${enm.fqn}")`);
         this.code.openBlock(`public enum ${enm.name}`);
     }
@@ -287,8 +288,9 @@ class JavaGenerator extends Generator {
         const interfaces = ifc.interfaces || [];
         const bases = [ 'software.amazon.jsii.JsiiSerializable', ...interfaces.map(x => this.toNativeFqn(x.fqn!)) ].join(', ');
 
-        const inner = ifc.parenttype ? ' static' : '';
-        if (!ifc.parenttype) { this.emitGeneratedAnnotation(); }
+        const nested = this.isNested(ifc);
+        const inner = nested ? ' static' : '';
+        if (!nested) { this.emitGeneratedAnnotation(); }
         this.code.openBlock(`public${inner} interface ${ifc.name} extends ${bases}`);
     }
 
@@ -531,7 +533,7 @@ class JavaGenerator extends Generator {
         this.code.line(`${access} final static ${propType} ${propName};`);
     }
 
-    private emitProperty(cls: spec.Type, prop: spec.Property, includeGetter = true, overrides = false) {
+    private emitProperty(cls: spec.Type, prop: spec.Property, includeGetter = true, overrides: boolean = !!prop.overrides) {
         const getterType = this.toJavaType(prop.type);
         const setterTypes = this.toJavaTypes(prop.type);
         const propClass = this.toJavaType(prop.type, true);
@@ -542,6 +544,7 @@ class JavaGenerator extends Generator {
 
         // for unions we only generate overloads for setters, not getters.
         if (includeGetter) {
+            this.code.line();
             this.addJavaDocs(prop);
             if (overrides) { this.code.line('@Override'); }
             if (prop.type.optional) { this.code.line(JSR305_NULLABLE); }
@@ -562,6 +565,7 @@ class JavaGenerator extends Generator {
 
         if (!prop.immutable) {
             for (const type of setterTypes) {
+                this.code.line();
                 this.addJavaDocs(prop);
                 if (overrides) { this.code.line('@Override'); }
                 const nullable = prop.type.optional ? `${JSR305_NULLABLE} ` : '';
@@ -581,13 +585,14 @@ class JavaGenerator extends Generator {
         }
     }
 
-    private emitMethod(cls: spec.Type, method: spec.Method, overrides = false) {
+    private emitMethod(cls: spec.Type, method: spec.Method, overrides: boolean = !!method.overrides) {
         const returnType = method.returns ? this.toJavaType(method.returns) : 'void';
         const statc = method.static ? 'static ' : '';
         const access = this.renderAccessLevel(method);
         const async = !!(method.returns && method.returns.promise);
         const methodName = slugify(method.name);
         const signature = `${returnType} ${methodName}(${this.renderMethodParameters(method)})`;
+        this.code.line();
         this.addJavaDocs(method);
         if (overrides) { this.code.line('@Override'); }
         if (method.returns && method.returns.optional) { this.code.line(JSR305_NULLABLE); }
@@ -640,14 +645,12 @@ class JavaGenerator extends Generator {
         // emit all properties
         for (const propName of Object.keys(properties)) {
             const prop = properties[propName];
-            this.code.line();
             this.emitProperty(ifc, prop, /* includeGetter: */ undefined, /* overrides: */ true);
         }
 
         // emit all the methods
         for (const methodName of Object.keys(methods)) {
             const method = methods[methodName];
-            this.code.line();
             this.emitMethod(ifc, method, /* overrides: */ true);
         }
 
@@ -783,22 +786,26 @@ class JavaGenerator extends Generator {
     }
 
     private openFileIfNeeded(type: spec.Type) {
-        if (type.parenttype) {
+        if (this.isNested(type)) {
             return;
         }
 
         this.code.openFile(this.toJavaFilePath(type.fqn));
-        if (type.namespace) {
-            this.code.line(`package ${this.toNativeFqn(type.namespace)};`);
-            this.code.line();
-        }
+        this.code.line(`package ${this.getNativeName(this.assembly, type.namespace)};`);
+        this.code.line();
     }
 
     private closeFileIfNeeded(type: spec.Type) {
-        if (type.parenttype) {
+        if (this.isNested(type)) {
             return;
         }
         this.code.closeFile(this.toJavaFilePath(type.fqn));
+    }
+
+    private isNested(type: spec.Type) {
+        if (!this.assembly.types || !type.namespace) { return false; }
+        const parent = `${type.assembly}.${type.namespace}`;
+        return parent in this.assembly.types;
     }
 
     private toJavaFilePath(fqn: string) {
@@ -1049,18 +1056,21 @@ class JavaGenerator extends Generator {
     private toNativeFqn(fqn: string): string {
         const [mod, ...name] = fqn.split('.');
         const depMod = this.findModule(mod);
-        const javaPackage = depMod.targets && depMod.targets.java && depMod.targets.java.package;
-        if (!javaPackage) { throw new Error(`The module ${mod} does not have a java.package setting`); }
-
-        // since this type was needed for some reason when we generate this code, we want to make
-        // sure it's module is included as a direct dependency, even if it's not defined as a direct
-        // dependency of this assembly in jsii. this can happen, for example, when we generate
-        // interface proxies and builders which "flatten" the hirarchy.
+        // Make sure any type that's used from a dependency is listed as a direct dependency of the POM.
         if (mod !== this.assembly.name) {
             this.referencedModules[mod] = depMod;
         }
+        return this.getNativeName(depMod, name.join('.'), mod);
+    }
 
-        return [javaPackage, ...name].join('.');
+    private getNativeName(assm: spec.Assembly, name: string | undefined): string;
+    private getNativeName(assm: spec.PackageVersion, name: string | undefined, assmName: string): string;
+    private getNativeName(assm: spec.Assembly | spec.PackageVersion,
+                          name: string | undefined,
+                          assmName: string = (assm as spec.Assembly).name): string {
+        const javaPackage = assm.targets && assm.targets.java && assm.targets.java.package;
+        if (!javaPackage) { throw new Error(`The module ${assmName} does not have a java.package setting`); }
+        return `${javaPackage}${name ? `.${name}` : ''}`;
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
@@ -76,8 +76,7 @@
           }
         }
       ],
-      "name": "Base",
-      "namespace": "@scope/jsii-calc-base"
+      "name": "Base"
     },
     "@scope/jsii-calc-base.BaseProps": {
       "assembly": "@scope/jsii-calc-base",
@@ -90,7 +89,6 @@
       ],
       "kind": "interface",
       "name": "BaseProps",
-      "namespace": "@scope/jsii-calc-base",
       "properties": [
         {
           "name": "bar",
@@ -102,5 +100,5 @@
     }
   },
   "version": "0.6.4",
-  "fingerprint": "3lcys0/Cd5ZbPR/CXccsL3Fdb66mNsVBs8jb+ySL0oU="
+  "fingerprint": "3AQHE+SKelQy94tarTiCYoSyQkfZyWyqSY/QU1fDmdE="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -9,6 +9,7 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
     protected Base(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     /**
      * @return the name of the class (to verify native type names are created for derived classes).
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -84,6 +84,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         public java.lang.String getBar() {
             return this.jsiiGet("bar", java.lang.String.class);
         }
+
         @Override
         public void setBar(final java.lang.String value) {
             this.jsiiSet("bar", java.util.Objects.requireNonNull(value, "bar is required"));
@@ -93,6 +94,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
             return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
         }
+
         @Override
         public void setFoo(final software.amazon.jsii.tests.calculator.baseofbase.Very value) {
             this.jsiiSet("foo", java.util.Objects.requireNonNull(value, "foo is required"));

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -90,8 +90,7 @@
           "name": "Value2"
         }
       ],
-      "name": "EnumFromScopedModule",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "EnumFromScopedModule"
     },
     "@scope/jsii-calc-lib.IFriendly": {
       "assembly": "@scope/jsii-calc-lib",
@@ -111,8 +110,7 @@
           }
         }
       ],
-      "name": "IFriendly",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "IFriendly"
     },
     "@scope/jsii-calc-lib.MyFirstStruct": {
       "assembly": "@scope/jsii-calc-lib",
@@ -123,7 +121,6 @@
       "fqn": "@scope/jsii-calc-lib.MyFirstStruct",
       "kind": "interface",
       "name": "MyFirstStruct",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -185,7 +182,6 @@
       },
       "kind": "class",
       "name": "Number",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -203,6 +199,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -230,13 +229,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
-      "name": "Operation",
-      "namespace": "@scope/jsii-calc-lib"
+      "name": "Operation"
     },
     "@scope/jsii-calc-lib.StructWithOnlyOptionals": {
       "assembly": "@scope/jsii-calc-lib",
@@ -247,7 +248,6 @@
       "fqn": "@scope/jsii-calc-lib.StructWithOnlyOptionals",
       "kind": "interface",
       "name": "StructWithOnlyOptionals",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "docs": {
@@ -301,7 +301,6 @@
         }
       ],
       "name": "Value",
-      "namespace": "@scope/jsii-calc-lib",
       "properties": [
         {
           "abstract": true,
@@ -318,5 +317,5 @@
     }
   },
   "version": "0.6.4",
-  "fingerprint": "jA30G5c81DZXD/7DMYLvdlY8XwEevVQAMAwkUBmPE64="
+  "fingerprint": "OLAA8NNlr68J5/yK8t4MB/T0+9GLicN/w/JsSqop/fA="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -129,6 +129,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         public java.lang.Number getAnumber() {
             return this.jsiiGet("anumber", java.lang.Number.class);
         }
+
         /**
          * An awesome number value
          */
@@ -144,6 +145,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         public java.lang.String getAstring() {
             return this.jsiiGet("astring", java.lang.String.class);
         }
+
         /**
          * A string value
          */
@@ -157,6 +159,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         public java.util.List<java.lang.String> getFirstOptional() {
             return this.jsiiGet("firstOptional", java.util.List.class);
         }
+
         @Override
         public void setFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this.jsiiSet("firstOptional", value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -17,15 +17,18 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     /**
      * The number multiplied by 2.
      */
     public java.lang.Number getDoubleValue() {
         return this.jsiiGet("doubleValue", java.lang.Number.class);
     }
+
     /**
      * The number.
      */
+    @Override
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -9,8 +9,10 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
     protected Operation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     /**
      * String representation of the value.
      */
+    @Override
     public abstract java.lang.String toString();
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -128,6 +128,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         public java.lang.String getOptional1() {
             return this.jsiiGet("optional1", java.lang.String.class);
         }
+
         /**
          * The first optional!
          */
@@ -141,6 +142,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         public java.lang.Number getOptional2() {
             return this.jsiiGet("optional2", java.lang.Number.class);
         }
+
         @Override
         public void setOptional2(@javax.annotation.Nullable final java.lang.Number value) {
             this.jsiiSet("optional2", value);
@@ -151,6 +153,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         public java.lang.Boolean getOptional3() {
             return this.jsiiGet("optional3", java.lang.Boolean.class);
         }
+
         @Override
         public void setOptional3(@javax.annotation.Nullable final java.lang.Boolean value) {
             this.jsiiSet("optional3", value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -9,12 +9,14 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
     protected Value(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     /**
      * String representation of the value.
      */
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
+
     /**
      * The value.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -207,13 +207,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Add",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -221,6 +223,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -254,7 +259,6 @@
         }
       ],
       "name": "AllTypes",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -459,8 +463,7 @@
           "name": "ThisIsGreat"
         }
       ],
-      "name": "AllTypesEnum",
-      "namespace": "jsii-calc"
+      "name": "AllTypesEnum"
     },
     "jsii-calc.AllowedMethodNames": {
       "assembly": "jsii-calc",
@@ -548,8 +551,7 @@
           ]
         }
       ],
-      "name": "AllowedMethodNames",
-      "namespace": "jsii-calc"
+      "name": "AllowedMethodNames"
     },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
@@ -615,8 +617,7 @@
           }
         }
       ],
-      "name": "AsyncVirtualMethods",
-      "namespace": "jsii-calc"
+      "name": "AsyncVirtualMethods"
     },
     "jsii-calc.BinaryOperation": {
       "abstract": true,
@@ -666,13 +667,15 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "BinaryOperation",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -784,7 +787,6 @@
         }
       ],
       "name": "Calculator",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -792,6 +794,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -883,7 +888,6 @@
       "fqn": "jsii-calc.CalculatorProps",
       "kind": "interface",
       "name": "CalculatorProps",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "initialValue",
@@ -909,7 +913,7 @@
       },
       "kind": "class",
       "name": "Base",
-      "namespace": "jsii-calc.DerivedClassHasNoProperties",
+      "namespace": "DerivedClassHasNoProperties",
       "properties": [
         {
           "name": "prop",
@@ -930,7 +934,7 @@
       },
       "kind": "class",
       "name": "Derived",
-      "namespace": "jsii-calc.DerivedClassHasNoProperties"
+      "namespace": "DerivedClassHasNoProperties"
     },
     "jsii-calc.DerivedStruct": {
       "assembly": "jsii-calc",
@@ -946,7 +950,6 @@
       ],
       "kind": "interface",
       "name": "DerivedStruct",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "anotherRequired",
@@ -1016,6 +1019,9 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1025,13 +1031,15 @@
             "comment": "Returns another random number."
           },
           "name": "next",
+          "overrides": {
+            "fqn": "jsii-calc.IRandomNumberGenerator"
+          },
           "returns": {
             "primitive": "number"
           }
         }
       ],
-      "name": "DoubleTrouble",
-      "namespace": "jsii-calc"
+      "name": "DoubleTrouble"
     },
     "jsii-calc.GiveMeStructs": {
       "assembly": "jsii-calc",
@@ -1094,7 +1102,6 @@
         }
       ],
       "name": "GiveMeStructs",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -1138,8 +1145,7 @@
           }
         }
       ],
-      "name": "IFriendlier",
-      "namespace": "jsii-calc"
+      "name": "IFriendlier"
     },
     "jsii-calc.IFriendlyRandomGenerator": {
       "assembly": "jsii-calc",
@@ -1153,8 +1159,7 @@
         }
       ],
       "kind": "interface",
-      "name": "IFriendlyRandomGenerator",
-      "namespace": "jsii-calc"
+      "name": "IFriendlyRandomGenerator"
     },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
@@ -1162,7 +1167,6 @@
       "fqn": "jsii-calc.IInterfaceWithProperties",
       "kind": "interface",
       "name": "IInterfaceWithProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -1190,7 +1194,6 @@
       ],
       "kind": "interface",
       "name": "IInterfaceWithPropertiesExtension",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "foo",
@@ -1219,8 +1222,7 @@
           }
         }
       ],
-      "name": "IRandomNumberGenerator",
-      "namespace": "jsii-calc"
+      "name": "IRandomNumberGenerator"
     },
     "jsii-calc.ImplictBaseOfBase": {
       "assembly": "jsii-calc",
@@ -1233,7 +1235,6 @@
       ],
       "kind": "interface",
       "name": "ImplictBaseOfBase",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "goo",
@@ -1264,8 +1265,7 @@
           }
         }
       ],
-      "name": "JSObjectLiteralForInterface",
-      "namespace": "jsii-calc"
+      "name": "JSObjectLiteralForInterface"
     },
     "jsii-calc.JSObjectLiteralToNative": {
       "assembly": "jsii-calc",
@@ -1282,8 +1282,7 @@
           }
         }
       ],
-      "name": "JSObjectLiteralToNative",
-      "namespace": "jsii-calc"
+      "name": "JSObjectLiteralToNative"
     },
     "jsii-calc.JSObjectLiteralToNativeClass": {
       "assembly": "jsii-calc",
@@ -1293,7 +1292,6 @@
       },
       "kind": "class",
       "name": "JSObjectLiteralToNativeClass",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "propA",
@@ -1475,7 +1473,6 @@
         }
       ],
       "name": "JavaReservedWords",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "while",
@@ -1535,6 +1532,9 @@
             "comment": "Say farewell."
           },
           "name": "farewell",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1544,6 +1544,9 @@
             "comment": "Say goodbye."
           },
           "name": "goodbye",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1553,6 +1556,9 @@
             "comment": "Returns another random number."
           },
           "name": "next",
+          "overrides": {
+            "fqn": "jsii-calc.IRandomNumberGenerator"
+          },
           "returns": {
             "primitive": "number"
           }
@@ -1562,13 +1568,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Multiply",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1576,6 +1584,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -1614,6 +1625,9 @@
             "comment": "Say farewell."
           },
           "name": "farewell",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1623,6 +1637,9 @@
             "comment": "Say goodbye."
           },
           "name": "goodbye",
+          "overrides": {
+            "fqn": "jsii-calc.IFriendlier"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1632,6 +1649,9 @@
             "comment": "Say hello!"
           },
           "name": "hello",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IFriendly"
+          },
           "returns": {
             "primitive": "string"
           }
@@ -1641,13 +1661,15 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "Negate",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1655,6 +1677,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -1705,7 +1730,6 @@
         }
       ],
       "name": "NodeStandardLibrary",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1760,7 +1784,6 @@
         }
       ],
       "name": "NumberGenerator",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "generator",
@@ -1826,8 +1849,7 @@
           }
         }
       ],
-      "name": "ObjectRefsInCollections",
-      "namespace": "jsii-calc"
+      "name": "ObjectRefsInCollections"
     },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
@@ -1852,8 +1874,7 @@
           }
         }
       ],
-      "name": "OverrideReturnsObject",
-      "namespace": "jsii-calc"
+      "name": "OverrideReturnsObject"
     },
     "jsii-calc.Polymorphism": {
       "assembly": "jsii-calc",
@@ -1878,8 +1899,7 @@
           }
         }
       ],
-      "name": "Polymorphism",
-      "namespace": "jsii-calc"
+      "name": "Polymorphism"
     },
     "jsii-calc.Power": {
       "assembly": "jsii-calc",
@@ -1918,7 +1938,6 @@
       },
       "kind": "class",
       "name": "Power",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -1936,6 +1955,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -1983,7 +2005,6 @@
         }
       ],
       "name": "ReferenceEnumFromScopedPackage",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "name": "foo",
@@ -2007,7 +2028,6 @@
         }
       ],
       "name": "ReturnsNumber",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2054,8 +2074,7 @@
           ]
         }
       ],
-      "name": "RuntimeTypeChecking",
-      "namespace": "jsii-calc"
+      "name": "RuntimeTypeChecking"
     },
     "jsii-calc.Statics": {
       "assembly": "jsii-calc",
@@ -2102,7 +2121,6 @@
         }
       ],
       "name": "Statics",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "const": true,
@@ -2195,8 +2213,7 @@
           "name": "C"
         }
       ],
-      "name": "StringEnum",
-      "namespace": "jsii-calc"
+      "name": "StringEnum"
     },
     "jsii-calc.Sum": {
       "assembly": "jsii-calc",
@@ -2212,7 +2229,6 @@
       },
       "kind": "class",
       "name": "Sum",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "docs": {
@@ -2220,6 +2236,9 @@
           },
           "immutable": true,
           "name": "expression",
+          "overrides": {
+            "fqn": "jsii-calc.composition.CompositeOperation"
+          },
           "type": {
             "fqn": "@scope/jsii-calc-lib.Value"
           }
@@ -2334,7 +2353,6 @@
         }
       ],
       "name": "SyncVirtualMethods",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2387,8 +2405,7 @@
           "name": "throwError"
         }
       ],
-      "name": "Thrower",
-      "namespace": "jsii-calc"
+      "name": "Thrower"
     },
     "jsii-calc.UnaryOperation": {
       "abstract": true,
@@ -2413,7 +2430,6 @@
       },
       "kind": "class",
       "name": "UnaryOperation",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2430,7 +2446,6 @@
       "fqn": "jsii-calc.UnionProperties",
       "kind": "interface",
       "name": "UnionProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2484,8 +2499,7 @@
           }
         }
       ],
-      "name": "UseBundledDependency",
-      "namespace": "jsii-calc"
+      "name": "UseBundledDependency"
     },
     "jsii-calc.UseCalcBase": {
       "assembly": "jsii-calc",
@@ -2505,8 +2519,7 @@
           }
         }
       ],
-      "name": "UseCalcBase",
-      "namespace": "jsii-calc"
+      "name": "UseCalcBase"
     },
     "jsii-calc.UsesInterfaceWithProperties": {
       "assembly": "jsii-calc",
@@ -2560,7 +2573,6 @@
         }
       ],
       "name": "UsesInterfaceWithProperties",
-      "namespace": "jsii-calc",
       "properties": [
         {
           "immutable": true,
@@ -2626,8 +2638,7 @@
           "variadic": true
         }
       ],
-      "name": "VariadicMethod",
-      "namespace": "jsii-calc"
+      "name": "VariadicMethod"
     },
     "jsii-calc.VirtualMethodPlayground": {
       "assembly": "jsii-calc",
@@ -2711,8 +2722,7 @@
           }
         }
       ],
-      "name": "VirtualMethodPlayground",
-      "namespace": "jsii-calc"
+      "name": "VirtualMethodPlayground"
     },
     "jsii-calc.composition.CompositeOperation": {
       "abstract": true,
@@ -2734,13 +2744,16 @@
             "comment": "String representation of the value."
           },
           "name": "toString",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "returns": {
             "primitive": "string"
           }
         }
       ],
       "name": "CompositeOperation",
-      "namespace": "jsii-calc.composition",
+      "namespace": "composition",
       "properties": [
         {
           "abstract": true,
@@ -2759,6 +2772,9 @@
           },
           "immutable": true,
           "name": "value",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.Value"
+          },
           "type": {
             "primitive": "number"
           }
@@ -2800,9 +2816,6 @@
             "fqn": "jsii-calc.composition.CompositeOperation.CompositionStringStyle"
           }
         }
-      ],
-      "subtypes": [
-        "jsii-calc.composition.CompositeOperation.CompositionStringStyle"
       ]
     },
     "jsii-calc.composition.CompositeOperation.CompositionStringStyle": {
@@ -2821,10 +2834,9 @@
         }
       ],
       "name": "CompositionStringStyle",
-      "namespace": "jsii-calc.composition.CompositeOperation",
-      "parenttype": "jsii-calc.composition.CompositeOperation"
+      "namespace": "composition.CompositeOperation"
     }
   },
   "version": "0.6.4",
-  "fingerprint": "gKUNI8uBG+ge5Ccbk0ay+JZ+j4C/4hPATR3jvtVm0Po="
+  "fingerprint": "w6KwhZtZH4/dMIvQlPb9nAIbic1GnqUVTSxVuf7TKbU="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -18,15 +18,19 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(lhs, "lhs is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(rhs, "rhs is required"))).toArray());
     }
+
     /**
      * String representation of the value.
      */
+    @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
+
     /**
      * The value.
      */
+    @Override
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -14,124 +14,164 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public software.amazon.jsii.tests.calculator.StringEnum enumMethod(final software.amazon.jsii.tests.calculator.StringEnum value) {
         return this.jsiiCall("enumMethod", software.amazon.jsii.tests.calculator.StringEnum.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     public java.lang.Number getEnumPropertyValue() {
         return this.jsiiGet("enumPropertyValue", java.lang.Number.class);
     }
+
     public java.util.List<java.lang.Object> getAnyArrayProperty() {
         return this.jsiiGet("anyArrayProperty", java.util.List.class);
     }
+
     public void setAnyArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("anyArrayProperty", java.util.Objects.requireNonNull(value, "anyArrayProperty is required"));
     }
+
     public java.util.Map<java.lang.String, java.lang.Object> getAnyMapProperty() {
         return this.jsiiGet("anyMapProperty", java.util.Map.class);
     }
+
     public void setAnyMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("anyMapProperty", java.util.Objects.requireNonNull(value, "anyMapProperty is required"));
     }
+
     public java.lang.Object getAnyProperty() {
         return this.jsiiGet("anyProperty", java.lang.Object.class);
     }
+
     public void setAnyProperty(final java.lang.Object value) {
         this.jsiiSet("anyProperty", java.util.Objects.requireNonNull(value, "anyProperty is required"));
     }
+
     public java.util.List<java.lang.String> getArrayProperty() {
         return this.jsiiGet("arrayProperty", java.util.List.class);
     }
+
     public void setArrayProperty(final java.util.List<java.lang.String> value) {
         this.jsiiSet("arrayProperty", java.util.Objects.requireNonNull(value, "arrayProperty is required"));
     }
+
     public java.lang.Boolean getBooleanProperty() {
         return this.jsiiGet("booleanProperty", java.lang.Boolean.class);
     }
+
     public void setBooleanProperty(final java.lang.Boolean value) {
         this.jsiiSet("booleanProperty", java.util.Objects.requireNonNull(value, "booleanProperty is required"));
     }
+
     public java.time.Instant getDateProperty() {
         return this.jsiiGet("dateProperty", java.time.Instant.class);
     }
+
     public void setDateProperty(final java.time.Instant value) {
         this.jsiiSet("dateProperty", java.util.Objects.requireNonNull(value, "dateProperty is required"));
     }
+
     public software.amazon.jsii.tests.calculator.AllTypesEnum getEnumProperty() {
         return this.jsiiGet("enumProperty", software.amazon.jsii.tests.calculator.AllTypesEnum.class);
     }
+
     public void setEnumProperty(final software.amazon.jsii.tests.calculator.AllTypesEnum value) {
         this.jsiiSet("enumProperty", java.util.Objects.requireNonNull(value, "enumProperty is required"));
     }
+
     public com.fasterxml.jackson.databind.node.ObjectNode getJsonProperty() {
         return this.jsiiGet("jsonProperty", com.fasterxml.jackson.databind.node.ObjectNode.class);
     }
+
     public void setJsonProperty(final com.fasterxml.jackson.databind.node.ObjectNode value) {
         this.jsiiSet("jsonProperty", java.util.Objects.requireNonNull(value, "jsonProperty is required"));
     }
+
     public java.util.Map<java.lang.String, java.lang.Number> getMapProperty() {
         return this.jsiiGet("mapProperty", java.util.Map.class);
     }
+
     public void setMapProperty(final java.util.Map<java.lang.String, java.lang.Number> value) {
         this.jsiiSet("mapProperty", java.util.Objects.requireNonNull(value, "mapProperty is required"));
     }
+
     public java.lang.Number getNumberProperty() {
         return this.jsiiGet("numberProperty", java.lang.Number.class);
     }
+
     public void setNumberProperty(final java.lang.Number value) {
         this.jsiiSet("numberProperty", java.util.Objects.requireNonNull(value, "numberProperty is required"));
     }
+
     public java.lang.String getStringProperty() {
         return this.jsiiGet("stringProperty", java.lang.String.class);
     }
+
     public void setStringProperty(final java.lang.String value) {
         this.jsiiSet("stringProperty", java.util.Objects.requireNonNull(value, "stringProperty is required"));
     }
+
     public java.util.List<java.lang.Object> getUnionArrayProperty() {
         return this.jsiiGet("unionArrayProperty", java.util.List.class);
     }
+
     public void setUnionArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("unionArrayProperty", java.util.Objects.requireNonNull(value, "unionArrayProperty is required"));
     }
+
     public java.util.Map<java.lang.String, java.lang.Object> getUnionMapProperty() {
         return this.jsiiGet("unionMapProperty", java.util.Map.class);
     }
+
     public void setUnionMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unionMapProperty", java.util.Objects.requireNonNull(value, "unionMapProperty is required"));
     }
+
     public java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
+
     public void setUnionProperty(final java.lang.String value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
+
     public void setUnionProperty(final java.lang.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
+
     public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
+
     public java.util.List<java.lang.Object> getUnknownArrayProperty() {
         return this.jsiiGet("unknownArrayProperty", java.util.List.class);
     }
+
     public void setUnknownArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("unknownArrayProperty", java.util.Objects.requireNonNull(value, "unknownArrayProperty is required"));
     }
+
     public java.util.Map<java.lang.String, java.lang.Object> getUnknownMapProperty() {
         return this.jsiiGet("unknownMapProperty", java.util.Map.class);
     }
+
     public void setUnknownMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unknownMapProperty", java.util.Objects.requireNonNull(value, "unknownMapProperty is required"));
     }
+
     public java.lang.Object getUnknownProperty() {
         return this.jsiiGet("unknownProperty", java.lang.Object.class);
     }
+
     public void setUnknownProperty(final java.lang.Object value) {
         this.jsiiSet("unknownProperty", java.util.Objects.requireNonNull(value, "unknownProperty is required"));
     }
+
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.StringEnum getOptionalEnumValue() {
         return this.jsiiGet("optionalEnumValue", software.amazon.jsii.tests.calculator.StringEnum.class);
     }
+
     public void setOptionalEnumValue(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.StringEnum value) {
         this.jsiiSet("optionalEnumValue", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -10,18 +10,22 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public void getBar(final java.lang.String _p1, final java.lang.Number _p2) {
         this.jsiiCall("getBar", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_p1, "_p1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_p2, "_p2 is required"))).toArray());
     }
+
     /**
      * getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
      */
     public java.lang.String getFoo(final java.lang.String withParam) {
         return this.jsiiCall("getFoo", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(withParam, "withParam is required")).toArray());
     }
+
     public void setBar(final java.lang.String _x, final java.lang.Number _y, final java.lang.Boolean _z) {
         this.jsiiCall("setBar", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_x, "_x is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_y, "_y is required"))), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_z, "_z is required"))).toArray());
     }
+
     /**
      * setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -10,15 +10,18 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.Number callMe() {
         return this.jsiiAsyncCall("callMe", java.lang.Number.class);
     }
+
     /**
      * Just calls "overrideMeToo"
      */
     public java.lang.Number callMe2() {
         return this.jsiiAsyncCall("callMe2", java.lang.Number.class);
     }
+
     /**
      * This method calls the "callMe" async method indirectly, which will then
      * invoke a virtual method. This is a "double promise" situation, which
@@ -28,12 +31,15 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     public java.lang.Number callMeDoublePromise() {
         return this.jsiiAsyncCall("callMeDoublePromise", java.lang.Number.class);
     }
+
     public java.lang.Number dontOverrideMe() {
         return this.jsiiCall("dontOverrideMe", java.lang.Number.class);
     }
+
     public java.lang.Number overrideMe(final java.lang.Number mult) {
         return this.jsiiAsyncCall("overrideMe", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(mult, "mult is required")).toArray());
     }
+
     public java.lang.Number overrideMeToo() {
         return this.jsiiAsyncCall("overrideMeToo", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -9,18 +9,22 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
     protected BinaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     /**
      * Say hello!
      */
+    @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
+
     /**
      * Left-hand side operand
      */
     public software.amazon.jsii.tests.calculator.lib.Value getLhs() {
         return this.jsiiGet("lhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * Right-hand side operand
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -24,66 +24,78 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Adds a number to the current value.
      */
     public void add(final java.lang.Number value) {
         this.jsiiCall("add", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     /**
      * Multiplies the current value by a number.
      */
     public void mul(final java.lang.Number value) {
         this.jsiiCall("mul", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     /**
      * Negates the current value.
      */
     public void neg() {
         this.jsiiCall("neg", Void.class);
     }
+
     /**
      * Raises the current value by a power.
      */
     public void pow(final java.lang.Number value) {
         this.jsiiCall("pow", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     /**
      * Returns teh value of the union property (if defined).
      */
     public java.lang.Number readUnionValue() {
         return this.jsiiCall("readUnionValue", java.lang.Number.class);
     }
+
     /**
      * Returns the expression.
      */
+    @Override
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * A log of all operations.
      */
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getOperationsLog() {
         return this.jsiiGet("operationsLog", java.util.List.class);
     }
+
     /**
      * A map of per operation name of all operations performed.
      */
     public java.util.Map<java.lang.String, java.util.List<software.amazon.jsii.tests.calculator.lib.Value>> getOperationsMap() {
         return this.jsiiGet("operationsMap", java.util.Map.class);
     }
+
     /**
      * The current value.
      */
     public software.amazon.jsii.tests.calculator.lib.Value getCurr() {
         return this.jsiiGet("curr", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * The current value.
      */
     public void setCurr(final software.amazon.jsii.tests.calculator.lib.Value value) {
         this.jsiiSet("curr", java.util.Objects.requireNonNull(value, "curr is required"));
     }
+
     /**
      * The maximum value allows in this calculator.
      */
@@ -91,12 +103,14 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
     public java.lang.Number getMaxValue() {
         return this.jsiiGet("maxValue", java.lang.Number.class);
     }
+
     /**
      * The maximum value allows in this calculator.
      */
     public void setMaxValue(@javax.annotation.Nullable final java.lang.Number value) {
         this.jsiiSet("maxValue", value);
     }
+
     /**
      * Example of a property that accepts a union of types.
      */
@@ -104,18 +118,21 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
     public java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
+
     /**
      * Example of a property that accepts a union of types.
      */
     public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Add value) {
         this.jsiiSet("unionProperty", value);
     }
+
     /**
      * Example of a property that accepts a union of types.
      */
     public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", value);
     }
+
     /**
      * Example of a property that accepts a union of types.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -94,6 +94,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         public java.lang.Number getInitialValue() {
             return this.jsiiGet("initialValue", java.lang.Number.class);
         }
+
         @Override
         public void setInitialValue(@javax.annotation.Nullable final java.lang.Number value) {
             this.jsiiSet("initialValue", value);
@@ -104,6 +105,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         public java.lang.Number getMaximumValue() {
             return this.jsiiGet("maximumValue", java.lang.Number.class);
         }
+
         @Override
         public void setMaximumValue(@javax.annotation.Nullable final java.lang.Number value) {
             this.jsiiSet("maximumValue", value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
@@ -10,9 +10,11 @@ public class Base extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.String getProp() {
         return this.jsiiGet("prop", java.lang.String.class);
     }
+
     public void setProp(final java.lang.String value) {
         this.jsiiSet("prop", java.util.Objects.requireNonNull(value, "prop is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -239,6 +239,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.time.Instant getAnotherRequired() {
             return this.jsiiGet("anotherRequired", java.time.Instant.class);
         }
+
         @Override
         public void setAnotherRequired(final java.time.Instant value) {
             this.jsiiSet("anotherRequired", java.util.Objects.requireNonNull(value, "anotherRequired is required"));
@@ -248,6 +249,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.lang.Boolean getBool() {
             return this.jsiiGet("bool", java.lang.Boolean.class);
         }
+
         @Override
         public void setBool(final java.lang.Boolean value) {
             this.jsiiSet("bool", java.util.Objects.requireNonNull(value, "bool is required"));
@@ -260,6 +262,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive() {
             return this.jsiiGet("nonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class);
         }
+
         /**
          * An example of a non primitive property.
          */
@@ -276,6 +279,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
             return this.jsiiGet("anotherOptional", java.util.Map.class);
         }
+
         /**
          * This is optional.
          */
@@ -289,6 +293,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.util.List<java.lang.String> getOptionalArray() {
             return this.jsiiGet("optionalArray", java.util.List.class);
         }
+
         @Override
         public void setOptionalArray(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this.jsiiSet("optionalArray", value);
@@ -301,6 +306,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.lang.Number getAnumber() {
             return this.jsiiGet("anumber", java.lang.Number.class);
         }
+
         /**
          * An awesome number value
          */
@@ -316,6 +322,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.lang.String getAstring() {
             return this.jsiiGet("astring", java.lang.String.class);
         }
+
         /**
          * A string value
          */
@@ -329,6 +336,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public java.util.List<java.lang.String> getFirstOptional() {
             return this.jsiiGet("firstOptional", java.util.List.class);
         }
+
         @Override
         public void setFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this.jsiiSet("firstOptional", value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
@@ -10,15 +10,19 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Say hello!
      */
+    @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
+
     /**
      * Returns another random number.
      */
+    @Override
     public java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -10,24 +10,28 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
      */
     public software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("derivedToFirst", software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(derived, "derived is required")).toArray());
     }
+
     /**
      * Returns the boolean from a DerivedStruct struct.
      */
     public software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("readDerivedNonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(derived, "derived is required")).toArray());
     }
+
     /**
      * Returns the "anumber" from a MyFirstStruct struct;
      */
     public java.lang.Number readFirstNumber(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {
         return this.jsiiCall("readFirstNumber", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(first, "first is required")).toArray());
     }
+
     public software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals getStructLiteral() {
         return this.jsiiGet("structLiteral", software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -85,6 +85,7 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
         public java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
+
         @Override
         public void setReadWriteString(final java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -100,6 +100,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
         public java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }
+
         @Override
         public void setFoo(final java.lang.Number value) {
             this.jsiiSet("foo", java.util.Objects.requireNonNull(value, "foo is required"));
@@ -114,6 +115,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
         public java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
+
         @Override
         public void setReadWriteString(final java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -105,6 +105,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         public java.time.Instant getGoo() {
             return this.jsiiGet("goo", java.time.Instant.class);
         }
+
         @Override
         public void setGoo(final java.time.Instant value) {
             this.jsiiSet("goo", java.util.Objects.requireNonNull(value, "goo is required"));
@@ -114,6 +115,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         public java.lang.String getBar() {
             return this.jsiiGet("bar", java.lang.String.class);
         }
+
         @Override
         public void setBar(final java.lang.String value) {
             this.jsiiSet("bar", java.util.Objects.requireNonNull(value, "bar is required"));
@@ -123,6 +125,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
             return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
         }
+
         @Override
         public void setFoo(final software.amazon.jsii.tests.calculator.baseofbase.Very value) {
             this.jsiiSet("foo", java.util.Objects.requireNonNull(value, "foo is required"));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
@@ -10,9 +10,11 @@ public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public software.amazon.jsii.tests.calculator.lib.IFriendly giveMeFriendly() {
         return this.jsiiCall("giveMeFriendly", software.amazon.jsii.tests.calculator.lib.IFriendly.class);
     }
+
     public software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator giveMeFriendlyGenerator() {
         return this.jsiiCall("giveMeFriendlyGenerator", software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
@@ -10,6 +10,7 @@ public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass returnLiteral() {
         return this.jsiiCall("returnLiteral", software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
@@ -10,15 +10,19 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.String getPropA() {
         return this.jsiiGet("propA", java.lang.String.class);
     }
+
     public void setPropA(final java.lang.String value) {
         this.jsiiSet("propA", java.util.Objects.requireNonNull(value, "propA is required"));
     }
+
     public java.lang.Number getPropB() {
         return this.jsiiGet("propB", java.lang.Number.class);
     }
+
     public void setPropB(final java.lang.Number value) {
         this.jsiiSet("propB", java.util.Objects.requireNonNull(value, "propB is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
@@ -10,165 +10,219 @@ public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public void abstract_() {
         this.jsiiCall("abstract", Void.class);
     }
+
     public void assert_() {
         this.jsiiCall("assert", Void.class);
     }
+
     public void boolean_() {
         this.jsiiCall("boolean", Void.class);
     }
+
     public void break_() {
         this.jsiiCall("break", Void.class);
     }
+
     public void byte_() {
         this.jsiiCall("byte", Void.class);
     }
+
     public void case_() {
         this.jsiiCall("case", Void.class);
     }
+
     public void catch_() {
         this.jsiiCall("catch", Void.class);
     }
+
     public void char_() {
         this.jsiiCall("char", Void.class);
     }
+
     public void class_() {
         this.jsiiCall("class", Void.class);
     }
+
     public void const_() {
         this.jsiiCall("const", Void.class);
     }
+
     public void continue_() {
         this.jsiiCall("continue", Void.class);
     }
+
     public void default_() {
         this.jsiiCall("default", Void.class);
     }
+
     public void do_() {
         this.jsiiCall("do", Void.class);
     }
+
     public void double_() {
         this.jsiiCall("double", Void.class);
     }
+
     public void else_() {
         this.jsiiCall("else", Void.class);
     }
+
     public void enum_() {
         this.jsiiCall("enum", Void.class);
     }
+
     public void extends_() {
         this.jsiiCall("extends", Void.class);
     }
+
     public void false_() {
         this.jsiiCall("false", Void.class);
     }
+
     public void final_() {
         this.jsiiCall("final", Void.class);
     }
+
     public void finally_() {
         this.jsiiCall("finally", Void.class);
     }
+
     public void float_() {
         this.jsiiCall("float", Void.class);
     }
+
     public void for_() {
         this.jsiiCall("for", Void.class);
     }
+
     public void goto_() {
         this.jsiiCall("goto", Void.class);
     }
+
     public void if_() {
         this.jsiiCall("if", Void.class);
     }
+
     public void implements_() {
         this.jsiiCall("implements", Void.class);
     }
+
     public void import_() {
         this.jsiiCall("import", Void.class);
     }
+
     public void instanceof_() {
         this.jsiiCall("instanceof", Void.class);
     }
+
     public void int_() {
         this.jsiiCall("int", Void.class);
     }
+
     public void interface_() {
         this.jsiiCall("interface", Void.class);
     }
+
     public void long_() {
         this.jsiiCall("long", Void.class);
     }
+
     public void native_() {
         this.jsiiCall("native", Void.class);
     }
+
     public void new_() {
         this.jsiiCall("new", Void.class);
     }
+
     public void null_() {
         this.jsiiCall("null", Void.class);
     }
+
     public void package_() {
         this.jsiiCall("package", Void.class);
     }
+
     public void private_() {
         this.jsiiCall("private", Void.class);
     }
+
     public void protected_() {
         this.jsiiCall("protected", Void.class);
     }
+
     public void public_() {
         this.jsiiCall("public", Void.class);
     }
+
     public void return_() {
         this.jsiiCall("return", Void.class);
     }
+
     public void short_() {
         this.jsiiCall("short", Void.class);
     }
+
     public void static_() {
         this.jsiiCall("static", Void.class);
     }
+
     public void strictfp_() {
         this.jsiiCall("strictfp", Void.class);
     }
+
     public void super_() {
         this.jsiiCall("super", Void.class);
     }
+
     public void switch_() {
         this.jsiiCall("switch", Void.class);
     }
+
     public void synchronized_() {
         this.jsiiCall("synchronized", Void.class);
     }
+
     public void this_() {
         this.jsiiCall("this", Void.class);
     }
+
     public void throw_() {
         this.jsiiCall("throw", Void.class);
     }
+
     public void throws_() {
         this.jsiiCall("throws", Void.class);
     }
+
     public void transient_() {
         this.jsiiCall("transient", Void.class);
     }
+
     public void true_() {
         this.jsiiCall("true", Void.class);
     }
+
     public void try_() {
         this.jsiiCall("try", Void.class);
     }
+
     public void void_() {
         this.jsiiCall("void", Void.class);
     }
+
     public void volatile_() {
         this.jsiiCall("volatile", Void.class);
     }
+
     public java.lang.String getWhile() {
         return this.jsiiGet("while", java.lang.String.class);
     }
+
     public void setWhile(final java.lang.String value) {
         this.jsiiSet("while", java.util.Objects.requireNonNull(value, "while is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -18,33 +18,43 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(lhs, "lhs is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(rhs, "rhs is required"))).toArray());
     }
+
     /**
      * Say farewell.
      */
+    @Override
     public java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
     }
+
     /**
      * Say goodbye.
      */
+    @Override
     public java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
     }
+
     /**
      * Returns another random number.
      */
+    @Override
     public java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);
     }
+
     /**
      * String representation of the value.
      */
+    @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
+
     /**
      * The value.
      */
+    @Override
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -13,33 +13,43 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(operand, "operand is required")).toArray());
     }
+
     /**
      * Say farewell.
      */
+    @Override
     public java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
     }
+
     /**
      * Say goodbye.
      */
+    @Override
     public java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
     }
+
     /**
      * Say hello!
      */
+    @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
+
     /**
      * String representation of the value.
      */
+    @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
+
     /**
      * The value.
      */
+    @Override
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
@@ -13,6 +13,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Uses node.js "crypto" module to calculate sha256 of a string.
      * @return "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
@@ -20,6 +21,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     public java.lang.String cryptoSha256() {
         return this.jsiiCall("cryptoSha256", java.lang.String.class);
     }
+
     /**
      * Reads a local resource file (resource.txt) asynchronously.
      * @return "Hello, resource!"
@@ -27,6 +29,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     public java.lang.String fsReadFile() {
         return this.jsiiAsyncCall("fsReadFile", java.lang.String.class);
     }
+
     /**
      * Sync version of fsReadFile.
      * @return "Hello, resource! SYNC!"
@@ -34,6 +37,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     public java.lang.String fsReadFileSync() {
         return this.jsiiCall("fsReadFileSync", java.lang.String.class);
     }
+
     /**
      * Returns the current os.platform() from the "os" node module.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -14,15 +14,19 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(generator, "generator is required")).toArray());
     }
+
     public java.lang.Boolean isSameGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {
         return this.jsiiCall("isSameGenerator", java.lang.Boolean.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(gen, "gen is required")).toArray());
     }
+
     public java.lang.Number nextTimes100() {
         return this.jsiiCall("nextTimes100", java.lang.Number.class);
     }
+
     public software.amazon.jsii.tests.calculator.IRandomNumberGenerator getGenerator() {
         return this.jsiiGet("generator", software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class);
     }
+
     public void setGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator value) {
         this.jsiiSet("generator", java.util.Objects.requireNonNull(value, "generator is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -13,12 +13,14 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Returns the sum of all values
      */
     public java.lang.Number sumFromArray(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
         return this.jsiiCall("sumFromArray", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(values, "values is required")).toArray());
     }
+
     /**
      * Returns the sum of all values in a map
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -10,6 +10,7 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.Number test(final software.amazon.jsii.tests.calculator.ReturnsNumber obj) {
         return this.jsiiCall("test", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -10,6 +10,7 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.String sayHello(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
         return this.jsiiCall("sayHello", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(friendly, "friendly is required")).toArray());
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -18,19 +18,23 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(base, "base is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(pow, "pow is required"))).toArray());
     }
+
     /**
      * The base of the power
      */
     public software.amazon.jsii.tests.calculator.lib.Value getBase() {
         return this.jsiiGet("base", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * The expression that this operation consists of.
      * Must be implemented by derived classes.
      */
+    @Override
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * The number of times to multiply
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -13,17 +13,21 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule loadFoo() {
         return this.jsiiCall("loadFoo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
+
     public void saveFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiCall("saveFoo", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule getFoo() {
         return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
+
     public void setFoo(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiSet("foo", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -10,12 +10,14 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * Used to verify verification of number of method arguments.
      */
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         this.jsiiCall("methodWithOptionalArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
     }
+
     /**
      * Used to verify verification of number of method arguments.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -16,6 +16,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     /**
      * Jsdocs for static method
      * @param name The name of the person to say hello to
@@ -23,6 +24,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     public static java.lang.String staticMethod(final java.lang.String name) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Statics.class, "staticMethod", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(name, "name is required")).toArray());
     }
+
     public java.lang.String justMethod() {
         return this.jsiiCall("justMethod", java.lang.String.class);
     }
@@ -39,6 +41,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * Constants can also use camelCase.
      */
     public final static java.util.Map<java.lang.String, java.lang.String> ZOO_BAR;
+
     /**
      * Jsdocs for static getter.
      * Jsdocs for static setter.
@@ -46,6 +49,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     public static software.amazon.jsii.tests.calculator.Statics getInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "instance", software.amazon.jsii.tests.calculator.Statics.class);
     }
+
     /**
      * Jsdocs for static getter.
      * Jsdocs for static setter.
@@ -53,12 +57,15 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     public static void setInstance(final software.amazon.jsii.tests.calculator.Statics value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "instance", java.util.Objects.requireNonNull(value, "instance is required"));
     }
+
     public static java.lang.Number getNonConstStatic() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.lang.Number.class);
     }
+
     public static void setNonConstStatic(final java.lang.Number value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.util.Objects.requireNonNull(value, "nonConstStatic is required"));
     }
+
     public java.lang.String getValue() {
         return this.jsiiGet("value", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
@@ -13,19 +13,23 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     /**
      * The expression that this operation consists of.
      * Must be implemented by derived classes.
      */
+    @Override
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * The parts to sum.
      */
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getParts() {
         return this.jsiiGet("parts", java.util.List.class);
     }
+
     /**
      * The parts to sum.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -10,66 +10,87 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.Number callerIsAsync() {
         return this.jsiiAsyncCall("callerIsAsync", java.lang.Number.class);
     }
+
     public java.lang.Number callerIsMethod() {
         return this.jsiiCall("callerIsMethod", java.lang.Number.class);
     }
+
     public void modifyOtherProperty(final java.lang.String value) {
         this.jsiiCall("modifyOtherProperty", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     public void modifyValueOfTheProperty(final java.lang.String value) {
         this.jsiiCall("modifyValueOfTheProperty", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     public java.lang.Number readA() {
         return this.jsiiCall("readA", java.lang.Number.class);
     }
+
     public java.lang.String retrieveOtherProperty() {
         return this.jsiiCall("retrieveOtherProperty", java.lang.String.class);
     }
+
     public java.lang.String retrieveReadOnlyProperty() {
         return this.jsiiCall("retrieveReadOnlyProperty", java.lang.String.class);
     }
+
     public java.lang.String retrieveValueOfTheProperty() {
         return this.jsiiCall("retrieveValueOfTheProperty", java.lang.String.class);
     }
+
     public java.lang.Number virtualMethod(final java.lang.Number n) {
         return this.jsiiCall("virtualMethod", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(n, "n is required")).toArray());
     }
+
     public void writeA(final java.lang.Number value) {
         this.jsiiCall("writeA", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     public java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
+
     public java.lang.Number getA() {
         return this.jsiiGet("a", java.lang.Number.class);
     }
+
     public void setA(final java.lang.Number value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
+
     public java.lang.Number getCallerIsProperty() {
         return this.jsiiGet("callerIsProperty", java.lang.Number.class);
     }
+
     public void setCallerIsProperty(final java.lang.Number value) {
         this.jsiiSet("callerIsProperty", java.util.Objects.requireNonNull(value, "callerIsProperty is required"));
     }
+
     public java.lang.String getOtherProperty() {
         return this.jsiiGet("otherProperty", java.lang.String.class);
     }
+
     public void setOtherProperty(final java.lang.String value) {
         this.jsiiSet("otherProperty", java.util.Objects.requireNonNull(value, "otherProperty is required"));
     }
+
     public java.lang.String getTheProperty() {
         return this.jsiiGet("theProperty", java.lang.String.class);
     }
+
     public void setTheProperty(final java.lang.String value) {
         this.jsiiSet("theProperty", java.util.Objects.requireNonNull(value, "theProperty is required"));
     }
+
     public java.lang.String getValueOfOtherProperty() {
         return this.jsiiGet("valueOfOtherProperty", java.lang.String.class);
     }
+
     public void setValueOfOtherProperty(final java.lang.String value) {
         this.jsiiSet("valueOfOtherProperty", java.util.Objects.requireNonNull(value, "valueOfOtherProperty is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
@@ -10,6 +10,7 @@ public class Thrower extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public void throwError() {
         this.jsiiCall("throwError", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -9,6 +9,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
     protected UnaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     public software.amazon.jsii.tests.calculator.lib.Value getOperand() {
         return this.jsiiGet("operand", software.amazon.jsii.tests.calculator.lib.Value.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -121,10 +121,12 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         public java.lang.Object getFoo() {
             return this.jsiiGet("foo", java.lang.Object.class);
         }
+
         @Override
         public void setFoo(@javax.annotation.Nullable final java.lang.String value) {
             this.jsiiSet("foo", value);
         }
+
         @Override
         public void setFoo(@javax.annotation.Nullable final java.lang.Number value) {
             this.jsiiSet("foo", value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -10,6 +10,7 @@ public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.Object value() {
         return this.jsiiCall("value", java.lang.Object.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
@@ -13,6 +13,7 @@ public class UseCalcBase extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public software.amazon.jsii.tests.calculator.base.Base hello() {
         return this.jsiiCall("hello", software.amazon.jsii.tests.calculator.base.Base.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -10,15 +10,19 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
     }
+
     public java.lang.String justRead() {
         return this.jsiiCall("justRead", java.lang.String.class);
     }
+
     public java.lang.String readStringAndNumber(final software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
         return this.jsiiCall("readStringAndNumber", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(ext, "ext is required")).toArray());
     }
+
     public java.lang.String writeAndRead(final java.lang.String value) {
         return this.jsiiCall("writeAndRead", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
     }
+
     public software.amazon.jsii.tests.calculator.IInterfaceWithProperties getObj() {
         return this.jsiiGet("obj", software.amazon.jsii.tests.calculator.IInterfaceWithProperties.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -13,6 +13,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.stream(java.util.Objects.requireNonNull(prefix, "prefix is required")).toArray());
     }
+
     /**
      * @param first the first element of the array to be returned (after the ``prefix`` provided at construction time).
      * @param others other elements to be included in the array.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -10,18 +10,23 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
+
     public java.lang.Number overrideMeAsync(final java.lang.Number index) {
         return this.jsiiAsyncCall("overrideMeAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(index, "index is required")).toArray());
     }
+
     public java.lang.Number overrideMeSync(final java.lang.Number index) {
         return this.jsiiCall("overrideMeSync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(index, "index is required")).toArray());
     }
+
     public java.lang.Number parallelSumAsync(final java.lang.Number count) {
         return this.jsiiAsyncCall("parallelSumAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
     }
+
     public java.lang.Number serialSumAsync(final java.lang.Number count) {
         return this.jsiiAsyncCall("serialSumAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
     }
+
     public java.lang.Number sumSync(final java.lang.Number count) {
         return this.jsiiCall("sumSync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -9,12 +9,15 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
     protected CompositeOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+
     /**
      * String representation of the value.
      */
+    @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
+
     /**
      * The expression that this operation consists of.
      * Must be implemented by derived classes.
@@ -22,42 +25,50 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
     /**
      * The value.
      */
+    @Override
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
+
     /**
      * A set of postfixes to include in a decorated .toString().
      */
     public java.util.List<java.lang.String> getDecorationPostfixes() {
         return this.jsiiGet("decorationPostfixes", java.util.List.class);
     }
+
     /**
      * A set of postfixes to include in a decorated .toString().
      */
     public void setDecorationPostfixes(final java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPostfixes", java.util.Objects.requireNonNull(value, "decorationPostfixes is required"));
     }
+
     /**
      * A set of prefixes to include in a decorated .toString().
      */
     public java.util.List<java.lang.String> getDecorationPrefixes() {
         return this.jsiiGet("decorationPrefixes", java.util.List.class);
     }
+
     /**
      * A set of prefixes to include in a decorated .toString().
      */
     public void setDecorationPrefixes(final java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPrefixes", java.util.Objects.requireNonNull(value, "decorationPrefixes is required"));
     }
+
     /**
      * The .toString() style.
      */
     public software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle getStringStyle() {
         return this.jsiiGet("stringStyle", software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle.class);
     }
+
     /**
      * The .toString() style.
      */

--- a/packages/jsii-spec/lib/spec.ts
+++ b/packages/jsii-spec/lib/spec.ts
@@ -286,9 +286,22 @@ export function isUnionTypeReference(ref: TypeReference): ref is UnionTypeRefere
 }
 
 /**
+ * Methods and properties can be overridden from parent classes or implemented from interfaces.
+ */
+export interface Overridable {
+    /**
+     * The name of the parent type (class or interface) that this entity overrides or implements. If undefined, then
+     * this entity is the first in it's hierarchy to declare this entity.
+     *
+     * @default undefined
+     */
+    overrides?: NamedTypeReference;
+}
+
+/**
  * A class property.
  */
-export interface Property extends Documentable {
+export interface Property extends Documentable, Overridable {
     /**
      * The name of the property.
      * @minLength 1
@@ -354,7 +367,7 @@ export interface Parameter extends Documentable {
 /**
  * Represents a method.
  */
-export interface Method extends Documentable {
+export interface Method extends Documentable, Overridable {
 
     /**
      * The name of the method. Undefined if this method is a initializer.
@@ -408,21 +421,21 @@ export type Type = TypeBase & (ClassType | EnumType | InterfaceType);
  */
 export interface TypeBase extends Documentable {
     /**
-     * The fully qualified name of the type (<assembly>.<namespace>.<name>)
-     * @minLength 1
+     * The fully qualified name of the type (``<assembly>.<namespace>.<name>``)
+     * @minLength 3
      */
     fqn: string;
 
     /**
-     * The name of the assembly. Cannot be undefined.
+     * The name of the assembly the type belongs to.
      * @minLength 1
      */
     assembly: string;
 
     /**
-     * The namespace of the type (foo.goo.doo).
-     * It is possible that namespace will be undefined, in which case the type is at the root
-     * of the assembly.
+     * The namespace of the type (``foo.bar.baz``). When undefined, the type is located at the root of the assembly
+     * (it's ``fqn`` would be like ``<assembly>.<name>``). If the `namespace` corresponds to an existing type's
+     * namespace-qualified (e.g: ``<namespace>.<name>``), then the current type is a nested type.
      */
     namespace?: string;
 
@@ -436,16 +449,6 @@ export interface TypeBase extends Documentable {
      * The kind of the type.
      */
     kind: TypeKind;
-
-    /**
-     * FQNs of all the subtypes of this type.
-     */
-    subtypes?: string[];
-
-    /**
-     * FQN of the parent type of this type (or undefined if this is not a subtype).
-     */
-    parenttype?: string;
 }
 
 /**

--- a/packages/jsii/lib/util.ts
+++ b/packages/jsii/lib/util.ts
@@ -1,11 +1,14 @@
 /**
- * Can be passed to JSON.stringify to filter out empty arrays and objects.
+ * Can be passed to JSON.stringify to filter out empty arrays, objects and strings, as well as ``false``.
  */
 export function filterEmpty(_key: any, value: any): any {
     if (Array.isArray(value) && value.length === 0) {
         return undefined;
     }
     if (typeof value === 'object' && Object.keys(value).length === 0) {
+        return undefined;
+    }
+    if (!value) {
         return undefined;
     }
 


### PR DESCRIPTION
* The `namespace` field no longer is prefixed with the `assembly` name
  + As a consequence, it is often blank, and thus skipped from the output (smaller files 🎉)
* There is no `subtypes` property anymore (it used to contain the list of nested types)
* There is no `parenttype` property anymore (if the namespace is a type name, then the type is nested)
* Introduced a new `overrides` field on `Method` and `Property`, indicating the `NamedTypeReference` of the ancestor that defines the member
  + Used to inject `@Override` annotations in Java code
  + Can be leveraged by other code generators that "need to know" when a method overrides (I'm looking at you, `C#`!)