### PR TITLE
Force generated assemblies to reference jsii-only dependencies.

### DIFF
--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyGenerator.cs
@@ -204,7 +204,7 @@ namespace Amazon.JSII.Generator
                     ).NormalizeWhitespace(elasticTrivia: true)
                 );
 
-                string directory = Path.Combine(packageOutputRoot, Path.Combine(anchorNamespace.Split('.')));
+                string directory = GetNamespaceDirectory(packageOutputRoot, @anchorNamespace);
                 SaveSyntaxTree(directory, "Anchor.cs", syntaxTree);
 
                 ClassDeclarationSyntax GenerateDependencyAnchor() {
@@ -275,14 +275,8 @@ namespace Amazon.JSII.Generator
 
             void SaveType(Type type)
             {
-                string packageName = Path.GetFileName(packageOutputRoot);
                 string @namespace = symbols.GetNamespace(type);
-                if (@namespace.StartsWith(packageName))
-                {
-                    @namespace = @namespace.Substring(packageName.Length).TrimStart('.');
-                }
-
-                string directory = Path.Combine(packageOutputRoot, Path.Combine(@namespace.Split('.')));
+                string directory = GetNamespaceDirectory(packageOutputRoot, @namespace);
 
                 switch (type.Kind)
                 {
@@ -326,6 +320,21 @@ namespace Amazon.JSII.Generator
                     syntaxTree.ToString()
                 );
             }
+        }
+
+        string GetNamespaceDirectory(string packageOutputRoot, string @namespace)
+        {
+            string packageName = Path.GetFileName(packageOutputRoot);
+
+            // packageOutputRoot is typically a directory like My.Root.Namespace/
+            // We don't want to create redundant directories, i.e.
+            // My.Root.Namespace/My/Root/Namespace/Sub/Namespace. We just
+            // want My.Root.Namespace/Sub/Namespace.
+            if (@namespace.StartsWith(packageName)) {
+                @namespace = @namespace.Substring(packageName.Length).TrimStart('.');
+            }
+
+            return Path.Combine(packageOutputRoot, Path.Combine(@namespace.Split('.')));
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/Internal/DependencyResolution/Anchor.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/Internal/DependencyResolution/Anchor.cs
@@ -1,0 +1,10 @@
+namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Internal.DependencyResolution
+{
+    public class Anchor
+    {
+        public Anchor()
+        {
+            new Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Internal.DependencyResolution.Anchor();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Internal/DependencyResolution/Anchor.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Internal/DependencyResolution/Anchor.cs
@@ -1,0 +1,10 @@
+namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Internal.DependencyResolution
+{
+    public class Anchor
+    {
+        public Anchor()
+        {
+            new Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Internal.DependencyResolution.Anchor();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Internal/DependencyResolution/Anchor.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Internal/DependencyResolution/Anchor.cs
@@ -1,0 +1,11 @@
+namespace Amazon.JSII.Tests.CalculatorNamespace.Internal.DependencyResolution
+{
+    public class Anchor
+    {
+        public Anchor()
+        {
+            new Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Internal.DependencyResolution.Anchor();
+            new Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Internal.DependencyResolution.Anchor();
+        }
+    }
+}

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -4630,7 +4630,8 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4648,11 +4649,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4665,15 +4668,18 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4776,7 +4782,8 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4786,6 +4793,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4798,17 +4806,20 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4825,6 +4836,7 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4897,7 +4909,8 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4907,6 +4920,7 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4982,7 +4996,8 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -5012,6 +5027,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -5029,6 +5045,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -5067,11 +5084,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						}
 					}
 				},


### PR DESCRIPTION
When a NuGet package is restored, all of its listed dependencies are restored (whether or not they are actually used). But when a .NET assembly is built, if it does not reference any .NET types from the dependency, the compiled .NET assembly will not reference the dependency .NET assembly.

At runtime, `jsii-dotnet-runtime` loads JSII dependencies by looking through the .NET assembly's references. If the dependency does not appear in references, it won't be found.

This breaks the following scenario:

* A JSII assembly `my-package` depends on `my-dependency`.
* In the TypeScript source, `my-package` requires symbols from `my-dependency`. Therefore the NuGet package `MyPackage` lists `MyDependency` as a dependency.
* However, the generated .NET source for `MyPackage` does not reference any symbols from `MyDependency`.

At runtime, the first time a type from `MyPackage` is used, `jsii-dotnet-runtime` will search for `MyPackage`'s dependencies, and ask `jsii-runtime` to load each of them (i.e. `my-dependency`) before attempting to load `my-package`. But due to the missing assembly reference, it won't be able to find `my-dependency`. So when the javascript code for `my-package` attempts to `require('my-dependency')`, it will fail.

To work around this issue, for each package, we generate a type `MyNamespace.Internal.DependencyResolution.Anchor` that references the `Anchor` from each of its dependencies. This way *all* listed dependencies will show up in the .NET assembly's references, avoiding this issue.