### PR TITLE
Fix namespace conversion for scoped packages, and output .NET artifacts to dist/dotnet/ rather than just dist/.

### DIFF
--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
@@ -60,6 +60,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn1",
                     assembly: "my-package",
                     name: "MyType",
+                    @namespace: "my-package",
                     isAbstract: false
                 );
                 Type type2 = new ClassType
@@ -67,7 +68,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     fullyQualifiedName: "myFqn2",
                     assembly: "my-package",
                     name: "myType2",
-                    @namespace: "MyType",
+                    @namespace: "my-package.MyType",
                     isAbstract: false
                 );
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeMetadataTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/TypeMetadataTests.cs
@@ -1,4 +1,5 @@
 ﻿using Amazon.JSII.JsonModel.Spec;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -47,7 +48,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myNamespace",
+                @namespace: "myModule.myNamespace",
                 isAbstract: false
             );
 
@@ -156,6 +157,75 @@ namespace Amazon.JSII.Generator.UnitTests
 
                 Assert.Equal("MyName_", metadata.Name);
             }
+
+            [Fact(DisplayName = _Prefix + nameof(EscapesScopedNamespace))]
+            public void EscapesScopedNamespace()
+            {
+                // If a folder or filename begins with @, the C# compiler interprets it as a response file (i.e. .rsp), breaking compilation.
+                // Additionally, C# namespaces may not include @. This also breaks compilation.
+
+                ClassType type = new ClassType(
+                    fullyQualifiedName: "@aws-cdk/cx-api.AppRuntime",
+                    assembly: "@aws-cdk/cx-api",
+                    name: "AppRuntime",
+                    @namespace: "@aws-cdk/cx-api",
+                    docs: new Docs
+                    {
+                        { "comment", "Information about the application's runtime components." }
+                    },
+                    properties: new Property[]
+                    {
+                        new Property(
+                            name: "libraries",
+                            type: new TypeReference(
+                                collection: new CollectionTypeReference(
+                                    CollectionKind.Map,
+                                    new TypeReference(primitive: PrimitiveType.String)
+                                )
+                            ),
+                            docs: new Docs
+                            {
+                                { "comment", "The list of libraries loaded in the application, associated with their versions." }
+                            }
+                        )
+                    },
+                    isAbstract: false
+                );
+
+                Assembly assembly = new Assembly(
+                    name: "@aws-cdk/cx-api",
+                    description: "Cloud executable protocol",
+                    homepage: "https://github.com/awslabs/aws-cdk",
+                    repository: new Assembly.AssemblyRepository(
+                        type: "git",
+                        url: "https://github.com/awslabs/aws-cdk.git"
+                    ),
+                    author: new Person(
+                        name: "Amazon Web Services",
+                        organization: true,
+                        roles: new[] { "author" },
+                        url: "https://aws.amazon.com"
+                    ),
+                    fingerprint: "Waqr5eba/zt52r9/c3IpkqJRi7kbpxl5vJKj4jt8fxE=",
+                    version: "0.8.2",
+                    license: "Apache-2.0",
+                    targets: new AssemblyTargets(
+                        dotnet: new AssemblyTargets.DotNetTarget(
+                            @namespace: "Amazon.CDK.CXAPI",
+                            packageId: "Amazon.CDK.CXAPI"
+                        )
+                    ),
+                    types: new Dictionary<string, JsonModel.Spec.Type> {
+                        { type.FullyQualifiedName, type }
+                    },
+                    readme: new Readme("## Cloud Executable protocol\nThis module is part of the [AWS Cloud Development Kit](https://github.com/awslabs/aws-cdk) project.\n")
+                );
+
+                ClassTypeMetadata metadata = new ClassTypeMetadata(type, assembly);
+                metadata.ResolveTypeNameConflicts(new HashSet<string>());
+
+                Assert.Equal("Amazon.CDK.CXAPI.AppRuntime", metadata.FrameworkFullyQualifiedName);
+            }
         }
 
         public class Enum
@@ -195,7 +265,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myNamespace",
+                @namespace: "myModule.myNamespace",
                 members: new EnumMember[] { }
             );
 
@@ -274,6 +344,62 @@ namespace Amazon.JSII.Generator.UnitTests
 
                 Assert.Equal("MyName_", metadata.Name);
             }
