### PR TITLE
Bump version to v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Bug Fixes
+
+* Missing types in JSII assembly, invalid Java code, confusing docs ([#208](https://github.com/awslabs/jsii/issues/208)) ([b37101f](https://github.com/awslabs/jsii/commit/b37101f)), closes [#175](https://github.com/awslabs/jsii/issues/175)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
       "rejectCycles": true
     }
   },
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/packages/codemaker/CHANGELOG.md
+++ b/packages/codemaker/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/codemaker/package.json
+++ b/packages/codemaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemaker",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A tiny utility for generating source code",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/jsii-build-tools/CHANGELOG.md
+++ b/packages/jsii-build-tools/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-build-tools/package.json
+++ b/packages/jsii-build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-build-tools",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Internal repository-level tools",
   "private": true,
   "bin": {

--- a/packages/jsii-calc-base-of-base/CHANGELOG.md
+++ b/packages/jsii-calc-base-of-base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+
+
+**Note:** Version bump only for package @scope/jsii-calc-base-of-base
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-calc-base-of-base/package.json
+++ b/packages/jsii-calc-base-of-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/jsii-calc-base-of-base",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An example transitive dependency for jsii-calc.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -27,8 +27,8 @@
     "test": "diff-test test/assembly.jsii .jsii"
   },
   "devDependencies": {
-    "jsii": "^0.7.1",
-    "jsii-build-tools": "^0.7.1",
+    "jsii": "^0.7.2",
+    "jsii-build-tools": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/jsii-calc-base-of-base/test/assembly.jsii
@@ -66,6 +66,6 @@
       ]
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "leMwJ4WvcsSePtFmqx6m1bb5mGfJyIpbDVLjHvkQT5k="
+  "version": "0.7.2",
+  "fingerprint": "MS1VGBFflGlA8lyStmdFJpdXpEz6btEhRcrWZAKHuzw="
 }

--- a/packages/jsii-calc-base/CHANGELOG.md
+++ b/packages/jsii-calc-base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+
+
+**Note:** Version bump only for package @scope/jsii-calc-base
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-calc-base/package.json
+++ b/packages/jsii-calc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/jsii-calc-base",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An example direct dependency for jsii-calc.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -27,12 +27,12 @@
     "test": "diff-test test/assembly.jsii .jsii"
   },
   "devDependencies": {
-    "jsii": "^0.7.1",
-    "jsii-build-tools": "^0.7.1",
+    "jsii": "^0.7.2",
+    "jsii-build-tools": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "@scope/jsii-calc-base-of-base": "^0.7.1"
+    "@scope/jsii-calc-base-of-base": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-calc-base/test/assembly.jsii
+++ b/packages/jsii-calc-base/test/assembly.jsii
@@ -25,7 +25,7 @@
           "npm": "@scope/jsii-calc-base-of-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "An example direct dependency for jsii-calc.",
@@ -99,6 +99,6 @@
       ]
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "LbaOS7fzFOPGTmU2ekKSu8LIOpDpaBHFa6OHaVpkbRI="
+  "version": "0.7.2",
+  "fingerprint": "FhkkDhQVwuiyhsELz3/rmLWuhyMG95AJRCMRy0lipQ8="
 }

--- a/packages/jsii-calc-bundled/CHANGELOG.md
+++ b/packages/jsii-calc-bundled/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+
+
+**Note:** Version bump only for package jsii-calc-bundled
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-calc-bundled/package.json
+++ b/packages/jsii-calc-bundled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-calc-bundled",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "index.js",
   "private": true,
   "author": {

--- a/packages/jsii-calc-lib/CHANGELOG.md
+++ b/packages/jsii-calc-lib/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+
+
+**Note:** Version bump only for package @scope/jsii-calc-lib
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-calc-lib/package.json
+++ b/packages/jsii-calc-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/jsii-calc-lib",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A simple calcuator library built on JSII.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -27,12 +27,12 @@
     "test": "diff-test test/assembly.jsii .jsii"
   },
   "devDependencies": {
-    "jsii": "^0.7.1",
-    "jsii-build-tools": "^0.7.1",
+    "jsii": "^0.7.2",
+    "jsii-build-tools": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "@scope/jsii-calc-base": "^0.7.1"
+    "@scope/jsii-calc-base": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -27,7 +27,7 @@
               "npm": "@scope/jsii-calc-base-of-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -46,7 +46,7 @@
           "npm": "@scope/jsii-calc-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "A simple calcuator library built on JSII.",
@@ -316,6 +316,6 @@
       ]
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "3IeTfxNyPz+olL7Po4gmiOwSNz2i7sRxA7d9Nf0f4qE="
+  "version": "0.7.2",
+  "fingerprint": "Q2fGATlcEQJxv2uFHrGaqepPXtfnDJPrkZw8zLPM/MY="
 }

