### PR TITLE
Feature: Add dotnet reference docs

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -5,10 +5,37 @@ import path = require('path');
 import xmlbuilder = require('xmlbuilder');
 import { IGenerator } from '../generator';
 import logging = require('../logging');
-import { Target, TargetOptions } from '../target';
+import { PackageInfo, Target, TargetOptions } from '../target';
 import { shell } from '../util';
 
 export default class Dotnet extends Target {
+    public static toPackageInfos(assm: spec.Assembly): { [language: string]: PackageInfo } {
+        const packageId = assm.targets!.dotnet!.packageId;
+        const version = assm.version;
+        const packageInfo: PackageInfo = {
+            repository: 'Nuget',
+            url: `https://www.nuget.org/packages/${packageId}/${version}`,
+            usage: {
+                dotnet: {
+                    language: 'console',
+                    code: `dotnet add package ${packageId} --version ${version}`
+                },
+                csproj: {
+                    language: 'xml',
+                    code: `<PackageReference Include="${packageId}" Version="${version}" />`
+                }
+            }
+        };
+        return {'C#': packageInfo};
+    }
+
+    // @ts-ignore: type is a required parameter
+    public static toNativeReference(type: spec.Type, options: any) {
+        return {
+            'c#': `using ${options.namespace};`
+        };
+    }
+
     protected readonly generator = new DotNetGenerator();
 
     constructor(options: TargetOptions) {

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -16,13 +16,17 @@ export default class Dotnet extends Target {
             repository: 'Nuget',
             url: `https://www.nuget.org/packages/${packageId}/${version}`,
             usage: {
-                dotnet: {
+                'csproj': {
+                    language: 'xml',
+                    code: `<PackageReference Include="${packageId}" Version="${version}" />`
+                },
+                'dotnet': {
                     language: 'console',
                     code: `dotnet add package ${packageId} --version ${version}`
                 },
-                csproj: {
+                'packages.config': {
                     language: 'xml',
-                    code: `<PackageReference Include="${packageId}" Version="${version}" />`
+                    code: `<package id="${packageId}" version="${version}" />`
                 }
             }
         };

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -19,6 +19,12 @@
 
          dotnet add package Amazon.JSII.Tests.CalculatorPackageId.BasePackageId --version 0.7.0
 
+      **packages.config**:
+
+      .. code-block:: xml
+
+         <package id="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" version="0.7.0" />
+
 
    .. group-tab:: Java
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -3,6 +3,23 @@
 
 .. tabs::
 
+   .. group-tab:: C#
+
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/0.7.0>`_
+
+      **csproj**:
+
+      .. code-block:: xml
+
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.0" />
+
+      **dotnet**:
+
+      .. code-block:: console
+
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.BasePackageId --version 0.7.0
+
+
    .. group-tab:: Java
 
       View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-base/0.7.0/>`_
@@ -109,6 +126,10 @@ Base
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.base.Base;
@@ -142,6 +163,10 @@ BaseProps (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 
       .. code-tab:: java
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -3,6 +3,23 @@
 
 .. tabs::
 
+   .. group-tab:: C#
+
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/0.7.0>`_
+
+      **csproj**:
+
+      .. code-block:: xml
+
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="0.7.0" />
+
+      **dotnet**:
+
+      .. code-block:: console
+
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.LibPackageId --version 0.7.0
+
+
    .. group-tab:: Java
 
       View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-lib/0.7.0/>`_
@@ -109,6 +126,10 @@ EnumFromScopedModule (enum)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule;
@@ -139,6 +160,10 @@ IFriendly (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
       .. code-tab:: java
 
@@ -175,6 +200,10 @@ MyFirstStruct (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
       .. code-tab:: java
 
@@ -225,6 +254,10 @@ Number
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.lib.Number;
@@ -271,6 +304,10 @@ Operation
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.lib.Operation;
@@ -308,6 +345,10 @@ StructWithOnlyOptionals (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
       .. code-tab:: java
 
@@ -354,6 +395,10 @@ Value
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
       .. code-tab:: java
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -19,6 +19,12 @@
 
          dotnet add package Amazon.JSII.Tests.CalculatorPackageId.LibPackageId --version 0.7.0
 
+      **packages.config**:
+
+      .. code-block:: xml
+
+         <package id="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" version="0.7.0" />
+
 
    .. group-tab:: Java
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -3,6 +3,23 @@ jsii-calc
 
 .. tabs::
 
+   .. group-tab:: C#
+
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId/0.7.0>`_
+
+      **csproj**:
+
+      .. code-block:: xml
+
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId" Version="0.7.0" />
+
+      **dotnet**:
+
+      .. code-block:: console
+
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId --version 0.7.0
+
+
    .. group-tab:: Java
 
       View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator/0.7.0/>`_
@@ -111,6 +128,10 @@ Add
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.Add;
@@ -158,6 +179,10 @@ AllTypes
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -288,6 +313,10 @@ AllTypesEnum (enum)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.AllTypesEnum;
@@ -317,6 +346,10 @@ AllowedMethodNames
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -381,6 +414,10 @@ AsyncVirtualMethods
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.AsyncVirtualMethods;
@@ -443,6 +480,10 @@ BinaryOperation
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.BinaryOperation;
@@ -500,6 +541,10 @@ Calculator
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -621,6 +666,10 @@ CalculatorProps (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.CalculatorProps;
@@ -664,6 +713,10 @@ Base
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base;
@@ -693,6 +746,10 @@ Derived
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived;
@@ -720,6 +777,10 @@ DerivedStruct (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -781,6 +842,10 @@ DoubleTrouble
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.DoubleTrouble;
@@ -821,6 +886,10 @@ GiveMeStructs
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -881,6 +950,10 @@ IFriendlier (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.IFriendlier;
@@ -927,6 +1000,10 @@ IFriendlyRandomGenerator (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator;
@@ -953,6 +1030,10 @@ IInterfaceWithProperties (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -989,6 +1070,10 @@ IInterfaceWithPropertiesExtension (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension;
@@ -1019,6 +1104,10 @@ IRandomNumberGenerator (interface)
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1057,6 +1146,10 @@ ImplictBaseOfBase (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.ImplictBaseOfBase;
@@ -1087,6 +1180,10 @@ JSObjectLiteralForInterface
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1122,6 +1219,10 @@ JSObjectLiteralToNative
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.JSObjectLiteralToNative;
@@ -1150,6 +1251,10 @@ JSObjectLiteralToNativeClass
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1184,6 +1289,10 @@ JavaReservedWords
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1422,6 +1531,10 @@ Multiply
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.Multiply;
@@ -1496,6 +1609,10 @@ Negate
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.Negate;
@@ -1567,6 +1684,10 @@ NodeStandardLibrary
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.NodeStandardLibrary;
@@ -1629,6 +1750,10 @@ NumberGenerator
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.NumberGenerator;
@@ -1674,6 +1799,10 @@ ObjectRefsInCollections
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1722,6 +1851,10 @@ OverrideReturnsObject
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.OverrideReturnsObject;
@@ -1753,6 +1886,10 @@ Polymorphism
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.Polymorphism;
@@ -1783,6 +1920,10 @@ Power
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1840,6 +1981,10 @@ ReferenceEnumFromScopedPackage
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.ReferenceEnumFromScopedPackage;
@@ -1883,6 +2028,10 @@ ReturnsNumber (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.ReturnsNumber;
@@ -1917,6 +2066,10 @@ RuntimeTypeChecking
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -1954,6 +2107,10 @@ Statics
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2043,6 +2200,10 @@ StringEnum (enum)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.StringEnum;
@@ -2072,6 +2233,10 @@ Sum
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2116,6 +2281,10 @@ SyncVirtualMethods
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2226,6 +2395,10 @@ Thrower
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.Thrower;
@@ -2253,6 +2426,10 @@ UnaryOperation
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2290,6 +2467,10 @@ UnionProperties (interface)
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.UnionProperties;
@@ -2325,6 +2506,10 @@ UseBundledDependency
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.UseBundledDependency;
@@ -2353,6 +2538,10 @@ UseCalcBase
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2385,6 +2574,10 @@ UsesInterfaceWithProperties
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2436,6 +2629,10 @@ VariadicMethod
 
    .. tabs::
 
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
       .. code-tab:: java
 
          import software.amazon.jsii.tests.calculator.VariadicMethod;
@@ -2470,6 +2667,10 @@ VirtualMethodPlayground
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2534,6 +2735,10 @@ CompositeOperation
    **Language-specific names:**
 
    .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
 
       .. code-tab:: java
 
@@ -2607,6 +2812,10 @@ CompositeOperation
       **Language-specific names:**
 
       .. tabs::
+
+         .. code-tab:: c#
+
+            using Amazon.JSII.Tests.CalculatorNamespace;
 
          .. code-tab:: java
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -19,6 +19,12 @@ jsii-calc
 
          dotnet add package Amazon.JSII.Tests.CalculatorPackageId --version 0.7.0
 
+      **packages.config**:
+
+      .. code-block:: xml
+
+         <package id="Amazon.JSII.Tests.CalculatorPackageId" version="0.7.0" />
+
 
    .. group-tab:: Java
 


### PR DESCRIPTION
This code generates the reference documentation for dotnet (C#). It includes how to add a reference to the package, and how to import the references into your code. Expected files for diff testing have been updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.