### PR TITLE
Output .NET build artifacts to dist/dotnet/ instead of just dist/.

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -28,7 +28,9 @@ export default class Dotnet extends Target {
             { cwd: sourceDir }
         );
 
-        await this.copyFiles(path.join(sourceDir, packageId, 'bin', 'Release'), outDir);
+        await this.copyFiles(
+            path.join(sourceDir, packageId, 'bin', 'Release'),
+            path.join(outDir, this.targetName));
         await fs.remove(path.join(outDir, 'netstandard2.0'));
     }
 


### PR DESCRIPTION
When `jsii-pacmak` looks for local dependencies, it looks in `dist/{targetname}`. But it places .NET artifacts directly in `dist/`. This change fixes that.