--- a/packages/jsii-calc/CHANGELOG.md
+++ b/packages/jsii-calc/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Bug Fixes
+
+* Missing types in JSII assembly, invalid Java code, confusing docs ([#208](https://github.com/awslabs/jsii/issues/208)) ([b37101f](https://github.com/awslabs/jsii/commit/b37101f)), closes [#175](https://github.com/awslabs/jsii/issues/175)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-calc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A simple calcuator built on JSII.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -31,14 +31,14 @@
     "jsii-calc-bundled"
   ],
   "dependencies": {
-    "@scope/jsii-calc-base": "^0.7.1",
-    "@scope/jsii-calc-lib": "^0.7.1",
-    "jsii-calc-bundled": "^0.7.1"
+    "@scope/jsii-calc-base": "^0.7.2",
+    "@scope/jsii-calc-lib": "^0.7.2",
+    "jsii-calc-bundled": "^0.7.2"
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii": "^0.7.1",
-    "jsii-build-tools": "^0.7.1",
+    "jsii": "^0.7.2",
+    "jsii-build-tools": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -8,7 +8,7 @@
     "url": "https://aws.amazon.com"
   },
   "bundled": {
-    "jsii-calc-bundled": "^0.7.1"
+    "jsii-calc-bundled": "^0.7.2"
   },
   "contributors": [
     {
@@ -53,7 +53,7 @@
               "npm": "@scope/jsii-calc-base-of-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -72,7 +72,7 @@
           "npm": "@scope/jsii-calc-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     },
     "@scope/jsii-calc-lib": {
       "dependencies": {
@@ -95,7 +95,7 @@
                   "npm": "@scope/jsii-calc-base-of-base"
                 }
               },
-              "version": "0.7.1"
+              "version": "0.7.2"
             }
           },
           "targets": {
@@ -114,7 +114,7 @@
               "npm": "@scope/jsii-calc-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -133,7 +133,7 @@
           "npm": "@scope/jsii-calc-lib"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "A simple calcuator built on JSII.",
@@ -2923,6 +2923,6 @@
       "namespace": "composition.CompositeOperation"
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "3uROoDToOcKIpYs9haAGnS37Iebz1/+ldcknrh37qDQ="
+  "version": "0.7.2",
+  "fingerprint": "nHPhW3Albvj9ofMYOPhVccNT7QB1Q0sOyrrlj2WhvS0="
 }

--- a/packages/jsii-dotnet-generator/CHANGELOG.md
+++ b/packages/jsii-dotnet-generator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+
+
+**Note:** Version bump only for package jsii-dotnet-generator
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-dotnet-generator/package.json
+++ b/packages/jsii-dotnet-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-dotnet-generator",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": ".NET code generator for jsii assemblies",
   "main": "index.js",
   "private": true,
@@ -11,10 +11,10 @@
     "package": "package-dotnet"
   },
   "dependencies": {
-    "jsii-dotnet-jsonmodel": "^0.7.1"
+    "jsii-dotnet-jsonmodel": "^0.7.2"
   },
   "devDependencies": {
-    "jsii-build-tools": "^0.7.1"
+    "jsii-build-tools": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-dotnet-jsonmodel/CHANGELOG.md
+++ b/packages/jsii-dotnet-jsonmodel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-dotnet-jsonmodel/package.json
+++ b/packages/jsii-dotnet-jsonmodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-dotnet-jsonmodel",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": ".NET json model for jsii spec and api.",
   "main": "lib/index.js",
   "private": true,
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-build-tools": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-dotnet-runtime-test/CHANGELOG.md
+++ b/packages/jsii-dotnet-runtime-test/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-dotnet-runtime-test/package.json
+++ b/packages/jsii-dotnet-runtime-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-dotnet-runtime-test",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Tests for the .NET client for jsii runtime",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -12,9 +12,9 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-calc": "^0.7.1",
-    "jsii-dotnet-runtime": "^0.7.1",
-    "jsii-pacmak": "^0.7.1",
+    "jsii-calc": "^0.7.2",
+    "jsii-dotnet-runtime": "^0.7.2",
+    "jsii-pacmak": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-dotnet-runtime/CHANGELOG.md
+++ b/packages/jsii-dotnet-runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-dotnet-runtime/package.json
+++ b/packages/jsii-dotnet-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-dotnet-runtime",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": ".NET client for jsii runtime",
   "main": "lib/index.js",
   "private": true,
@@ -13,12 +13,12 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-runtime": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-runtime": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "jsii-dotnet-jsonmodel": "^0.7.1"
+    "jsii-dotnet-jsonmodel": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-java-runtime-test/CHANGELOG.md
+++ b/packages/jsii-java-runtime-test/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-java-runtime-test/package.json
+++ b/packages/jsii-java-runtime-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-java-runtime-test",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Tests for the Java client for jsii runtime",
   "private": true,
   "main": "lib/index.js",
@@ -11,9 +11,9 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-calc": "^0.7.1",
-    "jsii-java-runtime": "^0.7.1",
-    "jsii-pacmak": "^0.7.1"
+    "jsii-calc": "^0.7.2",
+    "jsii-java-runtime": "^0.7.2",
+    "jsii-pacmak": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-java-runtime/CHANGELOG.md
+++ b/packages/jsii-java-runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-java-runtime/package.json
+++ b/packages/jsii-java-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-java-runtime",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Java client for jsii runtime",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -13,8 +13,8 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-runtime": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-runtime": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-kernel/CHANGELOG.md
+++ b/packages/jsii-kernel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-kernel/package.json
+++ b/packages/jsii-kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-kernel",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "kernel for jsii execution environment",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -12,21 +12,21 @@
     "package": "package-js"
   },
   "devDependencies": {
-    "@scope/jsii-calc-base": "^0.7.1",
-    "@scope/jsii-calc-lib": "^0.7.1",
+    "@scope/jsii-calc-base": "^0.7.2",
+    "@scope/jsii-calc-lib": "^0.7.2",
     "@types/fs-extra": "^4.0.8",
     "@types/node": "^9.6.18",
     "@types/nodeunit": "0.0.30",
     "@types/tar": "^4.0.0",
     "fs-extra": "^4.0.3",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-calc": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-calc": "^0.7.2",
     "nodeunit": "^0.11.3",
     "tslint": "*",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "jsii-spec": "^0.7.1",
+    "jsii-spec": "^0.7.2",
     "source-map": "^0.7.0",
     "tar": "^4.4.4"
   },

