### PR TITLE
Fix SNK property name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ The following targets are currently supported:
     /* Optional. Default: null (no icon). */
     "iconUrl": "path/to/icon.svg",
 
-    /* Optional. Used in conjunction with assemblyOriginatorKey. Default: false. */
+    /* Optional. Used in conjunction with assemblyOriginatorKeyFile. Default: false. */
     "signAssembly": true,
 
     /* Optional. Used in conjunction with signAssembly. Default: null. */
-    "assemblyOriginatorKey": "path/to/key.snk"
+    "assemblyOriginatorKeyFile": "path/to/key.snk"
   }
 }
 ```

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/AssemblyExtensionsTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/AssemblyExtensionsTests.cs
@@ -268,7 +268,7 @@ namespace Amazon.JSII.Generator.UnitTests
                         packageId: "My.PackageId",
                         title: "My Human Readable Title",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "https://www.example.com/icon.svg"
                     ))
                 );
@@ -285,7 +285,7 @@ namespace Amazon.JSII.Generator.UnitTests
                     element => Assert.Equal("<Authors>Jane Doe</Authors>", element.ToString()),
                     element => Assert.Equal("<Title>My Human Readable Title</Title>", element.ToString()),
                     element => Assert.Equal("<SignAssembly>true</SignAssembly>", element.ToString()),
-                    element => Assert.Equal("<AssemblyOriginatorKey>key.snk</AssemblyOriginatorKey>", element.ToString()),
+                    element => Assert.Equal("<AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>", element.ToString()),
                     element => Assert.Equal("<IconUrl>http://www.example.com/icon.svg</IconUrl>", element.ToString())
                 );
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyExtensions.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyExtensions.cs
@@ -77,9 +77,9 @@ namespace Amazon.JSII.Generator
                 yield return new XElement("SignAssembly", assembly.Targets.DotNet.SignAssembly);
             }
 
-            if (assembly.Targets.DotNet.AssemblyOriginatorKey != null)
+            if (assembly.Targets.DotNet.AssemblyOriginatorKeyFile != null)
             {
-                yield return new XElement("AssemblyOriginatorKey", assembly.Targets.DotNet.AssemblyOriginatorKey);
+                yield return new XElement("AssemblyOriginatorKeyFile", assembly.Targets.DotNet.AssemblyOriginatorKeyFile);
             }
 
             if (assembly.Targets.DotNet.IconUrl != null)

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel.UnitTests/Spec/AssemblyTests.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel.UnitTests/Spec/AssemblyTests.cs
@@ -38,7 +38,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     dependencies: new Dictionary<string, PackageVersion>(),
@@ -93,7 +93,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
       ""namespace"": ""Dot.Net.Namespace"",
       ""packageId"": ""Dot.Net.PackageId"",
       ""signAssembly"": true,
-      ""assemblyOriginatorKey"": ""key.snk"",
+      ""assemblyOriginatorKeyFile"": ""key.snk"",
       ""iconUrl"": ""http://www.example.com/icon.png""
     }
   }
@@ -119,7 +119,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     dependencies: new Dictionary<string, PackageVersion>(),
@@ -146,7 +146,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     types: new Dictionary<string, JsonModel.Spec.Type>(),
@@ -173,7 +173,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     types: new Dictionary<string, JsonModel.Spec.Type>(),
@@ -207,7 +207,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
       ""namespace"": ""Dot.Net.Namespace"",
       ""packageId"": ""Dot.Net.PackageId"",
       ""signAssembly"": true,
-      ""assemblyOriginatorKey"": ""key.snk"",
+      ""assemblyOriginatorKeyFile"": ""key.snk"",
       ""iconUrl"": ""http://www.example.com/icon.png""
     }
   }
@@ -233,7 +233,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     types: new Dictionary<string, JsonModel.Spec.Type>(),
@@ -267,7 +267,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
       ""namespace"": ""Dot.Net.Namespace"",
       ""packageId"": ""Dot.Net.PackageId"",
       ""signAssembly"": true,
-      ""assemblyOriginatorKey"": ""key.snk"",
+      ""assemblyOriginatorKeyFile"": ""key.snk"",
       ""iconUrl"": ""http://www.example.com/icon.png""
     }
   }
@@ -293,7 +293,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                         @namespace: "Dot.Net.Namespace",
                         packageId: "Dot.Net.PackageId",
                         signAssembly: true,
-                        assemblyOriginatorKey: "key.snk",
+                        assemblyOriginatorKeyFile: "key.snk",
                         iconUrl: "http://www.example.com/icon.png"
                     )),
                     types: new Dictionary<string, JsonModel.Spec.Type>(),
@@ -327,7 +327,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
       ""namespace"": ""Dot.Net.Namespace"",
       ""packageId"": ""Dot.Net.PackageId"",
       ""signAssembly"": true,
-      ""assemblyOriginatorKey"": ""key.snk"",
+      ""assemblyOriginatorKeyFile"": ""key.snk"",
       ""iconUrl"": ""http://www.example.com/icon.png""
     }
   }
@@ -426,7 +426,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
       ""namespace"": ""Dot.Net.Namespace"",
       ""packageId"": ""Dot.Net.PackageId"",
       ""signAssembly"": true,
-      ""assemblyOriginatorKey"": ""key.snk"",
+      ""assemblyOriginatorKeyFile"": ""key.snk"",
       ""iconUrl"": ""http://www.example.com/icon.png""
     },
     ""java"": { ""package"": ""com.amazonaws.cdk.Test"" }
@@ -460,7 +460,7 @@ namespace Amazon.JSII.JsonModel.UnitTests.Spec
                 Assert.Equal("Dot.Net.Namespace", dotNetTarget.Namespace);
                 Assert.Equal("Dot.Net.PackageId", dotNetTarget.PackageId);
                 Assert.True(dotNetTarget.SignAssembly);
-                Assert.Equal("key.snk", dotNetTarget.AssemblyOriginatorKey);
+                Assert.Equal("key.snk", dotNetTarget.AssemblyOriginatorKeyFile);
                 Assert.Equal("http://www.example.com/icon.png", dotNetTarget.IconUrl);
 
                 Assert.Equal("myVersion", actual.Version, ignoreLineEndingDifferences: true);

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/AssemblyTargets.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/AssemblyTargets.cs
@@ -24,7 +24,7 @@ namespace Amazon.JSII.JsonModel.Spec
                 string packageId,
                 string title = null,
                 bool? signAssembly = null,
-                string assemblyOriginatorKey = null,
+                string assemblyOriginatorKeyFile = null,
                 string iconUrl = null
             )
             {
@@ -33,7 +33,7 @@ namespace Amazon.JSII.JsonModel.Spec
 
                 Title = title;
                 SignAssembly = signAssembly;
-                AssemblyOriginatorKey = assemblyOriginatorKey;
+                AssemblyOriginatorKeyFile = assemblyOriginatorKeyFile;
                 IconUrl = iconUrl;
             }
             
@@ -49,8 +49,8 @@ namespace Amazon.JSII.JsonModel.Spec
             [JsonProperty("signAssembly", NullValueHandling = NullValueHandling.Ignore)]
             public bool? SignAssembly { get; }
 
-            [JsonProperty("assemblyOriginatorKey", NullValueHandling = NullValueHandling.Ignore)]
-            public string AssemblyOriginatorKey { get; }
+            [JsonProperty("assemblyOriginatorKeyFile", NullValueHandling = NullValueHandling.Ignore)]
+            public string AssemblyOriginatorKeyFile { get; }
 
             [JsonProperty("iconUrl", NullValueHandling = NullValueHandling.Ignore)]
             public string IconUrl { get; }


### PR DESCRIPTION
The correct name for the MSBuild property containing the path to the `.snk` file is `AssemblyOriginatorKeyFile`, not `AssemblyOriginatorKey`.