### PR TITLE
fix(jsii): add readme and restore missing files in jsii tarball

### DIFF
--- a/packages/jsii/.npmignore
+++ b/packages/jsii/.npmignore
@@ -1,3 +1,7 @@
 *
-!*.js
-!*.d.ts
+
+!**/*.js
+!**/*.d.ts
+!bin/jsii
+
+coverage

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -12,7 +12,7 @@
         "jsii": "bin/jsii"
     },
     "scripts": {
-        "build": "bash ./generate.sh && tsc",
+        "build": "cp ../../README.md . && bash ./generate.sh && tsc",
         "watch": "bash ./generate.sh && tsc -w",
         "test": "nyc nodeunit test/test.*.js",
         "package": "package-js"


### PR DESCRIPTION
1. npmignore excluded all files
2. README was not copied from root

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