--- a/packages/jsii-pacmak/CHANGELOG.md
+++ b/packages/jsii-pacmak/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Bug Fixes
+
+* Missing types in JSII assembly, invalid Java code, confusing docs ([#208](https://github.com/awslabs/jsii/issues/208)) ([b37101f](https://github.com/awslabs/jsii/commit/b37101f)), closes [#175](https://github.com/awslabs/jsii/issues/175)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-pacmak",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A code generation framework for jsii backend languages",
   "bin": {
     "jsii-pacmak": "bin/jsii-pacmak"
@@ -21,27 +21,27 @@
   ],
   "dependencies": {
     "clone": "^2.1.1",
-    "codemaker": "^0.7.1",
+    "codemaker": "^0.7.2",
     "fs-extra": "^4.0.3",
-    "jsii-spec": "^0.7.1",
+    "jsii-spec": "^0.7.2",
     "spdx-license-list": "^4.1.0",
     "xmlbuilder": "^10.0.0",
     "yargs": "^12.0.0"
   },
   "devDependencies": {
-    "@scope/jsii-calc-lib": "^0.7.1",
+    "@scope/jsii-calc-lib": "^0.7.2",
     "@types/clone": "^0.1.30",
     "@types/fs-extra": "^4.0.8",
     "@types/node": "^9.6.18",
     "@types/nodeunit": "0.0.30",
     "@types/xmlbuilder": "^0.0.32",
     "@types/yargs": "^11.1.1",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-calc": "^0.7.1",
-    "jsii-dotnet-generator": "^0.7.1",
-    "jsii-dotnet-jsonmodel": "^0.7.1",
-    "jsii-dotnet-runtime": "^0.7.1",
-    "jsii-java-runtime": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-calc": "^0.7.2",
+    "jsii-dotnet-generator": "^0.7.2",
+    "jsii-dotnet-jsonmodel": "^0.7.2",
+    "jsii-dotnet-runtime": "^0.7.2",
+    "jsii-java-runtime": "^0.7.2",
     "nodeunit": "^0.11.3",
     "tslint": "*",
     "typescript": "^3.0.1"

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
@@ -25,7 +25,7 @@
           "npm": "@scope/jsii-calc-base-of-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "An example direct dependency for jsii-calc.",
@@ -99,6 +99,6 @@
       ]
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "LbaOS7fzFOPGTmU2ekKSu8LIOpDpaBHFa6OHaVpkbRI="
+  "version": "0.7.2",
+  "fingerprint": "FhkkDhQVwuiyhsELz3/rmLWuhyMG95AJRCMRy0lipQ8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>0.7.1</PackageVersion>
+    <PackageVersion>0.7.2</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId.BasePackageId</PackageId>
     <Description>An example direct dependency for jsii-calc.</Description>
     <ProjectUrl>https://github.com/awslabs/jsii.git</ProjectUrl>
@@ -11,10 +11,10 @@
     <Language>en-US</Language>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="scope-jsii-calc-base-0.7.1.tgz" />
+    <EmbeddedResource Include="scope-jsii-calc-base-0.7.2.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.1" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.2" />
   </ItemGroup>
 </Project>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/AssemblyInfo.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using Amazon.JSII.Runtime.Deputy;
 
-[assembly: JsiiAssembly("@scope/jsii-calc-base", "0.7.1", "scope-jsii-calc-base-0.7.1.tgz")]
+[assembly: JsiiAssembly("@scope/jsii-calc-base", "0.7.2", "scope-jsii-calc-base-0.7.2.tgz")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
@@ -27,7 +27,7 @@
   </scm>
   <artifactId>calculator-base</artifactId>
   <groupId>software.amazon.jsii.tests</groupId>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,12 +36,12 @@
     <dependency>
       <artifactId>calculator-base-of-base</artifactId>
       <groupId>software.amazon.jsii.tests</groupId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/$Module.java
@@ -7,7 +7,7 @@ import software.amazon.jsii.JsiiModule;
 
 public final class $Module extends JsiiModule {
     public $Module() {
-        super("@scope/jsii-calc-base", "0.7.1", $Module.class, "jsii-calc-base@0.7.1.jsii.tgz");
+        super("@scope/jsii-calc-base", "0.7.2", $Module.class, "jsii-calc-base@0.7.2.jsii.tgz");
     }
 
     @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -5,42 +5,42 @@
 
    .. group-tab:: C#
 
-      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/0.7.1>`_
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/0.7.2>`_
 
       **csproj**:
 
       .. code-block:: xml
 
-         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.1" />
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.2" />
 
       **dotnet**:
 
       .. code-block:: console
 
-         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.BasePackageId --version 0.7.1
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.BasePackageId --version 0.7.2
 
       **packages.config**:
 
       .. code-block:: xml
 
-         <package id="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" version="0.7.1" />
+         <package id="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" version="0.7.2" />
 
 
    .. group-tab:: Java
 
-      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-base/0.7.1/>`_
+      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-base/0.7.2/>`_
 
       **Apache Buildr**:
 
       .. code-block:: none
 
-         'software.amazon.jsii.tests:calculator-base:jar:0.7.1'
+         'software.amazon.jsii.tests:calculator-base:jar:0.7.2'
 
       **Apache Ivy**:
 
       .. code-block:: xml
 
-         <dependency groupId="software.amazon.jsii.tests" name="calculator-base" rev="0.7.1"/>
+         <dependency groupId="software.amazon.jsii.tests" name="calculator-base" rev="0.7.2"/>
 
       **Apache Maven**:
 
@@ -49,72 +49,72 @@
          <dependency>
            <groupId>software.amazon.jsii.tests</groupId>
            <artifactId>calculator-base</artifactId>
-           <version>0.7.1</version>
+           <version>0.7.2</version>
          </dependency>
 
       **Gradle / Grails**:
 
       .. code-block:: none
 
-         compile 'software.amazon.jsii.tests:calculator-base:0.7.1'
+         compile 'software.amazon.jsii.tests:calculator-base:0.7.2'
 
       **Groovy Grape**:
 
       .. code-block:: none
 
          @Grapes(
-         @Grab(group='software.amazon.jsii.tests', module='calculator-base', version='0.7.1')
+         @Grab(group='software.amazon.jsii.tests', module='calculator-base', version='0.7.2')
          )
 
 
    .. group-tab:: JavaScript
 
-      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-base/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-base/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i @scope/jsii-calc-base@0.7.1
+         $ npm i @scope/jsii-calc-base@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "@scope/jsii-calc-base": "^0.7.1"
+           "@scope/jsii-calc-base": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add @scope/jsii-calc-base@0.7.1
+         $ yarn add @scope/jsii-calc-base@0.7.2
 
 
    .. group-tab:: TypeScript
 
-      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-base/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-base/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i @scope/jsii-calc-base@0.7.1
+         $ npm i @scope/jsii-calc-base@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "@scope/jsii-calc-base": "^0.7.1"
+           "@scope/jsii-calc-base": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add @scope/jsii-calc-base@0.7.1
+         $ yarn add @scope/jsii-calc-base@0.7.2
 
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -27,7 +27,7 @@
               "npm": "@scope/jsii-calc-base-of-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -46,7 +46,7 @@
           "npm": "@scope/jsii-calc-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "A simple calcuator library built on JSII.",
@@ -316,6 +316,6 @@
       ]
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "3IeTfxNyPz+olL7Po4gmiOwSNz2i7sRxA7d9Nf0f4qE="
+  "version": "0.7.2",
+  "fingerprint": "Q2fGATlcEQJxv2uFHrGaqepPXtfnDJPrkZw8zLPM/MY="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>0.7.1</PackageVersion>
+    <PackageVersion>0.7.2</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId.LibPackageId</PackageId>
     <Description>A simple calcuator library built on JSII.</Description>
     <ProjectUrl>https://github.com/awslabs/jsii.git</ProjectUrl>
@@ -11,11 +11,11 @@
     <Language>en-US</Language>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="scope-jsii-calc-lib-0.7.1.tgz" />
+    <EmbeddedResource Include="scope-jsii-calc-lib-0.7.2.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.1" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.2" />
   </ItemGroup>
 </Project>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/AssemblyInfo.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using Amazon.JSII.Runtime.Deputy;
 
-[assembly: JsiiAssembly("@scope/jsii-calc-lib", "0.7.1", "scope-jsii-calc-lib-0.7.1.tgz")]
+[assembly: JsiiAssembly("@scope/jsii-calc-lib", "0.7.2", "scope-jsii-calc-lib-0.7.2.tgz")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
@@ -27,7 +27,7 @@
   </scm>
   <artifactId>calculator-lib</artifactId>
   <groupId>software.amazon.jsii.tests</groupId>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,12 +36,12 @@
     <dependency>
       <artifactId>calculator-base</artifactId>
       <groupId>software.amazon.jsii.tests</groupId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
@@ -7,7 +7,7 @@ import software.amazon.jsii.JsiiModule;
 
 public final class $Module extends JsiiModule {
     public $Module() {
-        super("@scope/jsii-calc-lib", "0.7.1", $Module.class, "jsii-calc-lib@0.7.1.jsii.tgz");
+        super("@scope/jsii-calc-lib", "0.7.2", $Module.class, "jsii-calc-lib@0.7.2.jsii.tgz");
     }
 
     @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -5,42 +5,42 @@
 
    .. group-tab:: C#
 
-      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/0.7.1>`_
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/0.7.2>`_
 
       **csproj**:
 
       .. code-block:: xml
 
-         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="0.7.1" />
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="0.7.2" />
 
       **dotnet**:
 
       .. code-block:: console
 
-         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.LibPackageId --version 0.7.1
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId.LibPackageId --version 0.7.2
 
       **packages.config**:
 
       .. code-block:: xml
 
-         <package id="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" version="0.7.1" />
+         <package id="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" version="0.7.2" />
 
 
    .. group-tab:: Java
 
-      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-lib/0.7.1/>`_
+      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator-lib/0.7.2/>`_
 
       **Apache Buildr**:
 
       .. code-block:: none
 
-         'software.amazon.jsii.tests:calculator-lib:jar:0.7.1'
+         'software.amazon.jsii.tests:calculator-lib:jar:0.7.2'
 
       **Apache Ivy**:
 
       .. code-block:: xml
 
-         <dependency groupId="software.amazon.jsii.tests" name="calculator-lib" rev="0.7.1"/>
+         <dependency groupId="software.amazon.jsii.tests" name="calculator-lib" rev="0.7.2"/>
 
       **Apache Maven**:
 
@@ -49,72 +49,72 @@
          <dependency>
            <groupId>software.amazon.jsii.tests</groupId>
            <artifactId>calculator-lib</artifactId>
-           <version>0.7.1</version>
+           <version>0.7.2</version>
          </dependency>
 
       **Gradle / Grails**:
 
       .. code-block:: none
 
-         compile 'software.amazon.jsii.tests:calculator-lib:0.7.1'
+         compile 'software.amazon.jsii.tests:calculator-lib:0.7.2'
 
       **Groovy Grape**:
 
       .. code-block:: none
 
          @Grapes(
-         @Grab(group='software.amazon.jsii.tests', module='calculator-lib', version='0.7.1')
+         @Grab(group='software.amazon.jsii.tests', module='calculator-lib', version='0.7.2')
          )
 
 
    .. group-tab:: JavaScript
 
-      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-lib/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-lib/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i @scope/jsii-calc-lib@0.7.1
+         $ npm i @scope/jsii-calc-lib@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "@scope/jsii-calc-lib": "^0.7.1"
+           "@scope/jsii-calc-lib": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add @scope/jsii-calc-lib@0.7.1
+         $ yarn add @scope/jsii-calc-lib@0.7.2
 
 
    .. group-tab:: TypeScript
 
-      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-lib/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/@scope/jsii-calc-lib/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i @scope/jsii-calc-lib@0.7.1
+         $ npm i @scope/jsii-calc-lib@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "@scope/jsii-calc-lib": "^0.7.1"
+           "@scope/jsii-calc-lib": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add @scope/jsii-calc-lib@0.7.1
+         $ yarn add @scope/jsii-calc-lib@0.7.2
 
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -8,7 +8,7 @@
     "url": "https://aws.amazon.com"
   },
   "bundled": {
-    "jsii-calc-bundled": "^0.7.1"
+    "jsii-calc-bundled": "^0.7.2"
   },
   "contributors": [
     {
@@ -53,7 +53,7 @@
               "npm": "@scope/jsii-calc-base-of-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -72,7 +72,7 @@
           "npm": "@scope/jsii-calc-base"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     },
     "@scope/jsii-calc-lib": {
       "dependencies": {
@@ -95,7 +95,7 @@
                   "npm": "@scope/jsii-calc-base-of-base"
                 }
               },
-              "version": "0.7.1"
+              "version": "0.7.2"
             }
           },
           "targets": {
@@ -114,7 +114,7 @@
               "npm": "@scope/jsii-calc-base"
             }
           },
-          "version": "0.7.1"
+          "version": "0.7.2"
         }
       },
       "targets": {
@@ -133,7 +133,7 @@
           "npm": "@scope/jsii-calc-lib"
         }
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   },
   "description": "A simple calcuator built on JSII.",