+
+            [Fact(DisplayName = _Prefix + nameof(EscapesScopedNamespace))]
+            public void EscapesScopedNamespace()
+            {
+                // If a folder or filename begins with @, the C# compiler interprets it as a response file (i.e. .rsp), breaking compilation.
+                // Additionally, C# namespaces may not include @. This also breaks compilation.
+
+                EnumType type = new EnumType(
+                    fullyQualifiedName: "@aws-cdk/cx-api.AppRuntime",
+                    assembly: "@aws-cdk/cx-api",
+                    name: "AppRuntime",
+                    @namespace: "@aws-cdk/cx-api",
+                    docs: new Docs
+                    {
+                        { "comment", "Information about the application's runtime components." }
+                    },
+                    members: new EnumMember[]
+                    {
+                        new EnumMember("myEnumMember")
+                    }
+                );
+
+                Assembly assembly = new Assembly(
+                    name: "@aws-cdk/cx-api",
+                    description: "Cloud executable protocol",
+                    homepage: "https://github.com/awslabs/aws-cdk",
+                    repository: new Assembly.AssemblyRepository(
+                        type: "git",
+                        url: "https://github.com/awslabs/aws-cdk.git"
+                    ),
+                    author: new Person(
+                        name: "Amazon Web Services",
+                        organization: true,
+                        roles: new[] { "author" },
+                        url: "https://aws.amazon.com"
+                    ),
+                    fingerprint: "Waqr5eba/zt52r9/c3IpkqJRi7kbpxl5vJKj4jt8fxE=",
+                    version: "0.8.2",
+                    license: "Apache-2.0",
+                    targets: new AssemblyTargets(
+                        dotnet: new AssemblyTargets.DotNetTarget(
+                            @namespace: "Amazon.CDK.CXAPI",
+                            packageId: "Amazon.CDK.CXAPI"
+                        )
+                    ),
+                    types: new Dictionary<string, JsonModel.Spec.Type> {
+                        { type.FullyQualifiedName, type }
+                    },
+                    readme: new Readme("## Cloud Executable protocol\nThis module is part of the [AWS Cloud Development Kit](https://github.com/awslabs/aws-cdk) project.\n")
+                );
+
+                EnumTypeMetadata metadata = new EnumTypeMetadata(type, assembly);
+                metadata.ResolveTypeNameConflicts(new HashSet<string>());
+
+                Assert.Equal("Amazon.CDK.CXAPI.AppRuntime", metadata.FrameworkFullyQualifiedName);
+            }
         }
 
         public class Interface
@@ -313,7 +439,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 fullyQualifiedName: "myFqn",
                 assembly: "myModule",
                 name: "myName",
-                @namespace: "myNamespace",
+                @namespace: "myModule.myNamespace",
                 isDataType: true
             );
 
@@ -458,6 +584,75 @@ namespace Amazon.JSII.Generator.UnitTests
                 metadata.ResolveTypeNameConflicts(new HashSet<string>());
 
                 Assert.Equal("IMyName_", metadata.Name);
