### PR TITLE
Fix #221: improve diagnostics when dereference fails

### DIFF
--- a/packages/jsii/test/negatives/neg.deref-error.ts
+++ b/packages/jsii/test/negatives/neg.deref-error.ts
@@ -1,5 +1,4 @@
 ///!MATCH_ERROR: Unable to resolve referenced type 'Base'. Missing export?
-///!MATCH_ERROR: Base type of jsii.Derived is not a class or cannot be dereferenced (Base)
 
 class Base {
 

--- a/packages/jsii/test/negatives/neg.deref-error.ts
+++ b/packages/jsii/test/negatives/neg.deref-error.ts
@@ -1,0 +1,10 @@
+///!MATCH_ERROR: Unable to resolve referenced type 'Base'. Missing export?
+///!MATCH_ERROR: Base type of jsii.Derived is not a class or cannot be dereferenced (Base)
+
+class Base {
+
+}
+
+export class Derived extends Base {
+
+}


### PR DESCRIPTION
In some cases, when a type could not be referenced, the diagnostic 
message doesn't indicate that (the undefined return value will still 
cause an error, but we also want to know that we couldn't deref the 
type)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