@@ -2923,6 +2923,6 @@
       "namespace": "composition.CompositeOperation"
     }
   },
-  "version": "0.7.1",
-  "fingerprint": "3uROoDToOcKIpYs9haAGnS37Iebz1/+ldcknrh37qDQ="
+  "version": "0.7.2",
+  "fingerprint": "nHPhW3Albvj9ofMYOPhVccNT7QB1Q0sOyrrlj2WhvS0="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>0.7.1</PackageVersion>
+    <PackageVersion>0.7.2</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId</PackageId>
     <Description>A simple calcuator built on JSII.</Description>
     <ProjectUrl>https://github.com/awslabs/jsii.git</ProjectUrl>
@@ -11,14 +11,14 @@
     <Language>en-US</Language>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="jsii-calc-0.7.1.tgz" />
+    <EmbeddedResource Include="jsii-calc-0.7.2.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.1" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.1" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="0.7.2" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="0.7.2" />
   </ItemGroup>
 </Project>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/AssemblyInfo.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using Amazon.JSII.Runtime.Deputy;
 
-[assembly: JsiiAssembly("jsii-calc", "0.7.1", "jsii-calc-0.7.1.tgz")]
+[assembly: JsiiAssembly("jsii-calc", "0.7.2", "jsii-calc-0.7.2.tgz")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
@@ -48,7 +48,7 @@
   </scm>
   <artifactId>calculator</artifactId>
   <groupId>software.amazon.jsii.tests</groupId>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -57,22 +57,22 @@
     <dependency>
       <artifactId>calculator-base</artifactId>
       <groupId>software.amazon.jsii.tests</groupId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <artifactId>calculator-lib</artifactId>
       <groupId>software.amazon.jsii.tests</groupId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <artifactId>calculator-base-of-base</artifactId>
       <groupId>software.amazon.jsii.tests</groupId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -7,7 +7,7 @@ import software.amazon.jsii.JsiiModule;
 
 public final class $Module extends JsiiModule {
     public $Module() {
-        super("jsii-calc", "0.7.1", $Module.class, "jsii-calc@0.7.1.jsii.tgz");
+        super("jsii-calc", "0.7.2", $Module.class, "jsii-calc@0.7.2.jsii.tgz");
     }
 
     @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -5,42 +5,42 @@ jsii-calc
 
    .. group-tab:: C#
 
-      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId/0.7.1>`_
+      View in `Nuget <https://www.nuget.org/packages/Amazon.JSII.Tests.CalculatorPackageId/0.7.2>`_
 
       **csproj**:
 
       .. code-block:: xml
 
-         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId" Version="0.7.1" />
+         <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId" Version="0.7.2" />
 
       **dotnet**:
 
       .. code-block:: console
 
-         dotnet add package Amazon.JSII.Tests.CalculatorPackageId --version 0.7.1
+         dotnet add package Amazon.JSII.Tests.CalculatorPackageId --version 0.7.2
 
       **packages.config**:
 
       .. code-block:: xml
 
-         <package id="Amazon.JSII.Tests.CalculatorPackageId" version="0.7.1" />
+         <package id="Amazon.JSII.Tests.CalculatorPackageId" version="0.7.2" />
 
 
    .. group-tab:: Java
 
-      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator/0.7.1/>`_
+      View in `Maven Central <https://repo1.maven.org/maven2/software/amazon/jsii/tests/calculator/0.7.2/>`_
 
       **Apache Buildr**:
 
       .. code-block:: none
 
-         'software.amazon.jsii.tests:calculator:jar:0.7.1'
+         'software.amazon.jsii.tests:calculator:jar:0.7.2'
 
       **Apache Ivy**:
 
       .. code-block:: xml
 
-         <dependency groupId="software.amazon.jsii.tests" name="calculator" rev="0.7.1"/>
+         <dependency groupId="software.amazon.jsii.tests" name="calculator" rev="0.7.2"/>
 
       **Apache Maven**:
 
@@ -49,72 +49,72 @@ jsii-calc
          <dependency>
            <groupId>software.amazon.jsii.tests</groupId>
            <artifactId>calculator</artifactId>
-           <version>0.7.1</version>
+           <version>0.7.2</version>
          </dependency>
 
       **Gradle / Grails**:
 
       .. code-block:: none
 
-         compile 'software.amazon.jsii.tests:calculator:0.7.1'
+         compile 'software.amazon.jsii.tests:calculator:0.7.2'
 
       **Groovy Grape**:
 
       .. code-block:: none
 
          @Grapes(
-         @Grab(group='software.amazon.jsii.tests', module='calculator', version='0.7.1')
+         @Grab(group='software.amazon.jsii.tests', module='calculator', version='0.7.2')
          )
 
 
    .. group-tab:: JavaScript
 
-      View in `NPM <https://www.npmjs.com/package/jsii-calc/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/jsii-calc/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i jsii-calc@0.7.1
+         $ npm i jsii-calc@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "jsii-calc": "^0.7.1"
+           "jsii-calc": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add jsii-calc@0.7.1
+         $ yarn add jsii-calc@0.7.2
 
 
    .. group-tab:: TypeScript
 
-      View in `NPM <https://www.npmjs.com/package/jsii-calc/v/0.7.1>`_
+      View in `NPM <https://www.npmjs.com/package/jsii-calc/v/0.7.2>`_
 
       **npm**:
 
       .. code-block:: console
 
-         $ npm i jsii-calc@0.7.1
+         $ npm i jsii-calc@0.7.2
 
       **package.json**:
 
       .. code-block:: js
 
          {
-           "jsii-calc": "^0.7.1"
+           "jsii-calc": "^0.7.2"
          }
 
       **yarn**:
 
       .. code-block:: console
 
-         $ yarn add jsii-calc@0.7.1
+         $ yarn add jsii-calc@0.7.2
 
 
 

--- a/packages/jsii-ruby-runtime/CHANGELOG.md
+++ b/packages/jsii-ruby-runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-ruby-runtime/package.json
+++ b/packages/jsii-ruby-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-ruby-runtime",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Ruby client for jsii runtime",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.18",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-calc": "^0.7.1",
-    "jsii-pacmak": "^0.7.1",
-    "jsii-runtime": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-calc": "^0.7.2",
+    "jsii-pacmak": "^0.7.2",
+    "jsii-runtime": "^0.7.2",
     "typescript": "^3.0.1"
   },
   "author": {

--- a/packages/jsii-runtime/CHANGELOG.md
+++ b/packages/jsii-runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-runtime/package.json
+++ b/packages/jsii-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-runtime",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "jsii runtime kernel process",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -14,11 +14,11 @@
     "package": "package-js"
   },
   "devDependencies": {
-    "@scope/jsii-calc-base": "^0.7.1",
-    "@scope/jsii-calc-lib": "^0.7.1",
+    "@scope/jsii-calc-base": "^0.7.2",
+    "@scope/jsii-calc-lib": "^0.7.2",
     "@types/node": "^9.6.18",
-    "jsii-build-tools": "^0.7.1",
-    "jsii-calc": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
+    "jsii-calc": "^0.7.2",
     "nodeunit": "^0.11.3",
     "typescript": "^3.0.1",
     "wasm-loader": "^1.3.0",
@@ -26,8 +26,8 @@
     "webpack-command": "^0.2.1"
   },
   "dependencies": {
-    "jsii-kernel": "^0.7.1",
-    "jsii-spec": "^0.7.1"
+    "jsii-kernel": "^0.7.2",
+    "jsii-spec": "^0.7.2"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-spec/CHANGELOG.md
+++ b/packages/jsii-spec/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii-spec/package.json
+++ b/packages/jsii-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-spec",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Specification for jsii assemblies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -14,7 +14,7 @@
     "@types/jsonschema": "^1.1.1",
     "@types/node": "^9.6.18",
     "@types/nodeunit": "^0.0.30",
-    "jsii-build-tools": "^0.7.1",
+    "jsii-build-tools": "^0.7.2",
     "nodeunit": "^0.11.3",
     "typescript": "^3.0.1",
     "typescript-json-schema": "^0.27.0"

--- a/packages/jsii/CHANGELOG.md
+++ b/packages/jsii/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.2"></a>
+## [0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)
+
+
+### Bug Fixes
+
+* Missing types in JSII assembly, invalid Java code, confusing docs ([#208](https://github.com/awslabs/jsii/issues/208)) ([b37101f](https://github.com/awslabs/jsii/commit/b37101f)), closes [#175](https://github.com/awslabs/jsii/issues/175)
+
+
+### Features
+
+* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))
+
+
+
+
 <a name="0.7.1"></a>
 ## [0.7.1](https://github.com/awslabs/jsii/compare/v0.7.0...v0.7.1) (2018-08-28)
 

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsii",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "TypeScript compiler for jsii",
     "license": "Apache-2.0",
     "author": {
@@ -28,7 +28,7 @@
         "@types/semver": "^5.5.0",
         "@types/yargs": "^11.1.1",
         "clone": "^2.1.2",
-        "jsii-build-tools": "^0.7.1",
+        "jsii-build-tools": "^0.7.2",
         "nodeunit": "^0.11.3",
         "nyc": "^12.0.2"
     },
@@ -37,7 +37,7 @@
         "colors": "^1.3.1",
         "deep-equal": "^1.0.1",
         "fs-extra": "^7.0.0",
-        "jsii-spec": "^0.7.1",
+        "jsii-spec": "^0.7.2",
         "log4js": "^3.0.4",
         "semver": "^5.5.0",
         "sort-json": "^2.0.0",
@@ -46,6 +46,9 @@
         "yargs": "^12.0.1"
     },
     "nyc": {
-        "reporter": ["lcov", "text"]
+        "reporter": [
+            "lcov",
+            "text"
+        ]
     }
 }


### PR DESCRIPTION
[0.7.2](https://github.com/awslabs/jsii/compare/v0.7.1...v0.7.2) (2018-09-06)

Bug Fixes

* Missing types in JSII assembly, invalid Java code, confusing docs ([#208](https://github.com/awslabs/jsii/issues/208)) ([b37101f](https://github.com/awslabs/jsii/commit/b37101f)), closes [#175](https://github.com/awslabs/jsii/issues/175)

Features

* **jsii:** Re-implemented jsii to support --watch and produce better error reporting ([#188](https://github.com/awslabs/jsii/issues/188)) ([76472be](https://github.com/awslabs/jsii/commit/76472be))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