+            }
+
+            [Fact(DisplayName = _Prefix + nameof(EscapesScopedNamespace))]
+            public void EscapesScopedNamespace()
+            {
+                // If a folder or filename begins with @, the C# compiler interprets it as a response file (i.e. .rsp), breaking compilation.
+                // Additionally, C# namespaces may not include @. This also breaks compilation.
+
+                InterfaceType type = new InterfaceType(
+                    fullyQualifiedName: "@aws-cdk/cx-api.AppRuntime",
+                    assembly: "@aws-cdk/cx-api",
+                    name: "AppRuntime",
+                    @namespace: "@aws-cdk/cx-api",
+                    docs: new Docs
+                    {
+                        { "comment", "Information about the application's runtime components." }
+                    },
+                    properties: new Property[]
+                    {
+                        new Property(
+                            name: "libraries",
+                            type: new TypeReference(
+                                collection: new CollectionTypeReference(
+                                    CollectionKind.Map,
+                                    new TypeReference(primitive: PrimitiveType.String)
+                                )
+                            ),
+                            docs: new Docs
+                            {
+                                { "comment", "The list of libraries loaded in the application, associated with their versions." }
+                            }
+                        )
+                    },
+                    isDataType: true
+                );
+
+                Assembly assembly = new Assembly(
+                    name: "@aws-cdk/cx-api",
+                    description: "Cloud executable protocol",
+                    homepage: "https://github.com/awslabs/aws-cdk",
+                    repository: new Assembly.AssemblyRepository(
+                        type: "git",
+                        url: "https://github.com/awslabs/aws-cdk.git"
+                    ),
+                    author: new Person(
+                        name: "Amazon Web Services",
+                        organization: true,
+                        roles: new[] { "author" },
+                        url: "https://aws.amazon.com"
+                    ),
+                    fingerprint: "Waqr5eba/zt52r9/c3IpkqJRi7kbpxl5vJKj4jt8fxE=",
+                    version: "0.8.2",
+                    license: "Apache-2.0",
+                    targets: new AssemblyTargets(
+                        dotnet: new AssemblyTargets.DotNetTarget(
+                            @namespace: "Amazon.CDK.CXAPI",
+                            packageId: "Amazon.CDK.CXAPI"
+                        )
+                    ),
+                    types: new Dictionary<string, JsonModel.Spec.Type> {
+                        { type.FullyQualifiedName, type }
+                    },
+                    readme: new Readme("## Cloud Executable protocol\nThis module is part of the [AWS Cloud Development Kit](https://github.com/awslabs/aws-cdk) project.\n")
+                );
+
+                InterfaceTypeMetadata metadata = new InterfaceTypeMetadata(type, assembly);
+                metadata.ResolveTypeNameConflicts(new HashSet<string>());
+
+                Assert.Equal("Amazon.CDK.CXAPI.IAppRuntime", metadata.FrameworkFullyQualifiedName);
             }
         }
     }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
@@ -16,8 +16,8 @@ namespace Amazon.JSII.Generator
 
             Package = type.Assembly;
 
-            string suffix = type.Namespace != null ? $".{type.Namespace}" : "";
-            Namespace = $"{assembly.GetNativeNamespace(Package)}{suffix}";
+            string nativeNamespace = assembly.GetNativeNamespace(Package);
+            Namespace = type.Namespace?.Replace(Package, nativeNamespace) ?? nativeNamespace;
         }
 
         public virtual void ResolveTypeNameConflicts(ISet<string> namespaceNames)

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -28,7 +28,9 @@ export default class Dotnet extends Target {
             { cwd: sourceDir }
         );
 
-        await this.copyFiles(path.join(sourceDir, packageId, 'bin', 'Release'), outDir);
+        await this.copyFiles(
+            path.join(sourceDir, packageId, 'bin', 'Release'),
+            path.join(outDir, this.targetName));
         await fs.remove(path.join(outDir, 'netstandard2.0'));
     }
 

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -46,11 +46,6 @@
 				"json-schema-traverse": "^0.3.0"
 			}
 		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -102,6 +97,11 @@
 				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -110,8 +110,15 @@
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
 						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
 						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -538,6 +545,13 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				}
 			}
 		},
 		"has-flag": {
@@ -3402,14 +3416,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -3582,6 +3588,21 @@
 			"requires": {
 				"punycode": "^1.3.2",
 				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
 			}
 		},
 		"universalify": {
@@ -3632,6 +3653,11 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -3648,6 +3674,14 @@
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
 						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -1958,7 +1958,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1976,11 +1977,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1993,15 +1996,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2104,7 +2110,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2114,6 +2121,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2126,17 +2134,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2153,6 +2164,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2225,7 +2237,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2235,6 +2248,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2310,7 +2324,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2340,6 +2355,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2357,6 +2373,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2395,11 +2412,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},


### PR DESCRIPTION
1. `jsii-pacmak`, when searching for local dependencies, looks in `dist/dotnet/`. But it places .NET build output directly in `dist/`. This change fixes that.
2. `jsii-dotnet-generator` previously considered each type's namespace to *implicitly* begin with the assembly's root namespace. At some point, the `jsii` compiler changed to explicitly include the assembly name in each type's namespace. This change fixes that.
3. As a side effect of <span>#</span>2, some generated folders began with `@`, causing the C# compiler to interpret them as response (`.rsp`) files. The fix for <span>#</span>2 also fixes this issue.