### PR TITLE
Fix module loading on systems that use '\' instead of '/' as the path separator.

### DIFF
--- a/packages/jsii-kernel/lib/kernel.ts
+++ b/packages/jsii-kernel/lib/kernel.ts
@@ -126,7 +126,7 @@ export class Kernel {
                 await fs.move(path.join(staging, 'package'), packageDir);
 
                 // load the module and capture it's closure
-                const closure = this._execute(`require("${packageDir}")`, packageDir);
+                const closure = this._execute(`require(String.raw\`${packageDir}\`)`, packageDir);
                 const assm = new Assembly(assmSpec, closure);
                 this._addAssembly(assm);
 


### PR DESCRIPTION
If `packageDir` is something like `so\neat`, then the code run by `_execute` will be `require("so\neat")`, which fails due to the escape sequence `\n`.

With this change, the code run by `_execute` will instead be ``require(String.raw`so\neat`)``.