### PR TITLE
Java: support abstract return types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -26,7 +26,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argparse": {
@@ -35,7 +35,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -44,7 +44,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -77,9 +77,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -94,11 +94,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -122,7 +122,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -143,7 +143,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -171,9 +171,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"clean-yaml-object": {
@@ -215,7 +215,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -242,12 +242,12 @@
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"dev": true,
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -256,8 +256,8 @@
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -266,7 +266,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -297,8 +297,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -361,8 +361,8 @@
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -377,9 +377,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -406,7 +406,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -415,12 +415,12 @@
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -447,8 +447,8 @@
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-ansi": {
@@ -457,7 +457,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -472,9 +472,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -489,8 +489,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -535,8 +535,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -588,45 +588,45 @@
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"chalk": "2.4.1",
-				"cmd-shim": "2.0.2",
-				"columnify": "1.5.4",
-				"command-join": "2.0.0",
-				"conventional-changelog-cli": "1.3.22",
-				"conventional-recommended-bump": "1.2.1",
-				"dedent": "0.7.0",
-				"execa": "0.8.0",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"get-port": "3.2.0",
-				"glob": "7.1.3",
-				"glob-parent": "3.1.0",
-				"globby": "6.1.0",
-				"graceful-fs": "4.1.11",
-				"hosted-git-info": "2.7.1",
-				"inquirer": "3.3.0",
-				"is-ci": "1.2.0",
-				"load-json-file": "4.0.0",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"npmlog": "4.1.2",
-				"p-finally": "1.0.0",
-				"package-json": "4.0.1",
-				"path-exists": "3.0.0",
-				"read-cmd-shim": "1.0.1",
-				"read-pkg": "3.0.0",
-				"rimraf": "2.6.2",
-				"safe-buffer": "5.1.2",
-				"semver": "5.5.1",
-				"signal-exit": "3.0.2",
-				"slash": "1.0.0",
-				"strong-log-transformer": "1.0.6",
-				"temp-write": "3.4.0",
-				"write-file-atomic": "2.3.0",
-				"write-json-file": "2.3.0",
-				"write-pkg": "3.2.0",
-				"yargs": "8.0.2"
+				"async": "^1.5.0",
+				"chalk": "^2.1.0",
+				"cmd-shim": "^2.0.2",
+				"columnify": "^1.5.4",
+				"command-join": "^2.0.0",
+				"conventional-changelog-cli": "^1.3.13",
+				"conventional-recommended-bump": "^1.2.1",
+				"dedent": "^0.7.0",
+				"execa": "^0.8.0",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.1",
+				"get-port": "^3.2.0",
+				"glob": "^7.1.2",
+				"glob-parent": "^3.1.0",
+				"globby": "^6.1.0",
+				"graceful-fs": "^4.1.11",
+				"hosted-git-info": "^2.5.0",
+				"inquirer": "^3.2.2",
+				"is-ci": "^1.0.10",
+				"load-json-file": "^4.0.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"package-json": "^4.0.1",
+				"path-exists": "^3.0.0",
+				"read-cmd-shim": "^1.0.1",
+				"read-pkg": "^3.0.0",
+				"rimraf": "^2.6.1",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.4.1",
+				"signal-exit": "^3.0.2",
+				"slash": "^1.0.0",
+				"strong-log-transformer": "^1.0.6",
+				"temp-write": "^3.3.0",
+				"write-file-atomic": "^2.3.0",
+				"write-json-file": "^2.2.0",
+				"write-pkg": "^3.1.0",
+				"yargs": "^8.0.2"
 			},
 			"dependencies": {
 				"JSONStream": {
@@ -635,8 +635,8 @@
 					"integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
 					"dev": true,
 					"requires": {
-						"jsonparse": "1.3.1",
-						"through": "2.3.8"
+						"jsonparse": "^1.2.0",
+						"through": ">=2.2.7 <3"
 					}
 				},
 				"add-stream": {
@@ -651,9 +651,9 @@
 					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -686,8 +686,8 @@
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"array-find-index": {
@@ -708,7 +708,7 @@
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"dev": true,
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -748,9 +748,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -774,8 +774,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chardet": {
@@ -796,7 +796,7 @@
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "2.0.0"
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"cli-width": {
@@ -812,8 +812,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -838,8 +838,8 @@
 					"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"mkdirp": "0.5.1"
+						"graceful-fs": "^4.1.2",
+						"mkdirp": "~0.5.0"
 					}
 				},
 				"code-point-at": {
@@ -854,8 +854,8 @@
 					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 					"dev": true,
 					"requires": {
-						"strip-ansi": "3.0.1",
-						"wcwidth": "1.0.1"
+						"strip-ansi": "^3.0.0",
+						"wcwidth": "^1.0.0"
 					}
 				},
 				"command-join": {
@@ -870,8 +870,8 @@
 					"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 					"dev": true,
 					"requires": {
-						"array-ify": "1.0.0",
-						"dot-prop": "3.0.0"
+						"array-ify": "^1.0.0",
+						"dot-prop": "^3.0.0"
 					}
 				},
 				"concat-stream": {
@@ -880,10 +880,10 @@
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "1.1.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6",
-						"typedarray": "0.0.6"
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					}
 				},
 				"console-control-strings": {
@@ -898,17 +898,17 @@
 					"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
 					"dev": true,
 					"requires": {
-						"conventional-changelog-angular": "1.6.6",
-						"conventional-changelog-atom": "0.2.8",
-						"conventional-changelog-codemirror": "0.3.8",
-						"conventional-changelog-core": "2.0.11",
-						"conventional-changelog-ember": "0.3.12",
-						"conventional-changelog-eslint": "1.0.9",
-						"conventional-changelog-express": "0.3.6",
-						"conventional-changelog-jquery": "0.1.0",
-						"conventional-changelog-jscs": "0.1.0",
-						"conventional-changelog-jshint": "0.3.8",
-						"conventional-changelog-preset-loader": "1.1.8"
+						"conventional-changelog-angular": "^1.6.6",
+						"conventional-changelog-atom": "^0.2.8",
+						"conventional-changelog-codemirror": "^0.3.8",
+						"conventional-changelog-core": "^2.0.11",
+						"conventional-changelog-ember": "^0.3.12",
+						"conventional-changelog-eslint": "^1.0.9",
+						"conventional-changelog-express": "^0.3.6",
+						"conventional-changelog-jquery": "^0.1.0",
+						"conventional-changelog-jscs": "^0.1.0",
+						"conventional-changelog-jshint": "^0.3.8",
+						"conventional-changelog-preset-loader": "^1.1.8"
 					}
 				},
 				"conventional-changelog-angular": {
@@ -917,8 +917,8 @@
 					"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"q": "1.5.1"
+						"compare-func": "^1.3.1",
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-atom": {
@@ -927,7 +927,7 @@
 					"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-cli": {
@@ -936,11 +936,11 @@
 					"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
 					"dev": true,
 					"requires": {
-						"add-stream": "1.0.0",
-						"conventional-changelog": "1.1.24",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"tempfile": "1.1.1"
+						"add-stream": "^1.0.0",
+						"conventional-changelog": "^1.1.24",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"tempfile": "^1.1.1"
 					}
 				},
 				"conventional-changelog-codemirror": {
@@ -949,7 +949,7 @@
 					"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-core": {
@@ -958,19 +958,19 @@
 					"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
 					"dev": true,
 					"requires": {
-						"conventional-changelog-writer": "3.0.9",
-						"conventional-commits-parser": "2.1.7",
-						"dateformat": "3.0.3",
-						"get-pkg-repo": "1.4.0",
-						"git-raw-commits": "1.3.6",
-						"git-remote-origin-url": "2.0.0",
-						"git-semver-tags": "1.3.6",
-						"lodash": "4.17.10",
-						"normalize-package-data": "2.4.0",
-						"q": "1.5.1",
-						"read-pkg": "1.1.0",
-						"read-pkg-up": "1.0.1",
-						"through2": "2.0.3"
+						"conventional-changelog-writer": "^3.0.9",
+						"conventional-commits-parser": "^2.1.7",
+						"dateformat": "^3.0.0",
+						"get-pkg-repo": "^1.0.0",
+						"git-raw-commits": "^1.3.6",
+						"git-remote-origin-url": "^2.0.0",
+						"git-semver-tags": "^1.3.6",
+						"lodash": "^4.2.1",
+						"normalize-package-data": "^2.3.5",
+						"q": "^1.5.1",
+						"read-pkg": "^1.1.0",
+						"read-pkg-up": "^1.0.1",
+						"through2": "^2.0.0"
 					},
 					"dependencies": {
 						"load-json-file": {
@@ -979,11 +979,11 @@
 							"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"parse-json": {
@@ -992,7 +992,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-type": {
@@ -1001,9 +1001,9 @@
 							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -1018,9 +1018,9 @@
 							"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"strip-bom": {
@@ -1029,7 +1029,7 @@
 							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						}
 					}
@@ -1040,7 +1040,7 @@
 					"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-eslint": {
@@ -1049,7 +1049,7 @@
 					"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-express": {
@@ -1058,7 +1058,7 @@
 					"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-jquery": {
@@ -1067,7 +1067,7 @@
 					"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.4.1"
 					}
 				},
 				"conventional-changelog-jscs": {
@@ -1076,7 +1076,7 @@
 					"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.4.1"
 					}
 				},
 				"conventional-changelog-jshint": {
@@ -1085,8 +1085,8 @@
 					"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"q": "1.5.1"
+						"compare-func": "^1.3.1",
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-preset-loader": {
@@ -1101,16 +1101,16 @@
 					"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"conventional-commits-filter": "1.1.6",
-						"dateformat": "3.0.3",
-						"handlebars": "4.0.11",
-						"json-stringify-safe": "5.0.1",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"semver": "5.5.1",
-						"split": "1.0.1",
-						"through2": "2.0.3"
+						"compare-func": "^1.3.1",
+						"conventional-commits-filter": "^1.1.6",
+						"dateformat": "^3.0.0",
+						"handlebars": "^4.0.2",
+						"json-stringify-safe": "^5.0.1",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"semver": "^5.5.0",
+						"split": "^1.0.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"conventional-commits-filter": {
@@ -1119,8 +1119,8 @@
 					"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 					"dev": true,
 					"requires": {
-						"is-subset": "0.1.1",
-						"modify-values": "1.0.1"
+						"is-subset": "^0.1.1",
+						"modify-values": "^1.0.0"
 					}
 				},
 				"conventional-commits-parser": {
@@ -1129,13 +1129,13 @@
 					"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 					"dev": true,
 					"requires": {
-						"JSONStream": "1.3.4",
-						"is-text-path": "1.0.1",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"split2": "2.2.0",
-						"through2": "2.0.3",
-						"trim-off-newlines": "1.0.1"
+						"JSONStream": "^1.0.4",
+						"is-text-path": "^1.0.0",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0",
+						"trim-off-newlines": "^1.0.0"
 					}
 				},
 				"conventional-recommended-bump": {
@@ -1144,13 +1144,13 @@
 					"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
 					"dev": true,
 					"requires": {
-						"concat-stream": "1.6.2",
-						"conventional-commits-filter": "1.1.6",
-						"conventional-commits-parser": "2.1.7",
-						"git-raw-commits": "1.3.6",
-						"git-semver-tags": "1.3.6",
-						"meow": "3.7.0",
-						"object-assign": "4.1.1"
+						"concat-stream": "^1.4.10",
+						"conventional-commits-filter": "^1.1.1",
+						"conventional-commits-parser": "^2.1.1",
+						"git-raw-commits": "^1.3.0",
+						"git-semver-tags": "^1.3.0",
+						"meow": "^3.3.0",
+						"object-assign": "^4.0.1"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -1165,8 +1165,8 @@
 							"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 							"dev": true,
 							"requires": {
-								"camelcase": "2.1.1",
-								"map-obj": "1.0.1"
+								"camelcase": "^2.0.0",
+								"map-obj": "^1.0.0"
 							}
 						},
 						"indent-string": {
@@ -1175,7 +1175,7 @@
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"map-obj": {
@@ -1190,16 +1190,16 @@
 							"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 							"dev": true,
 							"requires": {
-								"camelcase-keys": "2.1.0",
-								"decamelize": "1.2.0",
-								"loud-rejection": "1.6.0",
-								"map-obj": "1.0.1",
-								"minimist": "1.2.0",
-								"normalize-package-data": "2.4.0",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"redent": "1.0.0",
-								"trim-newlines": "1.0.0"
+								"camelcase-keys": "^2.0.0",
+								"decamelize": "^1.1.2",
+								"loud-rejection": "^1.0.0",
+								"map-obj": "^1.0.1",
+								"minimist": "^1.1.3",
+								"normalize-package-data": "^2.3.4",
+								"object-assign": "^4.0.1",
+								"read-pkg-up": "^1.0.1",
+								"redent": "^1.0.0",
+								"trim-newlines": "^1.0.0"
 							}
 						},
 						"minimist": {
@@ -1214,8 +1214,8 @@
 							"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 							"dev": true,
 							"requires": {
-								"indent-string": "2.1.0",
-								"strip-indent": "1.0.1"
+								"indent-string": "^2.1.0",
+								"strip-indent": "^1.0.1"
 							}
 						},
 						"strip-indent": {
@@ -1224,7 +1224,7 @@
 							"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 							"dev": true,
 							"requires": {
-								"get-stdin": "4.0.1"
+								"get-stdin": "^4.0.1"
 							}
 						},
 						"trim-newlines": {
@@ -1241,7 +1241,7 @@
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"dev": true,
 					"requires": {
-						"capture-stack-trace": "1.0.0"
+						"capture-stack-trace": "^1.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -1250,9 +1250,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"currently-unhandled": {
@@ -1261,7 +1261,7 @@
 					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 					"dev": true,
 					"requires": {
-						"array-find-index": "1.0.2"
+						"array-find-index": "^1.0.1"
 					}
 				},
 				"dargs": {
@@ -1270,7 +1270,7 @@
 					"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"dateformat": {
@@ -1291,8 +1291,8 @@
 					"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 					"dev": true,
 					"requires": {
-						"decamelize": "1.2.0",
-						"map-obj": "1.0.1"
+						"decamelize": "^1.1.0",
+						"map-obj": "^1.0.0"
 					},
 					"dependencies": {
 						"map-obj": {
@@ -1321,7 +1321,7 @@
 					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"dev": true,
 					"requires": {
-						"clone": "1.0.4"
+						"clone": "^1.0.2"
 					}
 				},
 				"delegates": {
@@ -1342,7 +1342,7 @@
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 					"dev": true,
 					"requires": {
-						"is-obj": "1.0.1"
+						"is-obj": "^1.0.0"
 					}
 				},
 				"duplexer": {
@@ -1363,7 +1363,7 @@
 					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"execa": {
@@ -1372,13 +1372,13 @@
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"external-editor": {
@@ -1387,9 +1387,9 @@
 					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 					"dev": true,
 					"requires": {
-						"chardet": "0.4.2",
-						"iconv-lite": "0.4.24",
-						"tmp": "0.0.33"
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
 					}
 				},
 				"figures": {
@@ -1398,7 +1398,7 @@
 					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5"
+						"escape-string-regexp": "^1.0.5"
 					}
 				},
 				"find-up": {
@@ -1407,7 +1407,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"fs-extra": {
@@ -1416,9 +1416,9 @@
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.2"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"gauge": {
@@ -1427,14 +1427,14 @@
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.3"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -1443,7 +1443,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -1452,9 +1452,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -1471,11 +1471,11 @@
 					"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"meow": "3.7.0",
-						"normalize-package-data": "2.4.0",
-						"parse-github-repo-url": "1.4.1",
-						"through2": "2.0.3"
+						"hosted-git-info": "^2.1.4",
+						"meow": "^3.3.0",
+						"normalize-package-data": "^2.3.0",
+						"parse-github-repo-url": "^1.3.0",
+						"through2": "^2.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -1490,8 +1490,8 @@
 							"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 							"dev": true,
 							"requires": {
-								"camelcase": "2.1.1",
-								"map-obj": "1.0.1"
+								"camelcase": "^2.0.0",
+								"map-obj": "^1.0.0"
 							}
 						},
 						"indent-string": {
@@ -1500,7 +1500,7 @@
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"map-obj": {
@@ -1515,16 +1515,16 @@
 							"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 							"dev": true,
 							"requires": {
-								"camelcase-keys": "2.1.0",
-								"decamelize": "1.2.0",
-								"loud-rejection": "1.6.0",
-								"map-obj": "1.0.1",
-								"minimist": "1.2.0",
-								"normalize-package-data": "2.4.0",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"redent": "1.0.0",
-								"trim-newlines": "1.0.0"
+								"camelcase-keys": "^2.0.0",
+								"decamelize": "^1.1.2",
+								"loud-rejection": "^1.0.0",
+								"map-obj": "^1.0.1",
+								"minimist": "^1.1.3",
+								"normalize-package-data": "^2.3.4",
+								"object-assign": "^4.0.1",
+								"read-pkg-up": "^1.0.1",
+								"redent": "^1.0.0",
+								"trim-newlines": "^1.0.0"
 							}
 						},
 						"minimist": {
@@ -1539,8 +1539,8 @@
 							"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 							"dev": true,
 							"requires": {
-								"indent-string": "2.1.0",
-								"strip-indent": "1.0.1"
+								"indent-string": "^2.1.0",
+								"strip-indent": "^1.0.1"
 							}
 						},
 						"strip-indent": {
@@ -1549,7 +1549,7 @@
 							"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 							"dev": true,
 							"requires": {
-								"get-stdin": "4.0.1"
+								"get-stdin": "^4.0.1"
 							}
 						},
 						"trim-newlines": {
@@ -1584,11 +1584,11 @@
 					"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 					"dev": true,
 					"requires": {
-						"dargs": "4.1.0",
-						"lodash.template": "4.4.0",
-						"meow": "4.0.1",
-						"split2": "2.2.0",
-						"through2": "2.0.3"
+						"dargs": "^4.0.1",
+						"lodash.template": "^4.0.2",
+						"meow": "^4.0.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"git-remote-origin-url": {
@@ -1597,8 +1597,8 @@
 					"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 					"dev": true,
 					"requires": {
-						"gitconfiglocal": "1.0.0",
-						"pify": "2.3.0"
+						"gitconfiglocal": "^1.0.0",
+						"pify": "^2.3.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -1615,8 +1615,8 @@
 					"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 					"dev": true,
 					"requires": {
-						"meow": "4.0.1",
-						"semver": "5.5.1"
+						"meow": "^4.0.0",
+						"semver": "^5.5.0"
 					}
 				},
 				"gitconfiglocal": {
@@ -1625,7 +1625,7 @@
 					"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 					"dev": true,
 					"requires": {
-						"ini": "1.3.5"
+						"ini": "^1.3.2"
 					}
 				},
 				"glob-parent": {
@@ -1634,8 +1634,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					}
 				},
 				"globby": {
@@ -1644,11 +1644,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.3",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -1665,17 +1665,17 @@
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
-						"create-error-class": "3.0.2",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"is-redirect": "1.0.0",
-						"is-retry-allowed": "1.1.0",
-						"is-stream": "1.1.0",
-						"lowercase-keys": "1.0.1",
-						"safe-buffer": "5.1.2",
-						"timed-out": "4.0.1",
-						"unzip-response": "2.0.1",
-						"url-parse-lax": "1.0.0"
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
 					}
 				},
 				"handlebars": {
@@ -1684,10 +1684,10 @@
 					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					}
 				},
 				"has-unicode": {
@@ -1708,7 +1708,7 @@
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"indent-string": {
@@ -1729,20 +1729,20 @@
 					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.2.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.10",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rx-lite": "4.0.8",
-						"rx-lite-aggregates": "4.0.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -1751,7 +1751,7 @@
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -1780,7 +1780,7 @@
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-ci": {
@@ -1789,7 +1789,7 @@
 					"integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
 					"dev": true,
 					"requires": {
-						"ci-info": "1.4.0"
+						"ci-info": "^1.3.0"
 					}
 				},
 				"is-extglob": {
@@ -1804,7 +1804,7 @@
 					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1819,7 +1819,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.0"
 					}
 				},
 				"is-obj": {
@@ -1870,7 +1870,7 @@
 					"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 					"dev": true,
 					"requires": {
-						"text-extensions": "1.7.0"
+						"text-extensions": "^1.0.0"
 					}
 				},
 				"is-utf8": {
@@ -1891,7 +1891,7 @@
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"jsonparse": {
@@ -1906,7 +1906,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1922,7 +1922,7 @@
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -1931,10 +1931,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -1943,8 +1943,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
@@ -1965,8 +1965,8 @@
 					"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0",
-						"lodash.templatesettings": "4.1.0"
+						"lodash._reinterpolate": "~3.0.0",
+						"lodash.templatesettings": "^4.0.0"
 					}
 				},
 				"lodash.templatesettings": {
@@ -1975,7 +1975,7 @@
 					"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0"
+						"lodash._reinterpolate": "~3.0.0"
 					}
 				},
 				"longest": {
@@ -1990,8 +1990,8 @@
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 					"dev": true,
 					"requires": {
-						"currently-unhandled": "0.4.1",
-						"signal-exit": "3.0.2"
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"lowercase-keys": {
@@ -2006,7 +2006,7 @@
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -2021,7 +2021,7 @@
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"meow": {
@@ -2030,15 +2030,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2053,8 +2053,8 @@
 							"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 							"dev": true,
 							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "3.0.0"
+								"find-up": "^2.0.0",
+								"read-pkg": "^3.0.0"
 							}
 						}
 					}
@@ -2077,8 +2077,8 @@
 					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"is-plain-obj": "1.1.0"
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
 					}
 				},
 				"modify-values": {
@@ -2105,10 +2105,10 @@
 					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.1",
-						"validate-npm-package-license": "3.0.4"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -2117,7 +2117,7 @@
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"npmlog": {
@@ -2126,10 +2126,10 @@
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"requires": {
-						"are-we-there-yet": "1.1.5",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2150,7 +2150,7 @@
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"optimist": {
@@ -2159,8 +2159,8 @@
 					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.10",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-locale": {
@@ -2169,9 +2169,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					},
 					"dependencies": {
 						"execa": {
@@ -2180,13 +2180,13 @@
 							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 							"dev": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							}
 						}
 					}
@@ -2209,7 +2209,7 @@
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -2218,7 +2218,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "1.3.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2233,10 +2233,10 @@
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"dev": true,
 					"requires": {
-						"got": "6.7.1",
-						"registry-auth-token": "3.3.2",
-						"registry-url": "3.1.0",
-						"semver": "5.5.1"
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
 					}
 				},
 				"parse-github-repo-url": {
@@ -2251,8 +2251,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-dirname": {
@@ -2279,7 +2279,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -2300,7 +2300,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"prepend-http": {
@@ -2327,10 +2327,10 @@
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"requires": {
-						"deep-extend": "0.6.0",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2347,7 +2347,7 @@
 					"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.2"
 					}
 				},
 				"read-pkg": {
@@ -2356,9 +2356,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2367,8 +2367,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2377,8 +2377,8 @@
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"load-json-file": {
@@ -2387,11 +2387,11 @@
 							"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"parse-json": {
@@ -2400,7 +2400,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-exists": {
@@ -2409,7 +2409,7 @@
 							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 							"dev": true,
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-type": {
@@ -2418,9 +2418,9 @@
 							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -2435,9 +2435,9 @@
 							"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"strip-bom": {
@@ -2446,7 +2446,7 @@
 							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						}
 					}
@@ -2457,8 +2457,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"registry-auth-token": {
@@ -2467,8 +2467,8 @@
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"dev": true,
 					"requires": {
-						"rc": "1.2.8",
-						"safe-buffer": "5.1.2"
+						"rc": "^1.1.6",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"registry-url": {
@@ -2477,7 +2477,7 @@
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"dev": true,
 					"requires": {
-						"rc": "1.2.8"
+						"rc": "^1.0.1"
 					}
 				},
 				"repeat-string": {
@@ -2492,7 +2492,7 @@
 					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 					"dev": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2513,8 +2513,8 @@
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"dev": true,
 					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"right-align": {
@@ -2524,7 +2524,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"run-async": {
@@ -2533,7 +2533,7 @@
 					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 					"dev": true,
 					"requires": {
-						"is-promise": "2.1.0"
+						"is-promise": "^2.1.0"
 					}
 				},
 				"rx-lite": {
@@ -2548,7 +2548,7 @@
 					"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 					"dev": true,
 					"requires": {
-						"rx-lite": "4.0.8"
+						"rx-lite": "*"
 					}
 				},
 				"set-blocking": {
@@ -2563,7 +2563,7 @@
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2584,7 +2584,7 @@
 					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 					"dev": true,
 					"requires": {
-						"is-plain-obj": "1.1.0"
+						"is-plain-obj": "^1.0.0"
 					}
 				},
 				"source-map": {
@@ -2593,7 +2593,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				},
 				"spdx-correct": {
@@ -2602,8 +2602,8 @@
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2618,8 +2618,8 @@
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2634,7 +2634,7 @@
 					"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 					"dev": true,
 					"requires": {
-						"through": "2.3.8"
+						"through": "2"
 					}
 				},
 				"split2": {
@@ -2643,7 +2643,7 @@
 					"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 					"dev": true,
 					"requires": {
-						"through2": "2.0.3"
+						"through2": "^2.0.2"
 					}
 				},
 				"string-width": {
@@ -2652,8 +2652,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -2662,7 +2662,7 @@
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2697,11 +2697,11 @@
 					"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
 					"dev": true,
 					"requires": {
-						"byline": "5.0.0",
-						"duplexer": "0.1.1",
-						"minimist": "0.1.0",
-						"moment": "2.22.2",
-						"through": "2.3.8"
+						"byline": "^5.0.0",
+						"duplexer": "^0.1.1",
+						"minimist": "^0.1.0",
+						"moment": "^2.6.0",
+						"through": "^2.3.4"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2724,12 +2724,12 @@
 					"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"is-stream": "1.1.0",
-						"make-dir": "1.3.0",
-						"pify": "3.0.0",
-						"temp-dir": "1.0.0",
-						"uuid": "3.3.2"
+						"graceful-fs": "^4.1.2",
+						"is-stream": "^1.1.0",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"temp-dir": "^1.0.0",
+						"uuid": "^3.0.1"
 					},
 					"dependencies": {
 						"uuid": {
@@ -2746,8 +2746,8 @@
 					"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2",
-						"uuid": "2.0.3"
+						"os-tmpdir": "^1.0.0",
+						"uuid": "^2.0.1"
 					}
 				},
 				"text-extensions": {
@@ -2768,8 +2768,8 @@
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"dev": true,
 					"requires": {
-						"readable-stream": "2.3.6",
-						"xtend": "4.0.1"
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
 					}
 				},
 				"timed-out": {
@@ -2784,7 +2784,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				},
 				"trim-newlines": {
@@ -2812,9 +2812,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2831,9 +2831,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2864,7 +2864,7 @@
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "1.0.4"
+						"prepend-http": "^1.0.1"
 					}
 				},
 				"uuid": {
@@ -2879,8 +2879,8 @@
 					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"wcwidth": {
@@ -2889,7 +2889,7 @@
 					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"dev": true,
 					"requires": {
-						"defaults": "1.0.3"
+						"defaults": "^1.0.3"
 					}
 				},
 				"which-module": {
@@ -2904,7 +2904,7 @@
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"window-size": {
@@ -2926,8 +2926,8 @@
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -2936,7 +2936,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -2945,9 +2945,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2958,12 +2958,12 @@
 					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 					"dev": true,
 					"requires": {
-						"detect-indent": "5.0.0",
-						"graceful-fs": "4.1.11",
-						"make-dir": "1.3.0",
-						"pify": "3.0.0",
-						"sort-keys": "2.0.0",
-						"write-file-atomic": "2.3.0"
+						"detect-indent": "^5.0.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"sort-keys": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"write-pkg": {
@@ -2972,8 +2972,8 @@
 					"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 					"dev": true,
 					"requires": {
-						"sort-keys": "2.0.0",
-						"write-json-file": "2.3.0"
+						"sort-keys": "^2.0.0",
+						"write-json-file": "^2.2.0"
 					}
 				},
 				"xtend": {
@@ -2994,19 +2994,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3021,9 +3021,9 @@
 							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wrap-ansi": "^2.0.0"
 							},
 							"dependencies": {
 								"string-width": {
@@ -3032,9 +3032,9 @@
 									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 									"dev": true,
 									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
 									}
 								}
 							}
@@ -3045,7 +3045,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"load-json-file": {
@@ -3054,10 +3054,10 @@
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"strip-bom": "3.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"strip-bom": "^3.0.0"
 							}
 						},
 						"parse-json": {
@@ -3066,7 +3066,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-type": {
@@ -3075,7 +3075,7 @@
 							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 							"dev": true,
 							"requires": {
-								"pify": "2.3.0"
+								"pify": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -3090,9 +3090,9 @@
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "2.0.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "2.0.0"
+								"load-json-file": "^2.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^2.0.0"
 							}
 						},
 						"read-pkg-up": {
@@ -3101,8 +3101,8 @@
 							"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 							"dev": true,
 							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "2.0.0"
+								"find-up": "^2.0.0",
+								"read-pkg": "^2.0.0"
 							}
 						}
 					}
@@ -3113,7 +3113,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3138,8 +3138,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -3154,7 +3154,7 @@
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -3163,7 +3163,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -3178,8 +3178,8 @@
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3219,8 +3219,8 @@
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"dev": true,
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -3229,31 +3229,31 @@
 			"integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
 			"dev": true,
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "2.0.0",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"find-cache-dir": "2.0.0",
-				"find-up": "3.0.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "2.0.1",
-				"istanbul-lib-hook": "2.0.1",
-				"istanbul-lib-instrument": "2.3.2",
-				"istanbul-lib-report": "2.0.1",
-				"istanbul-lib-source-maps": "2.0.1",
-				"istanbul-reports": "2.0.0",
-				"make-dir": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"resolve-from": "4.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "5.0.0",
-				"uuid": "3.3.2",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^2.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.2",
+				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-hook": "^2.0.1",
+				"istanbul-lib-instrument": "^2.3.2",
+				"istanbul-lib-report": "^2.0.1",
+				"istanbul-lib-source-maps": "^2.0.1",
+				"istanbul-reports": "^2.0.0",
+				"make-dir": "^1.3.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.0.0",
+				"uuid": "^3.3.2",
 				"yargs": "11.1.0",
-				"yargs-parser": "9.0.2"
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -3272,10 +3272,10 @@
 					"dev": true,
 					"requires": {
 						"@babel/types": "7.0.0-beta.51",
-						"jsesc": "2.5.1",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"@babel/helper-function-name": {
@@ -3313,9 +3313,9 @@
 					"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"@babel/parser": {
@@ -3333,7 +3333,7 @@
 						"@babel/code-frame": "7.0.0-beta.51",
 						"@babel/parser": "7.0.0-beta.51",
 						"@babel/types": "7.0.0-beta.51",
-						"lodash": "4.17.10"
+						"lodash": "^4.17.5"
 					}
 				},
 				"@babel/traverse": {
@@ -3348,10 +3348,10 @@
 						"@babel/helper-split-export-declaration": "7.0.0-beta.51",
 						"@babel/parser": "7.0.0-beta.51",
 						"@babel/types": "7.0.0-beta.51",
-						"debug": "3.1.0",
-						"globals": "11.7.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
 					}
 				},
 				"@babel/types": {
@@ -3360,9 +3360,9 @@
 					"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "2.0.0"
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"align-text": {
@@ -3370,9 +3370,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -3390,7 +3390,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "2.0.0"
+						"default-require-extensions": "^2.0.0"
 					}
 				},
 				"archy": {
@@ -3418,7 +3418,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3432,10 +3432,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"make-dir": "1.3.0",
-						"md5-hex": "2.0.0",
-						"package-hash": "2.0.0",
-						"write-file-atomic": "2.3.0"
+						"make-dir": "^1.0.0",
+						"md5-hex": "^2.0.0",
+						"package-hash": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"camelcase": {
@@ -3450,8 +3450,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"cliui": {
@@ -3460,8 +3460,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -3498,8 +3498,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -3525,7 +3525,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "3.0.0"
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"error-ex": {
@@ -3533,7 +3533,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"es6-error": {
@@ -3546,13 +3546,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -3560,9 +3560,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.1"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -3572,9 +3572,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"make-dir": "1.3.0",
-						"pkg-dir": "3.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
 					}
 				},
 				"find-up": {
@@ -3582,7 +3582,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"foreground-child": {
@@ -3590,8 +3590,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fs.realpath": {
@@ -3614,12 +3614,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -3638,10 +3638,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3649,7 +3649,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -3674,8 +3674,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -3689,7 +3689,7 @@
 					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 					"dev": true,
 					"requires": {
-						"loose-envify": "1.4.0"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -3712,7 +3712,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -3740,7 +3740,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "1.0.0"
+						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-instrument": {
@@ -3754,8 +3754,8 @@
 						"@babel/template": "7.0.0-beta.51",
 						"@babel/traverse": "7.0.0-beta.51",
 						"@babel/types": "7.0.0-beta.51",
-						"istanbul-lib-coverage": "2.0.1",
-						"semver": "5.5.0"
+						"istanbul-lib-coverage": "^2.0.1",
+						"semver": "^5.5.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -3763,9 +3763,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "2.0.1",
-						"make-dir": "1.3.0",
-						"supports-color": "5.4.0"
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
@@ -3773,11 +3773,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "2.0.1",
-						"make-dir": "1.3.0",
-						"rimraf": "2.6.2",
-						"source-map": "0.6.1"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3792,7 +3792,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.11"
 					}
 				},
 				"jsesc": {
@@ -3811,7 +3811,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -3825,7 +3825,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -3833,10 +3833,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -3844,8 +3844,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "3.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
@@ -3870,7 +3870,7 @@
 					"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 					"dev": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0 || ^4.0.0"
 					}
 				},
 				"lru-cache": {
@@ -3878,8 +3878,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -3887,7 +3887,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"md5-hex": {
@@ -3895,7 +3895,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -3908,7 +3908,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
@@ -3916,7 +3916,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3936,7 +3936,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3969,10 +3969,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -3980,7 +3980,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3993,7 +3993,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
@@ -4001,8 +4001,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.10",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -4015,9 +4015,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -4030,7 +4030,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
@@ -4038,7 +4038,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
@@ -4051,10 +4051,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"lodash.flattendeep": "4.4.0",
-						"md5-hex": "2.0.0",
-						"release-zalgo": "1.0.0"
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
 					}
 				},
 				"parse-json": {
@@ -4062,8 +4062,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-exists": {
@@ -4086,7 +4086,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -4099,7 +4099,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "3.0.0"
+						"find-up": "^3.0.0"
 					}
 				},
 				"pseudomap": {
@@ -4112,9 +4112,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4122,8 +4122,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "3.0.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"release-zalgo": {
@@ -4131,7 +4131,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"es6-error": "4.1.1"
+						"es6-error": "^4.0.1"
 					}
 				},
 				"repeat-string": {
@@ -4160,7 +4160,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
@@ -4168,7 +4168,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"semver": {
@@ -4186,7 +4186,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -4209,12 +4209,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.1"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
@@ -4222,8 +4222,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -4236,8 +4236,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -4250,8 +4250,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4259,7 +4259,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4277,7 +4277,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"test-exclude": {
@@ -4285,10 +4285,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"minimatch": "3.0.4",
-						"read-pkg-up": "4.0.0",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"to-fast-properties": {
@@ -4309,9 +4309,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -4320,9 +4320,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -4344,8 +4344,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
@@ -4353,7 +4353,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -4377,8 +4377,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -4391,7 +4391,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -4399,9 +4399,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -4409,7 +4409,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -4424,9 +4424,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"signal-exit": "3.0.2"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"y18n": {
@@ -4444,18 +4444,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"cliui": {
@@ -4463,9 +4463,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"find-up": {
@@ -4473,7 +4473,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"locate-path": "2.0.0"
+								"locate-path": "^2.0.0"
 							}
 						},
 						"locate-path": {
@@ -4481,8 +4481,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-locate": "2.0.0",
-								"path-exists": "3.0.0"
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
 							}
 						},
 						"p-limit": {
@@ -4490,7 +4490,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-try": "1.0.0"
+								"p-try": "^1.0.0"
 							}
 						},
 						"p-locate": {
@@ -4498,7 +4498,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-limit": "1.3.0"
+								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
@@ -4513,7 +4513,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -4537,7 +4537,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -4564,7 +4564,7 @@
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"dev": true,
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -4621,13 +4621,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -4636,26 +4636,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"resolve": {
@@ -4664,7 +4664,7 @@
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -4673,7 +4673,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -4712,8 +4712,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"sprintf-js": {
@@ -4728,15 +4728,15 @@
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -4751,7 +4751,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -4760,7 +4760,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -4769,7 +4769,7 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"tap": {
@@ -4778,35 +4778,35 @@
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"dev": true,
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			},
 			"dependencies": {
 				"nyc": {
@@ -4815,33 +4815,33 @@
 					"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 					"dev": true,
 					"requires": {
-						"archy": "1.0.0",
-						"arrify": "1.0.1",
-						"caching-transform": "1.0.1",
-						"convert-source-map": "1.5.1",
-						"debug-log": "1.0.1",
-						"default-require-extensions": "1.0.0",
-						"find-cache-dir": "0.1.1",
-						"find-up": "2.1.0",
-						"foreground-child": "1.5.6",
-						"glob": "7.1.2",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-hook": "1.1.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-report": "1.1.3",
-						"istanbul-lib-source-maps": "1.2.3",
-						"istanbul-reports": "1.4.0",
-						"md5-hex": "1.3.0",
-						"merge-source-map": "1.1.0",
-						"micromatch": "3.1.10",
-						"mkdirp": "0.5.1",
-						"resolve-from": "2.0.0",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"spawn-wrap": "1.4.2",
-						"test-exclude": "4.2.1",
+						"archy": "^1.0.0",
+						"arrify": "^1.0.1",
+						"caching-transform": "^1.0.0",
+						"convert-source-map": "^1.5.1",
+						"debug-log": "^1.0.1",
+						"default-require-extensions": "^1.0.0",
+						"find-cache-dir": "^0.1.1",
+						"find-up": "^2.1.0",
+						"foreground-child": "^1.5.3",
+						"glob": "^7.0.6",
+						"istanbul-lib-coverage": "^1.1.2",
+						"istanbul-lib-hook": "^1.1.0",
+						"istanbul-lib-instrument": "^1.10.0",
+						"istanbul-lib-report": "^1.1.3",
+						"istanbul-lib-source-maps": "^1.2.3",
+						"istanbul-reports": "^1.4.0",
+						"md5-hex": "^1.2.0",
+						"merge-source-map": "^1.1.0",
+						"micromatch": "^3.1.10",
+						"mkdirp": "^0.5.0",
+						"resolve-from": "^2.0.0",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.1",
+						"spawn-wrap": "^1.4.2",
+						"test-exclude": "^4.2.0",
 						"yargs": "11.1.0",
-						"yargs-parser": "8.1.0"
+						"yargs-parser": "^8.0.0"
 					},
 					"dependencies": {
 						"align-text": {
@@ -4849,9 +4849,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2",
-								"longest": "1.0.1",
-								"repeat-string": "1.6.1"
+								"kind-of": "^3.0.2",
+								"longest": "^1.0.1",
+								"repeat-string": "^1.5.2"
 							}
 						},
 						"amdefine": {
@@ -4874,7 +4874,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"default-require-extensions": "1.0.0"
+								"default-require-extensions": "^1.0.0"
 							}
 						},
 						"archy": {
@@ -4927,9 +4927,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"chalk": "1.1.3",
-								"esutils": "2.0.2",
-								"js-tokens": "3.0.2"
+								"chalk": "^1.1.3",
+								"esutils": "^2.0.2",
+								"js-tokens": "^3.0.2"
 							}
 						},
 						"babel-generator": {
@@ -4937,14 +4937,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"detect-indent": "4.0.0",
-								"jsesc": "1.3.0",
-								"lodash": "4.17.10",
-								"source-map": "0.5.7",
-								"trim-right": "1.0.1"
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"detect-indent": "^4.0.0",
+								"jsesc": "^1.3.0",
+								"lodash": "^4.17.4",
+								"source-map": "^0.5.7",
+								"trim-right": "^1.0.1"
 							}
 						},
 						"babel-messages": {
@@ -4952,7 +4952,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0"
+								"babel-runtime": "^6.22.0"
 							}
 						},
 						"babel-runtime": {
@@ -4960,8 +4960,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-js": "2.5.6",
-								"regenerator-runtime": "0.11.1"
+								"core-js": "^2.4.0",
+								"regenerator-runtime": "^0.11.0"
 							}
 						},
 						"babel-template": {
@@ -4969,11 +4969,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"lodash": "4.17.10"
+								"babel-runtime": "^6.26.0",
+								"babel-traverse": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-traverse": {
@@ -4981,15 +4981,15 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-code-frame": "6.26.0",
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"debug": "2.6.9",
-								"globals": "9.18.0",
-								"invariant": "2.2.4",
-								"lodash": "4.17.10"
+								"babel-code-frame": "^6.26.0",
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"debug": "^2.6.8",
+								"globals": "^9.18.0",
+								"invariant": "^2.2.2",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-types": {
@@ -4997,10 +4997,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"esutils": "2.0.2",
-								"lodash": "4.17.10",
-								"to-fast-properties": "1.0.3"
+								"babel-runtime": "^6.26.0",
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.4",
+								"to-fast-properties": "^1.0.3"
 							}
 						},
 						"babylon": {
@@ -5018,13 +5018,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cache-base": "1.0.1",
-								"class-utils": "0.3.6",
-								"component-emitter": "1.2.1",
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"mixin-deep": "1.3.1",
-								"pascalcase": "0.1.1"
+								"cache-base": "^1.0.1",
+								"class-utils": "^0.3.5",
+								"component-emitter": "^1.2.1",
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.1",
+								"mixin-deep": "^1.2.0",
+								"pascalcase": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5032,7 +5032,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -5040,7 +5040,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5048,7 +5048,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5056,9 +5056,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -5078,7 +5078,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"balanced-match": "1.0.0",
+								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
 							}
 						},
@@ -5087,16 +5087,16 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -5104,7 +5104,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5119,15 +5119,15 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"collection-visit": "1.0.0",
-								"component-emitter": "1.2.1",
-								"get-value": "2.0.6",
-								"has-value": "1.0.0",
-								"isobject": "3.0.1",
-								"set-value": "2.0.0",
-								"to-object-path": "0.3.0",
-								"union-value": "1.0.0",
-								"unset-value": "1.0.0"
+								"collection-visit": "^1.0.0",
+								"component-emitter": "^1.2.1",
+								"get-value": "^2.0.6",
+								"has-value": "^1.0.0",
+								"isobject": "^3.0.1",
+								"set-value": "^2.0.0",
+								"to-object-path": "^0.3.0",
+								"union-value": "^1.0.0",
+								"unset-value": "^1.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5142,9 +5142,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"md5-hex": "1.3.0",
-								"mkdirp": "0.5.1",
-								"write-file-atomic": "1.3.4"
+								"md5-hex": "^1.2.0",
+								"mkdirp": "^0.5.1",
+								"write-file-atomic": "^1.1.4"
 							}
 						},
 						"camelcase": {
@@ -5159,8 +5159,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4",
-								"lazy-cache": "1.0.4"
+								"align-text": "^0.1.3",
+								"lazy-cache": "^1.0.3"
 							}
 						},
 						"chalk": {
@@ -5168,11 +5168,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-styles": "2.2.1",
-								"escape-string-regexp": "1.0.5",
-								"has-ansi": "2.0.0",
-								"strip-ansi": "3.0.1",
-								"supports-color": "2.0.0"
+								"ansi-styles": "^2.2.1",
+								"escape-string-regexp": "^1.0.2",
+								"has-ansi": "^2.0.0",
+								"strip-ansi": "^3.0.0",
+								"supports-color": "^2.0.0"
 							}
 						},
 						"class-utils": {
@@ -5180,10 +5180,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"define-property": "0.2.5",
-								"isobject": "3.0.1",
-								"static-extend": "0.1.2"
+								"arr-union": "^3.1.0",
+								"define-property": "^0.2.5",
+								"isobject": "^3.0.0",
+								"static-extend": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5191,7 +5191,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"isobject": {
@@ -5207,8 +5207,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"center-align": "0.1.3",
-								"right-align": "0.1.3",
+								"center-align": "^0.1.1",
+								"right-align": "^0.1.1",
 								"wordwrap": "0.0.2"
 							},
 							"dependencies": {
@@ -5230,8 +5230,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"map-visit": "1.0.0",
-								"object-visit": "1.0.1"
+								"map-visit": "^1.0.0",
+								"object-visit": "^1.0.0"
 							}
 						},
 						"commondir": {
@@ -5269,8 +5269,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"which": "^1.2.9"
 							}
 						},
 						"debug": {
@@ -5301,7 +5301,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"strip-bom": "2.0.0"
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"define-property": {
@@ -5309,8 +5309,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2",
-								"isobject": "3.0.1"
+								"is-descriptor": "^1.0.2",
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"is-accessor-descriptor": {
@@ -5318,7 +5318,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5326,7 +5326,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5334,9 +5334,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -5356,7 +5356,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"error-ex": {
@@ -5364,7 +5364,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-arrayish": "0.2.1"
+								"is-arrayish": "^0.2.1"
 							}
 						},
 						"escape-string-regexp": {
@@ -5382,13 +5382,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							},
 							"dependencies": {
 								"cross-spawn": {
@@ -5396,9 +5396,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"lru-cache": "4.1.3",
-										"shebang-command": "1.2.0",
-										"which": "1.3.0"
+										"lru-cache": "^4.0.1",
+										"shebang-command": "^1.2.0",
+										"which": "^1.2.9"
 									}
 								}
 							}
@@ -5408,13 +5408,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5422,7 +5422,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -5430,7 +5430,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5440,8 +5440,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"assign-symbols": "1.0.0",
-								"is-extendable": "1.0.1"
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
@@ -5449,7 +5449,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -5459,14 +5459,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5474,7 +5474,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
@@ -5482,7 +5482,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -5490,7 +5490,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5498,7 +5498,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5506,9 +5506,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"kind-of": {
@@ -5523,10 +5523,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -5534,7 +5534,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5544,9 +5544,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"commondir": "1.0.1",
-								"mkdirp": "0.5.1",
-								"pkg-dir": "1.0.0"
+								"commondir": "^1.0.1",
+								"mkdirp": "^0.5.1",
+								"pkg-dir": "^1.0.0"
 							}
 						},
 						"find-up": {
@@ -5554,7 +5554,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"locate-path": "2.0.0"
+								"locate-path": "^2.0.0"
 							}
 						},
 						"for-in": {
@@ -5567,8 +5567,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cross-spawn": "4.0.2",
-								"signal-exit": "3.0.2"
+								"cross-spawn": "^4",
+								"signal-exit": "^3.0.0"
 							}
 						},
 						"fragment-cache": {
@@ -5576,7 +5576,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"map-cache": "0.2.2"
+								"map-cache": "^0.2.2"
 							}
 						},
 						"fs.realpath": {
@@ -5604,12 +5604,12 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"fs.realpath": "1.0.0",
-								"inflight": "1.0.6",
-								"inherits": "2.0.3",
-								"minimatch": "3.0.4",
-								"once": "1.4.0",
-								"path-is-absolute": "1.0.1"
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
 							}
 						},
 						"globals": {
@@ -5627,10 +5627,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"async": "1.5.2",
-								"optimist": "0.6.1",
-								"source-map": "0.4.4",
-								"uglify-js": "2.8.29"
+								"async": "^1.4.0",
+								"optimist": "^0.6.1",
+								"source-map": "^0.4.4",
+								"uglify-js": "^2.6"
 							},
 							"dependencies": {
 								"source-map": {
@@ -5638,7 +5638,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"amdefine": "1.0.1"
+										"amdefine": ">=0.0.4"
 									}
 								}
 							}
@@ -5648,7 +5648,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"has-flag": {
@@ -5661,9 +5661,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "1.0.0",
-								"isobject": "3.0.1"
+								"get-value": "^2.0.6",
+								"has-values": "^1.0.0",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5678,8 +5678,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"kind-of": "4.0.0"
+								"is-number": "^3.0.0",
+								"kind-of": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
@@ -5687,7 +5687,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -5695,7 +5695,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -5705,7 +5705,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -5725,8 +5725,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"once": "1.4.0",
-								"wrappy": "1.0.2"
+								"once": "^1.3.0",
+								"wrappy": "1"
 							}
 						},
 						"inherits": {
@@ -5739,7 +5739,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"loose-envify": "1.3.1"
+								"loose-envify": "^1.0.0"
 							}
 						},
 						"invert-kv": {
@@ -5752,7 +5752,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-arrayish": {
@@ -5770,7 +5770,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"builtin-modules": "1.1.1"
+								"builtin-modules": "^1.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -5778,7 +5778,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -5786,9 +5786,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -5808,7 +5808,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"is-fullwidth-code-point": {
@@ -5821,7 +5821,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-odd": {
@@ -5829,7 +5829,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "4.0.0"
+								"is-number": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
@@ -5844,7 +5844,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5894,7 +5894,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"append-transform": "0.4.0"
+								"append-transform": "^0.4.0"
 							}
 						},
 						"istanbul-lib-instrument": {
@@ -5902,13 +5902,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-generator": "6.26.1",
-								"babel-template": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"semver": "5.5.0"
+								"babel-generator": "^6.18.0",
+								"babel-template": "^6.16.0",
+								"babel-traverse": "^6.18.0",
+								"babel-types": "^6.18.0",
+								"babylon": "^6.18.0",
+								"istanbul-lib-coverage": "^1.2.0",
+								"semver": "^5.3.0"
 							}
 						},
 						"istanbul-lib-report": {
@@ -5916,10 +5916,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"path-parse": "1.0.5",
-								"supports-color": "3.2.3"
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"path-parse": "^1.0.5",
+								"supports-color": "^3.1.2"
 							},
 							"dependencies": {
 								"supports-color": {
@@ -5927,7 +5927,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"has-flag": "1.0.0"
+										"has-flag": "^1.0.0"
 									}
 								}
 							}
@@ -5937,11 +5937,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "3.1.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"rimraf": "2.6.2",
-								"source-map": "0.5.7"
+								"debug": "^3.1.0",
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"rimraf": "^2.6.1",
+								"source-map": "^0.5.3"
 							},
 							"dependencies": {
 								"debug": {
@@ -5959,7 +5959,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"handlebars": "4.0.11"
+								"handlebars": "^4.0.3"
 							}
 						},
 						"js-tokens": {
@@ -5977,7 +5977,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						},
 						"lazy-cache": {
@@ -5991,7 +5991,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"invert-kv": "1.0.0"
+								"invert-kv": "^1.0.0"
 							}
 						},
 						"load-json-file": {
@@ -5999,11 +5999,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"locate-path": {
@@ -6011,8 +6011,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-locate": "2.0.0",
-								"path-exists": "3.0.0"
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
 							},
 							"dependencies": {
 								"path-exists": {
@@ -6037,7 +6037,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"js-tokens": "3.0.2"
+								"js-tokens": "^3.0.0"
 							}
 						},
 						"lru-cache": {
@@ -6045,8 +6045,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pseudomap": "1.0.2",
-								"yallist": "2.1.2"
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
 							}
 						},
 						"map-cache": {
@@ -6059,7 +6059,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"object-visit": "1.0.1"
+								"object-visit": "^1.0.0"
 							}
 						},
 						"md5-hex": {
@@ -6067,7 +6067,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"md5-o-matic": "0.1.1"
+								"md5-o-matic": "^0.1.1"
 							}
 						},
 						"md5-o-matic": {
@@ -6080,7 +6080,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"mimic-fn": "1.2.0"
+								"mimic-fn": "^1.0.0"
 							}
 						},
 						"merge-source-map": {
@@ -6088,7 +6088,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"source-map": "0.6.1"
+								"source-map": "^0.6.1"
 							},
 							"dependencies": {
 								"source-map": {
@@ -6103,19 +6103,19 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6135,7 +6135,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"brace-expansion": "1.1.11"
+								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
@@ -6148,8 +6148,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"for-in": "1.0.2",
-								"is-extendable": "1.0.1"
+								"for-in": "^1.0.2",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
@@ -6157,7 +6157,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -6180,18 +6180,18 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"fragment-cache": "0.2.1",
-								"is-odd": "2.0.0",
-								"is-windows": "1.0.2",
-								"kind-of": "6.0.2",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"fragment-cache": "^0.2.1",
+								"is-odd": "^2.0.0",
+								"is-windows": "^1.0.2",
+								"kind-of": "^6.0.2",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -6216,10 +6216,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"hosted-git-info": "2.6.0",
-								"is-builtin-module": "1.0.0",
-								"semver": "5.5.0",
-								"validate-npm-package-license": "3.0.3"
+								"hosted-git-info": "^2.1.4",
+								"is-builtin-module": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
 							}
 						},
 						"npm-run-path": {
@@ -6227,7 +6227,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-key": "2.0.1"
+								"path-key": "^2.0.0"
 							}
 						},
 						"number-is-nan": {
@@ -6245,9 +6245,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"copy-descriptor": "0.1.1",
-								"define-property": "0.2.5",
-								"kind-of": "3.2.2"
+								"copy-descriptor": "^0.1.0",
+								"define-property": "^0.2.5",
+								"kind-of": "^3.0.3"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6255,7 +6255,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -6265,7 +6265,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -6280,7 +6280,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -6295,7 +6295,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"wrappy": "1.0.2"
+								"wrappy": "1"
 							}
 						},
 						"optimist": {
@@ -6303,8 +6303,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"minimist": "0.0.8",
-								"wordwrap": "0.0.3"
+								"minimist": "~0.0.1",
+								"wordwrap": "~0.0.2"
 							}
 						},
 						"os-homedir": {
@@ -6317,9 +6317,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"execa": "0.7.0",
-								"lcid": "1.0.0",
-								"mem": "1.1.0"
+								"execa": "^0.7.0",
+								"lcid": "^1.0.0",
+								"mem": "^1.1.0"
 							}
 						},
 						"p-finally": {
@@ -6332,7 +6332,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-try": "1.0.0"
+								"p-try": "^1.0.0"
 							}
 						},
 						"p-locate": {
@@ -6340,7 +6340,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-limit": "1.2.0"
+								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
@@ -6353,7 +6353,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.1"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"pascalcase": {
@@ -6366,7 +6366,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-is-absolute": {
@@ -6389,9 +6389,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -6409,7 +6409,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pinkie": "2.0.4"
+								"pinkie": "^2.0.0"
 							}
 						},
 						"pkg-dir": {
@@ -6417,7 +6417,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"find-up": "1.1.2"
+								"find-up": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
@@ -6425,8 +6425,8 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -6446,9 +6446,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"read-pkg-up": {
@@ -6456,8 +6456,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"find-up": "1.1.2",
-								"read-pkg": "1.1.0"
+								"find-up": "^1.0.0",
+								"read-pkg": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
@@ -6465,8 +6465,8 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -6481,8 +6481,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "3.0.2",
-								"safe-regex": "1.1.0"
+								"extend-shallow": "^3.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"repeat-element": {
@@ -6500,7 +6500,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-finite": "1.0.2"
+								"is-finite": "^1.0.0"
 							}
 						},
 						"require-directory": {
@@ -6534,7 +6534,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4"
+								"align-text": "^0.1.1"
 							}
 						},
 						"rimraf": {
@@ -6542,7 +6542,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"glob": "7.1.2"
+								"glob": "^7.0.5"
 							}
 						},
 						"safe-regex": {
@@ -6550,7 +6550,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ret": "0.1.15"
+								"ret": "~0.1.10"
 							}
 						},
 						"semver": {
@@ -6568,10 +6568,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"split-string": "3.1.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.3",
+								"split-string": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -6579,7 +6579,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -6589,7 +6589,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"shebang-regex": "1.0.0"
+								"shebang-regex": "^1.0.0"
 							}
 						},
 						"shebang-regex": {
@@ -6612,14 +6612,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"base": "0.11.2",
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"map-cache": "0.2.2",
-								"source-map": "0.5.7",
-								"source-map-resolve": "0.5.1",
-								"use": "3.1.0"
+								"base": "^0.11.1",
+								"debug": "^2.2.0",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"map-cache": "^0.2.2",
+								"source-map": "^0.5.6",
+								"source-map-resolve": "^0.5.0",
+								"use": "^3.1.0"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6627,7 +6627,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -6635,7 +6635,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -6645,9 +6645,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"snapdragon-util": "3.0.1"
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.0",
+								"snapdragon-util": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6655,7 +6655,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -6663,7 +6663,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -6671,7 +6671,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -6679,9 +6679,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -6701,7 +6701,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.2.0"
 							}
 						},
 						"source-map": {
@@ -6714,11 +6714,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"atob": "2.1.1",
-								"decode-uri-component": "0.2.0",
-								"resolve-url": "0.2.1",
-								"source-map-url": "0.4.0",
-								"urix": "0.1.0"
+								"atob": "^2.0.0",
+								"decode-uri-component": "^0.2.0",
+								"resolve-url": "^0.2.1",
+								"source-map-url": "^0.4.0",
+								"urix": "^0.1.0"
 							}
 						},
 						"source-map-url": {
@@ -6731,12 +6731,12 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"foreground-child": "1.5.6",
-								"mkdirp": "0.5.1",
-								"os-homedir": "1.0.2",
-								"rimraf": "2.6.2",
-								"signal-exit": "3.0.2",
-								"which": "1.3.0"
+								"foreground-child": "^1.5.6",
+								"mkdirp": "^0.5.0",
+								"os-homedir": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"signal-exit": "^3.0.2",
+								"which": "^1.3.0"
 							}
 						},
 						"spdx-correct": {
@@ -6744,8 +6744,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-expression-parse": "3.0.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-expression-parse": "^3.0.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-exceptions": {
@@ -6758,8 +6758,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-exceptions": "2.1.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-license-ids": {
@@ -6772,7 +6772,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "3.0.2"
+								"extend-shallow": "^3.0.0"
 							}
 						},
 						"static-extend": {
@@ -6780,8 +6780,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "0.2.5",
-								"object-copy": "0.1.0"
+								"define-property": "^0.2.5",
+								"object-copy": "^0.1.0"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6789,7 +6789,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -6799,8 +6799,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-fullwidth-code-point": "2.0.0",
-								"strip-ansi": "4.0.0"
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -6813,7 +6813,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								}
 							}
@@ -6823,7 +6823,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"strip-bom": {
@@ -6831,7 +6831,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						},
 						"strip-eof": {
@@ -6849,11 +6849,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arrify": "1.0.1",
-								"micromatch": "3.1.10",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"require-main-filename": "1.0.1"
+								"arrify": "^1.0.1",
+								"micromatch": "^3.1.8",
+								"object-assign": "^4.1.0",
+								"read-pkg-up": "^1.0.1",
+								"require-main-filename": "^1.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -6871,16 +6871,16 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"arr-flatten": "1.1.0",
-										"array-unique": "0.3.2",
-										"extend-shallow": "2.0.1",
-										"fill-range": "4.0.0",
-										"isobject": "3.0.1",
-										"repeat-element": "1.1.2",
-										"snapdragon": "0.8.2",
-										"snapdragon-node": "2.1.1",
-										"split-string": "3.1.0",
-										"to-regex": "3.0.2"
+										"arr-flatten": "^1.1.0",
+										"array-unique": "^0.3.2",
+										"extend-shallow": "^2.0.1",
+										"fill-range": "^4.0.0",
+										"isobject": "^3.0.1",
+										"repeat-element": "^1.1.2",
+										"snapdragon": "^0.8.1",
+										"snapdragon-node": "^2.0.1",
+										"split-string": "^3.0.2",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"extend-shallow": {
@@ -6888,7 +6888,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -6898,13 +6898,13 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"debug": "2.6.9",
-										"define-property": "0.2.5",
-										"extend-shallow": "2.0.1",
-										"posix-character-classes": "0.1.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"debug": "^2.3.3",
+										"define-property": "^0.2.5",
+										"extend-shallow": "^2.0.1",
+										"posix-character-classes": "^0.1.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
@@ -6912,7 +6912,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-descriptor": "0.1.6"
+												"is-descriptor": "^0.1.0"
 											}
 										},
 										"extend-shallow": {
@@ -6920,7 +6920,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										},
 										"is-accessor-descriptor": {
@@ -6928,7 +6928,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
@@ -6936,7 +6936,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -6946,7 +6946,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
@@ -6954,7 +6954,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -6964,9 +6964,9 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-accessor-descriptor": "0.1.6",
-												"is-data-descriptor": "0.1.4",
-												"kind-of": "5.1.0"
+												"is-accessor-descriptor": "^0.1.6",
+												"is-data-descriptor": "^0.1.4",
+												"kind-of": "^5.0.0"
 											}
 										},
 										"kind-of": {
@@ -6981,14 +6981,14 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"array-unique": "0.3.2",
-										"define-property": "1.0.0",
-										"expand-brackets": "2.1.4",
-										"extend-shallow": "2.0.1",
-										"fragment-cache": "0.2.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"array-unique": "^0.3.2",
+										"define-property": "^1.0.0",
+										"expand-brackets": "^2.1.4",
+										"extend-shallow": "^2.0.1",
+										"fragment-cache": "^0.2.1",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
@@ -6996,7 +6996,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-descriptor": "1.0.2"
+												"is-descriptor": "^1.0.0"
 											}
 										},
 										"extend-shallow": {
@@ -7004,7 +7004,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -7014,10 +7014,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-number": "3.0.0",
-										"repeat-string": "1.6.1",
-										"to-regex-range": "2.1.1"
+										"extend-shallow": "^2.0.1",
+										"is-number": "^3.0.0",
+										"repeat-string": "^1.6.1",
+										"to-regex-range": "^2.1.0"
 									},
 									"dependencies": {
 										"extend-shallow": {
@@ -7025,7 +7025,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -7035,7 +7035,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -7043,7 +7043,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -7051,9 +7051,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"is-number": {
@@ -7061,7 +7061,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -7069,7 +7069,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -7089,19 +7089,19 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"arr-diff": "4.0.0",
-										"array-unique": "0.3.2",
-										"braces": "2.3.2",
-										"define-property": "2.0.2",
-										"extend-shallow": "3.0.2",
-										"extglob": "2.0.4",
-										"fragment-cache": "0.2.1",
-										"kind-of": "6.0.2",
-										"nanomatch": "1.2.9",
-										"object.pick": "1.3.0",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"arr-diff": "^4.0.0",
+										"array-unique": "^0.3.2",
+										"braces": "^2.3.1",
+										"define-property": "^2.0.2",
+										"extend-shallow": "^3.0.2",
+										"extglob": "^2.0.4",
+										"fragment-cache": "^0.2.1",
+										"kind-of": "^6.0.2",
+										"nanomatch": "^1.2.9",
+										"object.pick": "^1.3.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.2"
 									}
 								}
 							}
@@ -7116,7 +7116,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"to-regex": {
@@ -7124,10 +7124,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"regex-not": "1.0.2",
-								"safe-regex": "1.1.0"
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"regex-not": "^1.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"to-regex-range": {
@@ -7135,8 +7135,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1"
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1"
 							},
 							"dependencies": {
 								"is-number": {
@@ -7144,7 +7144,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									}
 								}
 							}
@@ -7160,9 +7160,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"source-map": "0.5.7",
-								"uglify-to-browserify": "1.0.2",
-								"yargs": "3.10.0"
+								"source-map": "~0.5.1",
+								"uglify-to-browserify": "~1.0.0",
+								"yargs": "~3.10.0"
 							},
 							"dependencies": {
 								"yargs": {
@@ -7171,9 +7171,9 @@
 									"dev": true,
 									"optional": true,
 									"requires": {
-										"camelcase": "1.2.1",
-										"cliui": "2.1.0",
-										"decamelize": "1.2.0",
+										"camelcase": "^1.0.2",
+										"cliui": "^2.1.0",
+										"decamelize": "^1.0.0",
 										"window-size": "0.1.0"
 									}
 								}
@@ -7190,10 +7190,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"get-value": "2.0.6",
-								"is-extendable": "0.1.1",
-								"set-value": "0.4.3"
+								"arr-union": "^3.1.0",
+								"get-value": "^2.0.6",
+								"is-extendable": "^0.1.1",
+								"set-value": "^0.4.3"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -7201,7 +7201,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"set-value": {
@@ -7209,10 +7209,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-extendable": "0.1.1",
-										"is-plain-object": "2.0.4",
-										"to-object-path": "0.3.0"
+										"extend-shallow": "^2.0.1",
+										"is-extendable": "^0.1.1",
+										"is-plain-object": "^2.0.1",
+										"to-object-path": "^0.3.0"
 									}
 								}
 							}
@@ -7222,8 +7222,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-value": "0.3.1",
-								"isobject": "3.0.1"
+								"has-value": "^0.3.1",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"has-value": {
@@ -7231,9 +7231,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"get-value": "2.0.6",
-										"has-values": "0.1.4",
-										"isobject": "2.1.0"
+										"get-value": "^2.0.3",
+										"has-values": "^0.1.4",
+										"isobject": "^2.0.0"
 									},
 									"dependencies": {
 										"isobject": {
@@ -7268,7 +7268,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7283,8 +7283,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-correct": "3.0.0",
-								"spdx-expression-parse": "3.0.0"
+								"spdx-correct": "^3.0.0",
+								"spdx-expression-parse": "^3.0.0"
 							}
 						},
 						"which": {
@@ -7292,7 +7292,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isexe": "2.0.0"
+								"isexe": "^2.0.0"
 							}
 						},
 						"which-module": {
@@ -7316,8 +7316,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1"
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1"
 							},
 							"dependencies": {
 								"is-fullwidth-code-point": {
@@ -7325,7 +7325,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"number-is-nan": "1.0.1"
+										"number-is-nan": "^1.0.0"
 									}
 								},
 								"string-width": {
@@ -7333,9 +7333,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
 									}
 								}
 							}
@@ -7350,9 +7350,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"imurmurhash": "0.1.4",
-								"slide": "1.1.6"
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"slide": "^1.1.5"
 							}
 						},
 						"y18n": {
@@ -7370,18 +7370,18 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cliui": "4.1.0",
-								"decamelize": "1.2.0",
-								"find-up": "2.1.0",
-								"get-caller-file": "1.0.2",
-								"os-locale": "2.1.0",
-								"require-directory": "2.1.1",
-								"require-main-filename": "1.0.1",
-								"set-blocking": "2.0.0",
-								"string-width": "2.1.1",
-								"which-module": "2.0.0",
-								"y18n": "3.2.1",
-								"yargs-parser": "9.0.2"
+								"cliui": "^4.0.0",
+								"decamelize": "^1.1.1",
+								"find-up": "^2.1.0",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^2.0.0",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^2.0.0",
+								"which-module": "^2.0.0",
+								"y18n": "^3.2.1",
+								"yargs-parser": "^9.0.2"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -7399,9 +7399,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"string-width": "2.1.1",
-										"strip-ansi": "4.0.0",
-										"wrap-ansi": "2.1.0"
+										"string-width": "^2.1.1",
+										"strip-ansi": "^4.0.0",
+										"wrap-ansi": "^2.0.0"
 									}
 								},
 								"strip-ansi": {
@@ -7409,7 +7409,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								},
 								"yargs-parser": {
@@ -7417,7 +7417,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"camelcase": "4.1.0"
+										"camelcase": "^4.1.0"
 									}
 								}
 							}
@@ -7427,7 +7427,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							},
 							"dependencies": {
 								"camelcase": {
@@ -7447,15 +7447,15 @@
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"dev": true,
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -7464,9 +7464,9 @@
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"dev": true,
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -7477,9 +7477,9 @@
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"dev": true,
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -7494,8 +7494,8 @@
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -7522,18 +7522,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.1",
-				"commander": "2.17.1",
-				"diff": "3.5.0",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.1",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
 				"diff": {
@@ -7550,7 +7550,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {
@@ -7559,7 +7559,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -7581,8 +7581,8 @@
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -7603,9 +7603,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -7614,7 +7614,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -7629,9 +7629,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/packages/codemaker/package-lock.json
+++ b/packages/codemaker/package-lock.json
@@ -17,7 +17,7 @@
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
 			"integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
 			"requires": {
-				"@types/node": "9.6.30"
+				"@types/node": "*"
 			}
 		},
 		"@types/node": {
@@ -35,10 +35,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -51,7 +51,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -59,7 +59,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -93,7 +93,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -111,7 +111,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -150,7 +150,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -168,12 +168,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -181,8 +181,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -190,7 +190,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -232,8 +232,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -281,8 +281,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -295,9 +295,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -310,9 +310,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -325,7 +325,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"universalify": {
@@ -350,7 +350,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -358,12 +358,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -386,8 +386,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"http-signature": {
@@ -395,9 +395,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -410,8 +410,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -445,8 +445,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -496,8 +496,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -510,7 +510,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -518,7 +518,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -531,8 +531,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -567,8 +567,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -576,42 +576,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -630,7 +630,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -673,74 +673,74 @@
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -755,43 +755,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -808,7 +808,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -816,23 +816,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -845,15 +845,15 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -866,9 +866,9 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -881,36 +881,36 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -924,8 +924,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -944,8 +944,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -976,8 +976,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1003,38 +1003,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1051,14 +1051,14 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1073,22 +1073,22 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1097,27 +1097,27 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1126,15 +1126,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1143,51 +1143,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1200,17 +1200,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1219,16 +1219,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1239,15 +1239,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1270,12 +1270,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1290,17 +1290,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1309,7 +1309,7 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1320,9 +1320,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1335,22 +1335,22 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1359,7 +1359,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1376,8 +1376,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1388,7 +1388,7 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1399,7 +1399,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1414,23 +1414,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1447,7 +1447,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1458,14 +1458,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1478,7 +1478,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1519,37 +1519,37 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1558,11 +1558,11 @@
 					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -1578,7 +1578,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -1593,7 +1593,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1605,26 +1605,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1645,15 +1645,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1664,14 +1664,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1682,14 +1682,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1702,19 +1702,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1731,7 +1731,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1742,15 +1742,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1770,18 +1770,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -1802,17 +1802,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1827,16 +1827,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1845,7 +1845,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1858,7 +1858,7 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1871,15 +1871,15 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -1890,9 +1890,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -1903,14 +1903,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -1921,7 +1921,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -1932,7 +1932,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -1951,9 +1951,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -1968,22 +1968,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2000,25 +2000,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2031,8 +2031,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2047,7 +2047,7 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2075,21 +2075,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2104,17 +2104,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2123,7 +2123,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2142,28 +2142,28 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2172,39 +2172,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2221,7 +2221,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2232,11 +2232,11 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2247,20 +2247,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2271,8 +2271,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2283,22 +2283,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2307,8 +2307,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2319,7 +2319,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2328,14 +2328,14 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2350,11 +2350,11 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2369,23 +2369,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2394,41 +2394,41 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2437,14 +2437,14 @@
 									"version": "0.1.4",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2453,9 +2453,9 @@
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -2468,28 +2468,28 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2498,17 +2498,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2517,37 +2517,37 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2564,19 +2564,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -2589,32 +2589,32 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -2628,9 +2628,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2638,9 +2638,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2655,27 +2655,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2684,17 +2684,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2724,7 +2724,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2737,15 +2737,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2765,24 +2765,24 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2795,9 +2795,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2812,18 +2812,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2838,23 +2838,23 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2863,7 +2863,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2884,7 +2884,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -2907,7 +2907,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -2952,13 +2952,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -2966,26 +2966,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"rimraf": {
@@ -2993,7 +2993,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -3021,8 +3021,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"sprintf-js": {
@@ -3035,15 +3035,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -3057,7 +3057,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -3065,7 +3065,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"tap": {
@@ -3073,35 +3073,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			}
 		},
 		"tap-mocha-reporter": {
@@ -3109,15 +3109,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -3125,9 +3125,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -3137,9 +3137,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -3152,8 +3152,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -3171,7 +3171,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -3190,8 +3190,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -3210,9 +3210,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -3220,7 +3220,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -3233,9 +3233,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/packages/jsii-build-tools/package-lock.json
+++ b/packages/jsii-build-tools/package-lock.json
@@ -7,9 +7,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -22,7 +22,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"universalify": {

--- a/packages/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/jsii-calc-base-of-base/test/assembly.jsii
@@ -58,6 +58,7 @@
       "name": "VeryBaseProps",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "fqn": "@scope/jsii-calc-base-of-base.Very"
@@ -67,5 +68,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "xM+yEz06NDR7n4G5n4VDoITs275dSqMhFDXgKOErl/M="
+  "fingerprint": "uxjBWk0nRDSHNR2FL01kRusKUoxa53smUFsizIJYBSs="
 }

--- a/packages/jsii-calc-base/test/assembly.jsii
+++ b/packages/jsii-calc-base/test/assembly.jsii
@@ -91,6 +91,7 @@
       "name": "BaseProps",
       "properties": [
         {
+          "abstract": true,
           "name": "bar",
           "type": {
             "primitive": "string"
@@ -100,5 +101,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "/t6/DercTjOI1TLjj3MowD7pZkpm70sJQdeKwQMpa9M="
+  "fingerprint": "6NsGM++itCYmctZJdOp8kPJ3CfBnajQ78wNpY+EwZIQ="
 }

--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -101,6 +101,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Say hello!"
           },
@@ -123,6 +124,7 @@
       "name": "MyFirstStruct",
       "properties": [
         {
+          "abstract": true,
           "docs": {
             "comment": "An awesome number value"
           },
@@ -132,6 +134,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "A string value"
           },
@@ -141,6 +144,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "firstOptional",
           "type": {
             "collection": {
@@ -250,6 +254,7 @@
       "name": "StructWithOnlyOptionals",
       "properties": [
         {
+          "abstract": true,
           "docs": {
             "comment": "The first optional!"
           },
@@ -260,6 +265,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optional2",
           "type": {
             "optional": true,
@@ -267,6 +273,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optional3",
           "type": {
             "optional": true,
@@ -317,5 +324,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "dGLkY7rPKJjBMLQCOCj5AXR3Q1+cZcoiazcIhDUV++8="
+  "fingerprint": "PD1bhVhBjZ0dNrD8K4FK6RT+W5RhpkTEJDml/OiM7Ws="
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -814,3 +814,55 @@ export namespace InterfaceInNamespaceIncludesClasses {
 export interface InterfaceWithOptionalMethodArguments {
     hello(arg1: string, arg2?: number): void
 }
+
+/**
+ * awslabs/jsii#220
+ * Abstract return type
+ */
+
+export interface InterfaceImplementedByAbstractClass {
+    readonly propFromInterface: string;
+}
+
+export abstract class AbstractClassBase {
+    public abstract readonly abstractProperty: string;
+}
+
+export abstract class AbstractClass extends AbstractClassBase implements InterfaceImplementedByAbstractClass {
+    public nonAbstractMethod() {
+        return 42;
+    }
+
+    public abstract abstractMethod(name: string): string;
+
+    public get propFromInterface() {
+        return 'propFromInterfaceValue';
+    }
+}
+
+class ConcreteClass extends AbstractClass {
+    public abstractMethod(name: string) {
+        return `Hello, ${name}!!`;
+    }
+
+    public get abstractProperty() {
+        return 'Hello, dude!';
+    }
+}
+
+
+export class AbstractClassReturner {
+    public giveMeAbstract(): AbstractClass {
+        return new ConcreteClass();
+    }
+
+    public giveMeInterface(): InterfaceImplementedByAbstractClass {
+        return new ConcreteClass();
+    }
+
+    public get returnAbstractFromProperty(): AbstractClassBase {
+        return {
+            abstractProperty: 'hello-abstract-property'
+        }
+    }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -165,6 +165,111 @@
     }
   },
   "types": {
+    "jsii-calc.AbstractClass": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "base": {
+        "fqn": "jsii-calc.AbstractClassBase"
+      },
+      "fqn": "jsii-calc.AbstractClass",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+        }
+      ],
+      "kind": "class",
+      "methods": [
+        {
+          "abstract": true,
+          "name": "abstractMethod",
+          "parameters": [
+            {
+              "name": "name",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "nonAbstractMethod",
+          "returns": {
+            "primitive": "number"
+          }
+        }
+      ],
+      "name": "AbstractClass",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "propFromInterface",
+          "overrides": {
+            "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.AbstractClassBase": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.AbstractClassBase",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "AbstractClassBase",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "abstractProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.AbstractClassReturner": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.AbstractClassReturner",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "giveMeAbstract",
+          "returns": {
+            "fqn": "jsii-calc.AbstractClass"
+          }
+        },
+        {
+          "name": "giveMeInterface",
+          "returns": {
+            "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+          }
+        }
+      ],
+      "name": "AbstractClassReturner",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "returnAbstractFromProperty",
+          "type": {
+            "fqn": "jsii-calc.AbstractClassBase"
+          }
+        }
+      ]
+    },
     "jsii-calc.Add": {
       "assembly": "jsii-calc",
       "base": {
@@ -890,6 +995,7 @@
       "name": "CalculatorProps",
       "properties": [
         {
+          "abstract": true,
           "name": "initialValue",
           "type": {
             "optional": true,
@@ -897,6 +1003,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "maximumValue",
           "type": {
             "optional": true,
@@ -952,18 +1059,21 @@
       "name": "DerivedStruct",
       "properties": [
         {
+          "abstract": true,
           "name": "anotherRequired",
           "type": {
             "primitive": "date"
           }
         },
         {
+          "abstract": true,
           "name": "bool",
           "type": {
             "primitive": "boolean"
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "An example of a non primitive property."
           },
@@ -973,6 +1083,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "This is optional."
           },
@@ -988,6 +1099,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optionalArray",
           "type": {
             "collection": {
@@ -1126,6 +1238,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Say farewell."
           },
@@ -1135,6 +1248,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "Say goodbye.",
             "return": "A goodbye blessing."
@@ -1169,6 +1283,7 @@
       "name": "IInterfaceWithProperties",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "readOnlyString",
           "type": {
@@ -1176,6 +1291,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "readWriteString",
           "type": {
             "primitive": "string"
@@ -1196,6 +1312,7 @@
       "name": "IInterfaceWithPropertiesExtension",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1212,6 +1329,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Returns another random number.",
             "return": "A random number."
@@ -1237,9 +1355,30 @@
       "name": "ImplictBaseOfBase",
       "properties": [
         {
+          "abstract": true,
           "name": "goo",
           "type": {
             "primitive": "date"
+          }
+        }
+      ]
+    },
+    "jsii-calc.InterfaceImplementedByAbstractClass": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "comment": "awslabs/jsii#220\nAbstract return type"
+      },
+      "fqn": "jsii-calc.InterfaceImplementedByAbstractClass",
+      "kind": "interface",
+      "name": "InterfaceImplementedByAbstractClass",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "propFromInterface",
+          "type": {
+            "primitive": "string"
           }
         }
       ]
@@ -1272,6 +1411,7 @@
       "namespace": "InterfaceInNamespaceIncludesClasses",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1288,6 +1428,7 @@
       "namespace": "InterfaceInNamespaceOnlyInterface",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1304,6 +1445,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "name": "hello",
           "parameters": [
             {
@@ -2101,6 +2243,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "name": "obtainNumber",
           "returns": {
             "primitive": "number"
@@ -2110,6 +2253,7 @@
       "name": "ReturnsNumber",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "numberProp",
           "type": {
@@ -2528,6 +2672,7 @@
       "name": "UnionProperties",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "bar",
           "type": {
@@ -2547,6 +2692,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "optional": true,
@@ -2924,5 +3070,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "24z7SEbRKIt7qRAyBqepDewNh+2kbwGcOBLFVu2Hgi8="
+  "fingerprint": "hajD3L82lt+a5tNLGsSr/WrmrdtMKz+aAkPIHgN3LE8="
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceGeneratorTests.cs
@@ -81,7 +81,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 fullyQualifiedName: "myInterfaceFqn",
                 assembly: "",
                 name: "MyInterface",
-                methods: new Method[] { new Method(false, false, false, name: "myMethod") }
+                methods: new Method[] { new Method(false, false, true, name: "myMethod") }
             );
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceMethodGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceMethodGeneratorTests.cs
@@ -39,7 +39,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             (
                 false,
                 false,
-                false,
+                true,
                 name: "myMethod",
                 returns: new TypeReference(fullyQualifiedName: "myReturnTypeFqn")
             );
@@ -55,7 +55,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             (
                 false,
                 false,
-                false,
+                true,
                 name: "myMethod",
                 parameters: new[]
                 {
@@ -81,7 +81,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             (
                 false,
                 false,
-                false,
+                true,
                 name: "myMethod"
             );
 
@@ -100,7 +100,7 @@ void MyMethod();";
             (
                 false,
                 false,
-                false,
+                true,
                 name: "myMethod",
                 parameters: new[]
                 {
@@ -135,7 +135,7 @@ void MyMethod(string myParameter1, string @event);";
             (
                 false,
                 false,
-                false,
+                true,
                 name: "myMethod",
                 returns: new TypeReference(primitive: PrimitiveType.String)
             );

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
@@ -59,7 +59,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myInterface",
                 "myNamespace",
-                methods: new Method[] { new Method(false, false, false, name: "myMethod") }
+                methods: new Method[] { new Method(false, false, true, name: "myMethod") }
             );
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");
@@ -94,7 +94,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myAncestorInterface",
                 "myNamespace",
-                methods: new [] { new Method(false, false, false, name: "myAncestorMethod") }
+                methods: new [] { new Method(false, false, true, name: "myAncestorMethod") }
             );
             InterfaceType baseInterface = new InterfaceType
             (
@@ -102,7 +102,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myBaseInterface",
                 "myNamespace",
-                methods: new[] { new Method(false, false, false, name: "myBaseMethod") },
+                methods: new[] { new Method(false, false, true, name: "myBaseMethod") },
                 interfaces: new[] { new TypeReference("myAncestorInterfaceFqn") }
             );
             InterfaceType interfaceType = new InterfaceType
@@ -191,6 +191,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
           ""docs"": {
             ""comment"": ""The arbitrary name of this environment (user-set, or at least user-meaningful) ""
           },
+          ""abstract"": true,
           ""name"": ""name"",
           ""type"": {
             ""primitive"": ""string""
@@ -200,6 +201,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
           ""docs"": {
             ""comment"": ""The 12-digit AWS account ID for the account this environment deploys into ""
           },
+          ""abstract"": true,
           ""name"": ""account"",
           ""type"": {
             ""primitive"": ""string""
@@ -209,6 +211,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
           ""docs"": {
             ""comment"": ""The AWS region name where this environment deploys into ""
           },
+          ""abstract"": true,
           ""name"": ""region"",
           ""type"": {
             ""primitive"": ""string""

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
@@ -34,7 +34,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         [Fact(DisplayName = Prefix + nameof(IncludesAttribute))]
         public void IncludesAttribute()
         {
-            Method method = new Method(false, false, false, name: "myMethod");
+            Method method = new Method(false, false, true, name: "myMethod");
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");
 
@@ -53,7 +53,7 @@ public virtual void MyMethod()
         {
             Method method = new Method
             (
-                false, false, false, name: "myMethod",
+                false, false, true, name: "myMethod",
                 parameters: new[]
                 {
                     new Parameter("myParam", new TypeReference("myParamTypeFqn")),
@@ -81,7 +81,7 @@ public virtual void MyMethod(MyParamType myParam, string @event)
         {
             Method method = new Method
             (
-                false, false, false, name: "myMethod",
+                false, false, true, name: "myMethod",
                 docs: new Docs { { "foo", "bar" } }
             );
 
@@ -102,7 +102,7 @@ public virtual void MyMethod()
         {
             Method method = new Method
             (
-                false, false, false, name: "myMethod",
+                false, false, true, name: "myMethod",
                 returns: new TypeReference("myReturnTypeFqn")
             );
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassMethodGenerator.cs
@@ -46,7 +46,7 @@ namespace Amazon.JSII.Generator.Class
                 yield break;
             }
 
-            if (Method.IsAbstract)
+            if (Method.IsAbstract == true)
             {
                 if (IsDefinedOnAncestor)
                 {
@@ -64,7 +64,7 @@ namespace Amazon.JSII.Generator.Class
 
         protected override BlockSyntax GetBody()
         {
-            if (Method.IsAbstract)
+            if (Method.IsAbstract == true)
             {
                 return null;
             }
@@ -77,6 +77,6 @@ namespace Amazon.JSII.Generator.Class
             return SF.Block(SF.ReturnStatement(CreateInvocationExpression()));
         }
 
-        protected override bool HasSemicolon => Method.IsAbstract;
+        protected override bool HasSemicolon => Method.IsAbstract == true;
     }
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultPropertyGenerator.cs
@@ -13,7 +13,7 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceDefaultPropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == false)
+            if (property.IsAbstract != true)
             {
                 throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultPropertyGenerator.cs
@@ -13,9 +13,9 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceDefaultPropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == true)
+            if (property.IsAbstract == false)
             {
-                throw new ArgumentException("Abstract properties are not allowed on interfaces", nameof(property));
+                throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }
 
             if (property.IsProtected == true)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceMethodGenerator.cs
@@ -11,7 +11,7 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceMethodGenerator(InterfaceType type, Method method, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, method, symbols, namespaces)
         {
-            if (!method.IsAbstract)
+            if (method.IsAbstract != true)
             {
                 throw new ArgumentException("Interface methods must be abstract", nameof(method));
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceMethodGenerator.cs
@@ -11,9 +11,9 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceMethodGenerator(InterfaceType type, Method method, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, method, symbols, namespaces)
         {
-            if (method.IsAbstract)
+            if (!method.IsAbstract)
             {
-                throw new ArgumentException("Abstract methods are not allowed on interfaces", nameof(method));
+                throw new ArgumentException("Interface methods must be abstract", nameof(method));
             }
 
             if (method.IsProtected)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfacePropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfacePropertyGenerator.cs
@@ -14,7 +14,7 @@ namespace Amazon.JSII.Generator.Interface
         public InterfacePropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == false)
+            if (property.IsAbstract != true)
             {
                 throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfacePropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfacePropertyGenerator.cs
@@ -14,9 +14,9 @@ namespace Amazon.JSII.Generator.Interface
         public InterfacePropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == true)
+            if (property.IsAbstract == false)
             {
-                throw new ArgumentException("Abstract properties are not allowed on interfaces", nameof(property));
+                throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }
 
             if (property.IsProtected == true)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
@@ -21,7 +21,7 @@ namespace Amazon.JSII.Generator.Interface
             return SF.ClassDeclaration
             (
                 CreateAttributes(),
-                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword)),
+                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword), SF.Token(SyntaxKind.SealedKeyword)),
                 GetProxyTypeNameSyntax(),
                 null,
                 CreateBaseList(),

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
@@ -21,7 +21,7 @@ namespace Amazon.JSII.Generator.Interface
             return SF.ClassDeclaration
             (
                 CreateAttributes(),
-                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword), SF.Token(SyntaxKind.SealedKeyword)),
+                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword)),
                 GetProxyTypeNameSyntax(),
                 null,
                 CreateBaseList(),

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
@@ -12,7 +12,7 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceProxyMethodGenerator(InterfaceType type, Method method, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, method, symbols, namespaces)
         {
-            if (!method.IsAbstract)
+            if (method.IsAbstract != true)
             {
                 throw new ArgumentException("Interface methods must be abstract", nameof(method));
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
@@ -12,9 +12,9 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceProxyMethodGenerator(InterfaceType type, Method method, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, method, symbols, namespaces)
         {
-            if (method.IsAbstract)
+            if (!method.IsAbstract)
             {
-                throw new ArgumentException("Abstract methods are not allowed on interfaces", nameof(method));
+                throw new ArgumentException("Interface methods must be abstract", nameof(method));
             }
 
             if (method.IsProtected)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
@@ -13,7 +13,7 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceProxyPropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == false)
+            if (property.IsAbstract != true)
             {
                 throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
@@ -13,9 +13,9 @@ namespace Amazon.JSII.Generator.Interface
         public InterfaceProxyPropertyGenerator(InterfaceType type, Property property, ISymbolMap symbols, INamespaceSet namespaces)
             : base(type, property, symbols, namespaces)
         {
-            if (property.IsAbstract == true)
+            if (property.IsAbstract == false)
             {
-                throw new ArgumentException("Abstract properties are not allowed on interfaces", nameof(property));
+                throw new ArgumentException("Interface properties must be abstract", nameof(property));
             }
 
             if (property.IsProtected == true)

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.JsonModel.Spec
         (
             bool isInitializer,
             bool isProtected,
-            bool isAbstract,
+            bool? isAbstract = null,
             Parameter[] parameters = null,
             Docs docs = null,
             string name = null,
@@ -39,8 +39,8 @@ namespace Amazon.JSII.JsonModel.Spec
         [JsonProperty("protected")]
         public bool IsProtected { get; }
 
-        [JsonProperty("abstract")]
-        public bool IsAbstract { get; }
+        [JsonProperty("abstract", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsAbstract { get; }
 
         [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
         public Parameter[] Parameters { get; }

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -3,6 +3,8 @@ package software.amazon.jsii.testing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import software.amazon.jsii.JsiiException;
+import software.amazon.jsii.tests.calculator.AbstractClass;
+import software.amazon.jsii.tests.calculator.AbstractClassReturner;
 import software.amazon.jsii.tests.calculator.Add;
 import software.amazon.jsii.tests.calculator.AllTypes;
 import software.amazon.jsii.tests.calculator.AsyncVirtualMethods;
@@ -15,6 +17,7 @@ import software.amazon.jsii.tests.calculator.IFriendlier;
 import software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator;
 import software.amazon.jsii.tests.calculator.IInterfaceWithProperties;
 import software.amazon.jsii.tests.calculator.IRandomNumberGenerator;
+import software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass;
 import software.amazon.jsii.tests.calculator.JSObjectLiteralForInterface;
 import software.amazon.jsii.tests.calculator.JSObjectLiteralToNative;
 import software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass;
@@ -817,6 +820,21 @@ public class ComplianceTest {
         assertTrue(obj.getOsPlatform().length() > 0);
         assertEquals("6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50",
             obj.cryptoSha256());
+    }
+
+    @Test
+    public void returnAbstract() {
+        AbstractClassReturner obj = new AbstractClassReturner();
+        AbstractClass obj2 = obj.giveMeAbstract();
+
+        assertEquals("Hello, John!!", obj2.abstractMethod("John"));
+        assertEquals("propFromInterfaceValue", obj2.getPropFromInterface());
+        assertEquals(42, obj2.nonAbstractMethod());
+
+        InterfaceImplementedByAbstractClass iface = obj.giveMeInterface();
+        assertEquals("propFromInterfaceValue", iface.getPropFromInterface());
+
+        assertEquals("hello-abstract-property", obj.getReturnAbstractFromProperty().getAbstractProperty());
     }
 
     static class MulTen extends Multiply {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -232,7 +233,7 @@ public final class JsiiEngine implements JsiiCallbackHandler {
     private JsiiObject createNative(final String fqn) {
         try {
             Class<?> klass = resolveJavaClass(fqn);
-            if (klass.isInterface()) {
+            if (klass.isInterface() || Modifier.isAbstract(klass.getModifiers())) {
                 // "$" is used to represent inner classes in Java
                 klass = Class.forName(klass.getCanonicalName() + "$" + INTERFACE_PROXY_CLASS_NAME);
             }

--- a/packages/jsii-kernel/package-lock.json
+++ b/packages/jsii-kernel/package-lock.json
@@ -7,7 +7,7 @@
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
 			"integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
 			"requires": {
-				"@types/node": "9.6.30"
+				"@types/node": "*"
 			}
 		},
 		"@types/node": {
@@ -25,7 +25,7 @@
 			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
 			"integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
 			"requires": {
-				"@types/node": "9.6.30"
+				"@types/node": "*"
 			}
 		},
 		"ajv": {
@@ -33,10 +33,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -54,7 +54,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -62,7 +62,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -90,9 +90,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"chalk": {
@@ -100,11 +100,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				}
 			}
@@ -120,7 +120,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -138,7 +138,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -162,9 +162,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -172,7 +172,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"supports-color": {
@@ -180,7 +180,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -218,7 +218,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -241,12 +241,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -254,8 +254,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -263,7 +263,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -290,8 +290,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -344,8 +344,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -358,9 +358,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -373,9 +373,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -388,7 +388,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"universalify": {
@@ -413,7 +413,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -421,12 +421,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -449,8 +449,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-ansi": {
@@ -458,7 +458,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -471,9 +471,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -486,8 +486,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -526,8 +526,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -577,8 +577,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -591,7 +591,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -599,7 +599,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -612,8 +612,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -648,8 +648,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -657,42 +657,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -711,7 +711,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -754,74 +754,74 @@
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -836,43 +836,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -889,7 +889,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -897,23 +897,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -926,15 +926,15 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -947,9 +947,9 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -962,36 +962,36 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -1005,8 +1005,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1025,8 +1025,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -1057,8 +1057,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1084,38 +1084,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1132,14 +1132,14 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1154,22 +1154,22 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1178,27 +1178,27 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1207,15 +1207,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1224,51 +1224,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1281,17 +1281,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1300,16 +1300,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1320,15 +1320,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1351,12 +1351,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1371,17 +1371,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1390,7 +1390,7 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1401,9 +1401,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1416,22 +1416,22 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1440,7 +1440,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1457,8 +1457,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1469,7 +1469,7 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1480,7 +1480,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1495,23 +1495,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1528,7 +1528,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1539,14 +1539,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1559,7 +1559,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1600,37 +1600,37 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1639,11 +1639,11 @@
 					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -1659,7 +1659,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -1674,7 +1674,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1686,26 +1686,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1726,15 +1726,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1745,14 +1745,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1763,14 +1763,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1783,19 +1783,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1812,7 +1812,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1823,15 +1823,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1851,18 +1851,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -1883,17 +1883,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1908,16 +1908,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1926,7 +1926,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1939,7 +1939,7 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1952,15 +1952,15 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -1971,9 +1971,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -1984,14 +1984,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2002,7 +2002,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -2013,7 +2013,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2032,9 +2032,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2049,22 +2049,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2081,25 +2081,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2112,8 +2112,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2128,7 +2128,7 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2156,21 +2156,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2185,17 +2185,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2204,7 +2204,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2223,28 +2223,28 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2253,39 +2253,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2302,7 +2302,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2313,11 +2313,11 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2328,20 +2328,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2352,8 +2352,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2364,22 +2364,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2388,8 +2388,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2400,7 +2400,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2409,14 +2409,14 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2431,11 +2431,11 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2450,23 +2450,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2475,41 +2475,41 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2518,14 +2518,14 @@
 									"version": "0.1.4",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2534,9 +2534,9 @@
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -2549,28 +2549,28 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2579,17 +2579,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2598,37 +2598,37 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2645,19 +2645,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -2670,32 +2670,32 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -2709,9 +2709,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2719,9 +2719,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2736,27 +2736,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2765,17 +2765,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2805,7 +2805,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2818,15 +2818,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2846,24 +2846,24 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2876,9 +2876,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2893,18 +2893,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2919,23 +2919,23 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2944,7 +2944,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2965,7 +2965,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -2988,7 +2988,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -3038,13 +3038,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -3052,26 +3052,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"resolve": {
@@ -3079,7 +3079,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -3087,7 +3087,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -3120,8 +3120,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3141,15 +3141,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -3163,7 +3163,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -3171,7 +3171,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -3184,35 +3184,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			}
 		},
 		"tap-mocha-reporter": {
@@ -3220,15 +3220,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -3236,9 +3236,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -3248,9 +3248,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tar": {
@@ -3258,13 +3258,13 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
 			"integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
 			"requires": {
-				"chownr": "1.0.1",
-				"fs-minipass": "1.2.5",
-				"minipass": "2.3.4",
-				"minizlib": "1.1.0",
-				"mkdirp": "0.5.1",
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"chownr": "^1.0.1",
+				"fs-minipass": "^1.2.5",
+				"minipass": "^2.3.3",
+				"minizlib": "^1.1.0",
+				"mkdirp": "^0.5.0",
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.2"
 			},
 			"dependencies": {
 				"chownr": {
@@ -3277,7 +3277,7 @@
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"requires": {
-						"minipass": "2.3.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"minimist": {
@@ -3290,8 +3290,8 @@
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 					"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 					"requires": {
-						"safe-buffer": "5.1.2",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
@@ -3299,7 +3299,7 @@
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
 					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 					"requires": {
-						"minipass": "2.3.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
@@ -3332,8 +3332,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -3356,18 +3356,18 @@
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.1",
-				"commander": "2.17.1",
-				"diff": "3.5.0",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.1",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
 				"diff": {
@@ -3382,7 +3382,7 @@
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {
@@ -3390,7 +3390,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -3409,8 +3409,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -3429,9 +3429,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -3439,7 +3439,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -3452,9 +3452,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/packages/jsii-pacmak/.gitignore
+++ b/packages/jsii-pacmak/.gitignore
@@ -1,2 +1,7 @@
 lib/version.ts
 lib/targets/dotnet-generator/
+.classpath
+.project
+.settings
+target/
+

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1,3 +1,4 @@
+import clone = require('clone');
 import fs = require('fs-extra');
 import spec = require('jsii-spec');
 import path = require('path');
@@ -195,9 +196,14 @@ class JavaGenerator extends Generator {
     }
 
     protected onEndClass(cls: spec.ClassType) {
+        if (cls.abstract) {
+            this.emitInterfaceProxy(cls);
+        }
+
         this.code.closeBlock();
         this.closeFileIfNeeded(cls);
     }
+
     protected onInitializer(cls: spec.ClassType, method: spec.Method) {
         this.addJavaDocs(method);
         this.code.openBlock(`${this.renderAccessLevel(method)} ${cls.name}(${this.renderMethodParameters(method)})`);
@@ -611,49 +617,67 @@ class JavaGenerator extends Generator {
      * able to interact with them, so we will create a proxy class which
      * implements this interface and has the same methods.
      */
-    private emitInterfaceProxy(ifc: spec.InterfaceType) {
+    private emitInterfaceProxy(ifc: spec.InterfaceType | spec.ClassType) {
         const name = INTERFACE_PROXY_CLASS_NAME;
 
         this.code.line();
         this.code.line('/**');
-        this.code.line(' * A proxy class which for javascript object literal which adhere to this interface.');
+        this.code.line(' * A proxy class which represents a concrete javascript instance of this type.');
         this.code.line(' */');
-        this.code.openBlock(`final class ${name} extends software.amazon.jsii.JsiiObject implements ${this.toNativeFqn(ifc.fqn)}`);
+
+        const suffix = ifc.kind === spec.TypeKind.Interface
+            ? `extends software.amazon.jsii.JsiiObject implements ${this.toNativeFqn(ifc.fqn)}`
+            : `extends ${this.toNativeFqn(ifc.fqn)}`;
+
+        this.code.openBlock(`final static class ${name} ${suffix}`);
         this.emitJsiiInitializers(name);
 
         // compile a list of all unique methods from the current interface and all
         // base interfaces (and their bases).
         const methods: { [name: string]: spec.Method } = {};
         const properties: { [name: string]: spec.Property } = {};
-        const collectMembers = (currentIfc: spec.InterfaceType) => {
-            for (const prop of currentIfc.properties || []) {
-                properties[prop.name] = prop;
-            }
-            for (const method of currentIfc.methods || []) {
-                methods[method.name!] = method;
-            }
-            for (const base of currentIfc.interfaces || []) {
-                const type = this.findType(base.fqn!);
-                if (type.kind !== spec.TypeKind.Interface) {
-                    throw new Error(`Base interfaces of an interface must be an interface (${base.fqn} is of type ${type.kind})`);
+        const collectAbstractMembers = (currentType: spec.InterfaceType | spec.ClassType) => {
+            for (const prop of currentType.properties || []) {
+                if (prop.abstract) {
+                    properties[prop.name] = prop;
                 }
-                collectMembers(type as spec.InterfaceType);
+            }
+            for (const method of currentType.methods || []) {
+                if (method.abstract) {
+                    methods[method.name!] = method;
+                }
+            }
+
+            const bases = new Array<spec.NamedTypeReference>();
+            bases.push(...currentType.interfaces || []);
+            if (currentType.kind === spec.TypeKind.Class && currentType.base) {
+                bases.push(currentType.base);
+            }
+            for (const base of bases) {
+                const type = this.findType(base.fqn!);
+                if (type.kind !== spec.TypeKind.Interface && type.kind !== spec.TypeKind.Class) {
+                    throw new Error(`Base interfaces of an interface must be an interface or a class (${base.fqn} is of type ${type.kind})`);
+                }
+                collectAbstractMembers(type);
             }
         };
-        collectMembers(ifc);
+        collectAbstractMembers(ifc);
 
         // emit all properties
         for (const propName of Object.keys(properties)) {
-            const prop = properties[propName];
+            const prop = clone(properties[propName]);
+            prop.abstract = false;
             this.emitProperty(ifc, prop, /* includeGetter: */ undefined, /* overrides: */ true);
         }
 
         // emit all the methods
         for (const methodName of Object.keys(methods)) {
-            const method = methods[methodName];
+            const method = clone(methods[methodName]);
+            method.abstract = false;
             this.emitMethod(ifc, method, /* overrides: */ true);
 
             for (const overloadedMethod of this.createOverloadsForOptionals(method)) {
+                overloadedMethod.abstract = false;
                 this.emitMethod(ifc, overloadedMethod, /* overrides: */ true);
             }
         }

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -12,7 +12,7 @@
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
 			"integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
 			"requires": {
-				"@types/node": "9.6.30"
+				"@types/node": "*"
 			}
 		},
 		"@types/node": {
@@ -40,10 +40,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -61,7 +61,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -69,7 +69,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -97,9 +97,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"chalk": {
@@ -107,11 +107,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				}
 			}
@@ -127,7 +127,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -145,7 +145,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -169,9 +169,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -179,7 +179,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"supports-color": {
@@ -187,7 +187,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -230,7 +230,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -253,12 +253,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -266,8 +266,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -275,7 +275,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -302,8 +302,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -356,8 +356,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -370,9 +370,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -385,9 +385,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -400,7 +400,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"universalify": {
@@ -425,7 +425,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -433,12 +433,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -461,8 +461,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-ansi": {
@@ -470,7 +470,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -483,9 +483,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -498,8 +498,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -538,8 +538,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -589,8 +589,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -603,7 +603,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -611,7 +611,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -624,8 +624,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -660,8 +660,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -669,42 +669,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -723,7 +723,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -766,74 +766,74 @@
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -848,43 +848,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -901,7 +901,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -909,23 +909,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -938,15 +938,15 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -959,9 +959,9 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -974,36 +974,36 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -1017,8 +1017,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1037,8 +1037,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -1069,8 +1069,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1096,38 +1096,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1144,14 +1144,14 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1166,22 +1166,22 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1190,27 +1190,27 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1219,15 +1219,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1236,51 +1236,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1293,17 +1293,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1312,16 +1312,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1332,15 +1332,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1363,12 +1363,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1383,17 +1383,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1402,7 +1402,7 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1413,9 +1413,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1428,22 +1428,22 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1452,7 +1452,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1469,8 +1469,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1481,7 +1481,7 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1492,7 +1492,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1507,23 +1507,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1540,7 +1540,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1551,14 +1551,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1571,7 +1571,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1612,37 +1612,37 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1651,11 +1651,11 @@
 					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -1671,7 +1671,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -1686,7 +1686,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1698,26 +1698,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1738,15 +1738,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1757,14 +1757,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1775,14 +1775,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1795,19 +1795,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1824,7 +1824,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1835,15 +1835,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1863,18 +1863,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -1895,17 +1895,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1920,16 +1920,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1938,7 +1938,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1951,7 +1951,7 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1964,15 +1964,15 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -1983,9 +1983,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -1996,14 +1996,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2014,7 +2014,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -2025,7 +2025,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2044,9 +2044,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2061,22 +2061,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2093,25 +2093,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2124,8 +2124,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2140,7 +2140,7 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2168,21 +2168,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2197,17 +2197,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2216,7 +2216,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2235,28 +2235,28 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2265,39 +2265,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2314,7 +2314,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2325,11 +2325,11 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2340,20 +2340,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2364,8 +2364,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2376,22 +2376,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2400,8 +2400,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2412,7 +2412,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2421,14 +2421,14 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2443,11 +2443,11 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2462,23 +2462,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2487,41 +2487,41 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2530,14 +2530,14 @@
 									"version": "0.1.4",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2546,9 +2546,9 @@
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -2561,28 +2561,28 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2591,17 +2591,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2610,37 +2610,37 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2657,19 +2657,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -2682,32 +2682,32 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -2721,9 +2721,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2731,9 +2731,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2748,27 +2748,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2777,17 +2777,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2817,7 +2817,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2830,15 +2830,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2858,24 +2858,24 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2888,9 +2888,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2905,18 +2905,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2931,23 +2931,23 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2956,7 +2956,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2977,7 +2977,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -3000,7 +3000,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -3050,13 +3050,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -3064,26 +3064,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"resolve": {
@@ -3091,7 +3091,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -3099,7 +3099,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -3132,8 +3132,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spdx-license-list": {
@@ -3151,15 +3151,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -3173,7 +3173,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -3181,7 +3181,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -3194,35 +3194,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			}
 		},
 		"tap-mocha-reporter": {
@@ -3230,15 +3230,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -3246,9 +3246,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -3258,9 +3258,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -3273,8 +3273,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -3297,18 +3297,18 @@
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.1",
-				"commander": "2.17.1",
-				"diff": "3.5.0",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.1",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
 				"diff": {
@@ -3323,7 +3323,7 @@
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {
@@ -3331,7 +3331,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -3350,8 +3350,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -3370,9 +3370,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -3380,7 +3380,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -3393,9 +3393,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"xmlbuilder": {
@@ -3418,18 +3418,18 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
 			"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "2.0.0",
-				"find-up": "3.0.0",
-				"get-caller-file": "1.0.3",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "4.0.0",
-				"yargs-parser": "10.1.0"
+				"cliui": "^4.0.0",
+				"decamelize": "^2.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^10.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3447,9 +3447,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
@@ -3462,9 +3462,9 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"decamelize": {
@@ -3480,13 +3480,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -3494,7 +3494,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"requires": {
-						"locate-path": "3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"get-caller-file": {
@@ -3532,7 +3532,7 @@
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"locate-path": {
@@ -3540,8 +3540,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"requires": {
-						"p-locate": "3.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -3549,8 +3549,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"mem": {
@@ -3558,7 +3558,7 @@
 					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"mimic-fn": {
@@ -3571,7 +3571,7 @@
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3584,9 +3584,9 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -3599,7 +3599,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 					"requires": {
-						"p-try": "2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
@@ -3607,7 +3607,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"requires": {
-						"p-limit": "2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
@@ -3650,7 +3650,7 @@
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -3668,8 +3668,8 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -3677,7 +3677,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-eof": {
@@ -3690,7 +3690,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -3703,8 +3703,8 @@
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3717,7 +3717,7 @@
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -3725,9 +3725,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -3735,7 +3735,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -3760,7 +3760,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
@@ -91,6 +91,7 @@
       "name": "BaseProps",
       "properties": [
         {
+          "abstract": true,
           "name": "bar",
           "type": {
             "primitive": "string"
@@ -100,5 +101,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "/t6/DercTjOI1TLjj3MowD7pZkpm70sJQdeKwQMpa9M="
+  "fingerprint": "6NsGM++itCYmctZJdOp8kPJ3CfBnajQ78wNpY+EwZIQ="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -16,4 +16,13 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
     public java.lang.Object typeName() {
         return this.jsiiCall("typeName", java.lang.Object.class);
     }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.base.Base {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -73,9 +73,9 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.base.BaseProps {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.base.BaseProps {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -193,6 +193,6 @@ BaseProps (interface)
 
    .. py:attribute:: bar
 
-      :type: string
+      :type: string *(abstract)*
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -101,6 +101,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Say hello!"
           },
@@ -123,6 +124,7 @@
       "name": "MyFirstStruct",
       "properties": [
         {
+          "abstract": true,
           "docs": {
             "comment": "An awesome number value"
           },
@@ -132,6 +134,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "A string value"
           },
@@ -141,6 +144,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "firstOptional",
           "type": {
             "collection": {
@@ -250,6 +254,7 @@
       "name": "StructWithOnlyOptionals",
       "properties": [
         {
+          "abstract": true,
           "docs": {
             "comment": "The first optional!"
           },
@@ -260,6 +265,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optional2",
           "type": {
             "optional": true,
@@ -267,6 +273,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optional3",
           "type": {
             "optional": true,
@@ -317,5 +324,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "dGLkY7rPKJjBMLQCOCj5AXR3Q1+cZcoiazcIhDUV++8="
+  "fingerprint": "PD1bhVhBjZ0dNrD8K4FK6RT+W5RhpkTEJDml/OiM7Ws="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -12,9 +12,9 @@ public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
     java.lang.String hello();
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IFriendly {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IFriendly {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -115,9 +115,9 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.MyFirstStruct {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.MyFirstStruct {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -15,4 +15,29 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
      */
     @Override
     public abstract java.lang.String toString();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.lib.Operation {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The value.
+         */
+        @Override
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+
+        /**
+         * String representation of the value.
+         */
+        @Override
+        public java.lang.String toString() {
+            return this.jsiiCall("toString", java.lang.String.class);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -113,9 +113,9 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -23,4 +23,21 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.lib.Value {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The value.
+         */
+        @Override
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -196,6 +196,7 @@ IFriendly (interface)
 
 
       :rtype: string
+      :abstract: Yes
 
 
 MyFirstStruct (interface)
@@ -235,7 +236,7 @@ MyFirstStruct (interface)
       An awesome number value
 
 
-      :type: number
+      :type: number *(abstract)*
 
 
    .. py:attribute:: astring
@@ -243,12 +244,12 @@ MyFirstStruct (interface)
       A string value
 
 
-      :type: string
+      :type: string *(abstract)*
 
 
    .. py:attribute:: firstOptional
 
-      :type: string[] or undefined
+      :type: string[] or undefined *(abstract)*
 
 
 Number
@@ -380,17 +381,17 @@ StructWithOnlyOptionals (interface)
       The first optional!
 
 
-      :type: string or undefined
+      :type: string or undefined *(abstract)*
 
 
    .. py:attribute:: optional2
 
-      :type: number or undefined
+      :type: number or undefined *(abstract)*
 
 
    .. py:attribute:: optional3
 
-      :type: boolean or undefined
+      :type: boolean or undefined *(abstract)*
 
 
 Value

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -165,6 +165,111 @@
     }
   },
   "types": {
+    "jsii-calc.AbstractClass": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "base": {
+        "fqn": "jsii-calc.AbstractClassBase"
+      },
+      "fqn": "jsii-calc.AbstractClass",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+        }
+      ],
+      "kind": "class",
+      "methods": [
+        {
+          "abstract": true,
+          "name": "abstractMethod",
+          "parameters": [
+            {
+              "name": "name",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "nonAbstractMethod",
+          "returns": {
+            "primitive": "number"
+          }
+        }
+      ],
+      "name": "AbstractClass",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "propFromInterface",
+          "overrides": {
+            "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.AbstractClassBase": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.AbstractClassBase",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "AbstractClassBase",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "abstractProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.AbstractClassReturner": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.AbstractClassReturner",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "giveMeAbstract",
+          "returns": {
+            "fqn": "jsii-calc.AbstractClass"
+          }
+        },
+        {
+          "name": "giveMeInterface",
+          "returns": {
+            "fqn": "jsii-calc.InterfaceImplementedByAbstractClass"
+          }
+        }
+      ],
+      "name": "AbstractClassReturner",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "returnAbstractFromProperty",
+          "type": {
+            "fqn": "jsii-calc.AbstractClassBase"
+          }
+        }
+      ]
+    },
     "jsii-calc.Add": {
       "assembly": "jsii-calc",
       "base": {
@@ -890,6 +995,7 @@
       "name": "CalculatorProps",
       "properties": [
         {
+          "abstract": true,
           "name": "initialValue",
           "type": {
             "optional": true,
@@ -897,6 +1003,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "maximumValue",
           "type": {
             "optional": true,
@@ -952,18 +1059,21 @@
       "name": "DerivedStruct",
       "properties": [
         {
+          "abstract": true,
           "name": "anotherRequired",
           "type": {
             "primitive": "date"
           }
         },
         {
+          "abstract": true,
           "name": "bool",
           "type": {
             "primitive": "boolean"
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "An example of a non primitive property."
           },
@@ -973,6 +1083,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "This is optional."
           },
@@ -988,6 +1099,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "optionalArray",
           "type": {
             "collection": {
@@ -1126,6 +1238,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Say farewell."
           },
@@ -1135,6 +1248,7 @@
           }
         },
         {
+          "abstract": true,
           "docs": {
             "comment": "Say goodbye.",
             "return": "A goodbye blessing."
@@ -1169,6 +1283,7 @@
       "name": "IInterfaceWithProperties",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "readOnlyString",
           "type": {
@@ -1176,6 +1291,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "readWriteString",
           "type": {
             "primitive": "string"
@@ -1196,6 +1312,7 @@
       "name": "IInterfaceWithPropertiesExtension",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1212,6 +1329,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "docs": {
             "comment": "Returns another random number.",
             "return": "A random number."
@@ -1237,9 +1355,30 @@
       "name": "ImplictBaseOfBase",
       "properties": [
         {
+          "abstract": true,
           "name": "goo",
           "type": {
             "primitive": "date"
+          }
+        }
+      ]
+    },
+    "jsii-calc.InterfaceImplementedByAbstractClass": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "comment": "awslabs/jsii#220\nAbstract return type"
+      },
+      "fqn": "jsii-calc.InterfaceImplementedByAbstractClass",
+      "kind": "interface",
+      "name": "InterfaceImplementedByAbstractClass",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "propFromInterface",
+          "type": {
+            "primitive": "string"
           }
         }
       ]
@@ -1272,6 +1411,7 @@
       "namespace": "InterfaceInNamespaceIncludesClasses",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1288,6 +1428,7 @@
       "namespace": "InterfaceInNamespaceOnlyInterface",
       "properties": [
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "primitive": "number"
@@ -1304,6 +1445,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "name": "hello",
           "parameters": [
             {
@@ -2101,6 +2243,7 @@
       "kind": "interface",
       "methods": [
         {
+          "abstract": true,
           "name": "obtainNumber",
           "returns": {
             "primitive": "number"
@@ -2110,6 +2253,7 @@
       "name": "ReturnsNumber",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "numberProp",
           "type": {
@@ -2528,6 +2672,7 @@
       "name": "UnionProperties",
       "properties": [
         {
+          "abstract": true,
           "immutable": true,
           "name": "bar",
           "type": {
@@ -2547,6 +2692,7 @@
           }
         },
         {
+          "abstract": true,
           "name": "foo",
           "type": {
             "optional": true,
@@ -2924,5 +3070,5 @@
     }
   },
   "version": "0.7.4",
-  "fingerprint": "24z7SEbRKIt7qRAyBqepDewNh+2kbwGcOBLFVu2Hgi8="
+  "fingerprint": "hajD3L82lt+a5tNLGsSr/WrmrdtMKz+aAkPIHgN3LE8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
@@ -1,0 +1,34 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(AbstractClass), "jsii-calc.AbstractClass", "[]")]
+    public abstract class AbstractClass : AbstractClassBase, IInterfaceImplementedByAbstractClass
+    {
+        protected AbstractClass(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected AbstractClass(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected AbstractClass(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("propFromInterface", "{\"primitive\":\"string\"}")]
+        public virtual string PropFromInterface
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiMethod("abstractMethod", "{\"primitive\":\"string\"}", "[{\"name\":\"name\",\"type\":{\"primitive\":\"string\"}}]")]
+        public abstract string AbstractMethod(string name);
+        [JsiiMethod("nonAbstractMethod", "{\"primitive\":\"number\"}", "[]")]
+        public virtual double NonAbstractMethod()
+        {
+            return InvokeInstanceMethod<double>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBase.cs
@@ -1,0 +1,26 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(AbstractClassBase), "jsii-calc.AbstractClassBase", "[]")]
+    public abstract class AbstractClassBase : DeputyBase
+    {
+        protected AbstractClassBase(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected AbstractClassBase(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected AbstractClassBase(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("abstractProperty", "{\"primitive\":\"string\"}")]
+        public virtual string AbstractProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
@@ -1,0 +1,38 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(AbstractClassReturner), "jsii-calc.AbstractClassReturner", "[]")]
+    public class AbstractClassReturner : DeputyBase
+    {
+        public AbstractClassReturner(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected AbstractClassReturner(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected AbstractClassReturner(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("returnAbstractFromProperty", "{\"fqn\":\"jsii-calc.AbstractClassBase\"}")]
+        public virtual AbstractClassBase ReturnAbstractFromProperty
+        {
+            get => GetInstanceProperty<AbstractClassBase>();
+        }
+
+        [JsiiMethod("giveMeAbstract", "{\"fqn\":\"jsii-calc.AbstractClass\"}", "[]")]
+        public virtual AbstractClass GiveMeAbstract()
+        {
+            return InvokeInstanceMethod<AbstractClass>(new object[]{});
+        }
+
+        [JsiiMethod("giveMeInterface", "{\"fqn\":\"jsii-calc.InterfaceImplementedByAbstractClass\"}", "[]")]
+        public virtual IInterfaceImplementedByAbstractClass GiveMeInterface()
+        {
+            return InvokeInstanceMethod<IInterfaceImplementedByAbstractClass>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClass.cs
@@ -1,0 +1,18 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>
+    /// awslabs/jsii#220
+    /// Abstract return type
+    /// </summary>
+    [JsiiInterface(typeof(IInterfaceImplementedByAbstractClass), "jsii-calc.InterfaceImplementedByAbstractClass")]
+    public interface IInterfaceImplementedByAbstractClass
+    {
+        [JsiiProperty("propFromInterface", "{\"primitive\":\"string\"}")]
+        string PropFromInterface
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClass.cs
@@ -1,0 +1,17 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>
+    /// awslabs/jsii#220
+    /// Abstract return type
+    /// </summary>
+    public class InterfaceImplementedByAbstractClass : DeputyBase, IInterfaceImplementedByAbstractClass
+    {
+        [JsiiProperty("propFromInterface", "{\"primitive\":\"string\"}", true)]
+        public string PropFromInterface
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClassProxy.cs
@@ -1,0 +1,22 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>
+    /// awslabs/jsii#220
+    /// Abstract return type
+    /// </summary>
+    [JsiiInterfaceProxy(typeof(IInterfaceImplementedByAbstractClass), "jsii-calc.InterfaceImplementedByAbstractClass")]
+    internal class InterfaceImplementedByAbstractClassProxy : DeputyBase, IInterfaceImplementedByAbstractClass
+    {
+        private InterfaceImplementedByAbstractClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("propFromInterface", "{\"primitive\":\"string\"}")]
+        public virtual string PropFromInterface
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -18,6 +18,9 @@ public final class $Module extends JsiiModule {
     @Override
     protected Class<?> resolveClass(final String fqn) throws ClassNotFoundException {
         switch (fqn) {
+            case "jsii-calc.AbstractClass": return software.amazon.jsii.tests.calculator.AbstractClass.class;
+            case "jsii-calc.AbstractClassBase": return software.amazon.jsii.tests.calculator.AbstractClassBase.class;
+            case "jsii-calc.AbstractClassReturner": return software.amazon.jsii.tests.calculator.AbstractClassReturner.class;
             case "jsii-calc.Add": return software.amazon.jsii.tests.calculator.Add.class;
             case "jsii-calc.AllTypes": return software.amazon.jsii.tests.calculator.AllTypes.class;
             case "jsii-calc.AllTypesEnum": return software.amazon.jsii.tests.calculator.AllTypesEnum.class;
@@ -37,6 +40,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.IInterfaceWithPropertiesExtension": return software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension.class;
             case "jsii-calc.IRandomNumberGenerator": return software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class;
             case "jsii-calc.ImplictBaseOfBase": return software.amazon.jsii.tests.calculator.ImplictBaseOfBase.class;
+            case "jsii-calc.InterfaceImplementedByAbstractClass": return software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass.class;
             case "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo": return software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses.Foo.class;
             case "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello": return software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses.Hello.class;
             case "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello": return software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface.Hello.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -1,0 +1,44 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClass")
+public abstract class AbstractClass extends software.amazon.jsii.tests.calculator.AbstractClassBase implements software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass {
+    protected AbstractClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+
+    public abstract java.lang.String abstractMethod(final java.lang.String name);
+
+    public java.lang.Number nonAbstractMethod() {
+        return this.jsiiCall("nonAbstractMethod", java.lang.Number.class);
+    }
+
+    @Override
+    public java.lang.String getPropFromInterface() {
+        return this.jsiiGet("propFromInterface", java.lang.String.class);
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.AbstractClass {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getPropFromInterface() {
+            return this.jsiiGet("propFromInterface", java.lang.String.class);
+        }
+
+        @Override
+        public java.lang.String getAbstractProperty() {
+            return this.jsiiGet("abstractProperty", java.lang.String.class);
+        }
+
+        @Override
+        public java.lang.String abstractMethod(final java.lang.String name) {
+            return this.jsiiCall("abstractMethod", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(name, "name is required")).toArray());
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
@@ -1,0 +1,27 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassBase")
+public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject {
+    protected AbstractClassBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+
+    public java.lang.String getAbstractProperty() {
+        return this.jsiiGet("abstractProperty", java.lang.String.class);
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.AbstractClassBase {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getAbstractProperty() {
+            return this.jsiiGet("abstractProperty", java.lang.String.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
@@ -1,0 +1,25 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassReturner")
+public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
+    protected AbstractClassReturner(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public AbstractClassReturner() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public software.amazon.jsii.tests.calculator.AbstractClass giveMeAbstract() {
+        return this.jsiiCall("giveMeAbstract", software.amazon.jsii.tests.calculator.AbstractClass.class);
+    }
+
+    public software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass giveMeInterface() {
+        return this.jsiiCall("giveMeInterface", software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass.class);
+    }
+
+    public software.amazon.jsii.tests.calculator.AbstractClassBase getReturnAbstractFromProperty() {
+        return this.jsiiGet("returnAbstractFromProperty", software.amazon.jsii.tests.calculator.AbstractClassBase.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -31,4 +31,37 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
     public software.amazon.jsii.tests.calculator.lib.Value getRhs() {
         return this.jsiiGet("rhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.BinaryOperation {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The value.
+         */
+        @Override
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+
+        /**
+         * Say hello!
+         */
+        @Override
+        public java.lang.String hello() {
+            return this.jsiiCall("hello", java.lang.String.class);
+        }
+
+        /**
+         * String representation of the value.
+         */
+        @Override
+        public java.lang.String toString() {
+            return this.jsiiCall("toString", java.lang.String.class);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -82,9 +82,9 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.CalculatorProps {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.CalculatorProps {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -228,9 +228,9 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.DerivedStruct {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.DerivedStruct {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -16,9 +16,9 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
     java.lang.String goodbye();
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlier {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlier {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
@@ -4,9 +4,9 @@ package software.amazon.jsii.tests.calculator;
 public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IRandomNumberGenerator, software.amazon.jsii.tests.calculator.lib.IFriendly {
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -69,9 +69,9 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -89,9 +89,9 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -12,9 +12,9 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
     java.lang.Number next();
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IRandomNumberGenerator {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IRandomNumberGenerator {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -94,9 +94,9 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ImplictBaseOfBase {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ImplictBaseOfBase {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceImplementedByAbstractClass.java
@@ -1,0 +1,65 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * awslabs/jsii#220
+ * Abstract return type
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface InterfaceImplementedByAbstractClass extends software.amazon.jsii.JsiiSerializable {
+    java.lang.String getPropFromInterface();
+
+    /**
+     * @return a {@link Builder} of {@link InterfaceImplementedByAbstractClass}
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link InterfaceImplementedByAbstractClass}
+     */
+    final class Builder {
+        private java.lang.String _propFromInterface;
+
+        /**
+         * Sets the value of PropFromInterface
+         * @param value the value to be set
+         * @return {@code this}
+         */
+        public Builder withPropFromInterface(final java.lang.String value) {
+            this._propFromInterface = java.util.Objects.requireNonNull(value, "propFromInterface is required");
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link InterfaceImplementedByAbstractClass}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        public InterfaceImplementedByAbstractClass build() {
+            return new InterfaceImplementedByAbstractClass() {
+                private final java.lang.String $propFromInterface = java.util.Objects.requireNonNull(_propFromInterface, "propFromInterface is required");
+
+                @Override
+                public java.lang.String getPropFromInterface() {
+                    return this.$propFromInterface;
+                }
+
+            };
+        }
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getPropFromInterface() {
+            return this.jsiiGet("propFromInterface", java.lang.String.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -52,9 +52,9 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses.Hello {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses.Hello {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -52,9 +52,9 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface.Hello {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface.Hello {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceWithOptionalMethodArguments.java
@@ -10,9 +10,9 @@ public interface InterfaceWithOptionalMethodArguments extends software.amazon.js
     void hello(final java.lang.String arg1);
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceWithOptionalMethodArguments {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceWithOptionalMethodArguments {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsNumber.java
@@ -6,9 +6,9 @@ public interface ReturnsNumber extends software.amazon.jsii.JsiiSerializable {
     java.lang.Number obtainNumber();
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ReturnsNumber {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ReturnsNumber {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -13,4 +13,29 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
     public software.amazon.jsii.tests.calculator.lib.Value getOperand() {
         return this.jsiiGet("operand", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.UnaryOperation {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The value.
+         */
+        @Override
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+
+        /**
+         * String representation of the value.
+         */
+        @Override
+        public java.lang.String toString() {
+            return this.jsiiCall("toString", java.lang.String.class);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -104,9 +104,9 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
-     * A proxy class which for javascript object literal which adhere to this interface.
+     * A proxy class which represents a concrete javascript instance of this type.
      */
-    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.UnionProperties {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.UnionProperties {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
             super(mode);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -89,4 +89,38 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
          */
         Decorated,
     }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The expression that this operation consists of.
+         * Must be implemented by derived classes.
+         */
+        @Override
+        public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
+            return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
+        }
+
+        /**
+         * The value.
+         */
+        @Override
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+
+        /**
+         * String representation of the value.
+         */
+        @Override
+        public java.lang.String toString() {
+            return this.jsiiCall("toString", java.lang.String.class);
+        }
+    }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -125,6 +125,132 @@ Reference
 
 .. py:module:: jsii-calc
 
+AbstractClass
+^^^^^^^^^^^^^
+
+.. py:class:: AbstractClass()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.AbstractClass;
+
+      .. code-tab:: javascript
+
+         const { AbstractClass } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { AbstractClass } from 'jsii-calc';
+
+
+
+   :extends: :py:class:`~jsii-calc.AbstractClassBase`
+   :implements: :py:class:`~jsii-calc.InterfaceImplementedByAbstractClass`
+   :abstract: Yes
+
+   .. py:method:: abstractMethod(name) -> string
+
+      :param name: 
+      :type name: string
+      :rtype: string
+      :abstract: Yes
+
+
+   .. py:method:: nonAbstractMethod() -> number
+
+      :rtype: number
+
+
+   .. py:attribute:: propFromInterface
+
+      :type: string *(readonly)*
+
+
+AbstractClassBase
+^^^^^^^^^^^^^^^^^
+
+.. py:class:: AbstractClassBase()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.AbstractClassBase;
+
+      .. code-tab:: javascript
+
+         const { AbstractClassBase } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { AbstractClassBase } from 'jsii-calc';
+
+
+
+   :abstract: Yes
+
+   .. py:attribute:: abstractProperty
+
+      :type: string *(readonly)* *(abstract)*
+
+
+AbstractClassReturner
+^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: AbstractClassReturner()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.AbstractClassReturner;
+
+      .. code-tab:: javascript
+
+         const { AbstractClassReturner } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { AbstractClassReturner } from 'jsii-calc';
+
+
+
+
+   .. py:method:: giveMeAbstract() -> jsii-calc.AbstractClass
+
+      :rtype: :py:class:`~jsii-calc.AbstractClass`
+
+
+   .. py:method:: giveMeInterface() -> jsii-calc.InterfaceImplementedByAbstractClass
+
+      :rtype: :py:class:`~jsii-calc.InterfaceImplementedByAbstractClass`
+
+
+   .. py:attribute:: returnAbstractFromProperty
+
+      :type: :py:class:`~jsii-calc.AbstractClassBase` *(readonly)*
+
+
 Add
 ^^^
 
@@ -697,12 +823,12 @@ CalculatorProps (interface)
 
    .. py:attribute:: initialValue
 
-      :type: number or undefined
+      :type: number or undefined *(abstract)*
 
 
    .. py:attribute:: maximumValue
 
-      :type: number or undefined
+      :type: number or undefined *(abstract)*
 
 
 
@@ -810,12 +936,12 @@ DerivedStruct (interface)
 
    .. py:attribute:: anotherRequired
 
-      :type: date
+      :type: date *(abstract)*
 
 
    .. py:attribute:: bool
 
-      :type: boolean
+      :type: boolean *(abstract)*
 
 
    .. py:attribute:: nonPrimitive
@@ -823,7 +949,7 @@ DerivedStruct (interface)
       An example of a non primitive property.
 
 
-      :type: :py:class:`~jsii-calc.DoubleTrouble`
+      :type: :py:class:`~jsii-calc.DoubleTrouble` *(abstract)*
 
 
    .. py:attribute:: anotherOptional
@@ -831,12 +957,12 @@ DerivedStruct (interface)
       This is optional.
 
 
-      :type: string => :py:class:`@scope/jsii-calc-lib.Value` or undefined
+      :type: string => :py:class:`@scope/jsii-calc-lib.Value` or undefined *(abstract)*
 
 
    .. py:attribute:: optionalArray
 
-      :type: string[] or undefined
+      :type: string[] or undefined *(abstract)*
 
 
 DoubleTrouble
@@ -986,6 +1112,7 @@ IFriendlier (interface)
 
 
       :rtype: string
+      :abstract: Yes
 
 
    .. py:method:: goodbye() -> string
@@ -995,6 +1122,7 @@ IFriendlier (interface)
 
       :return: A goodbye blessing.
       :rtype: string
+      :abstract: Yes
 
 
 IFriendlyRandomGenerator (interface)
@@ -1059,12 +1187,12 @@ IInterfaceWithProperties (interface)
 
    .. py:attribute:: readOnlyString
 
-      :type: string *(readonly)*
+      :type: string *(readonly)* *(abstract)*
 
 
    .. py:attribute:: readWriteString
 
-      :type: string
+      :type: string *(abstract)*
 
 
 IInterfaceWithPropertiesExtension (interface)
@@ -1099,7 +1227,7 @@ IInterfaceWithPropertiesExtension (interface)
 
    .. py:attribute:: foo
 
-      :type: number
+      :type: number *(abstract)*
 
 
 IRandomNumberGenerator (interface)
@@ -1141,6 +1269,7 @@ IRandomNumberGenerator (interface)
 
       :return: A random number.
       :rtype: number
+      :abstract: Yes
 
 
 ImplictBaseOfBase (interface)
@@ -1175,7 +1304,44 @@ ImplictBaseOfBase (interface)
 
    .. py:attribute:: goo
 
-      :type: date
+      :type: date *(abstract)*
+
+
+InterfaceImplementedByAbstractClass (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: InterfaceImplementedByAbstractClass
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.InterfaceImplementedByAbstractClass;
+
+      .. code-tab:: javascript
+
+         // InterfaceImplementedByAbstractClass is an interface
+
+      .. code-tab:: typescript
+
+         import { InterfaceImplementedByAbstractClass } from 'jsii-calc';
+
+
+
+   awslabs/jsii#220 Abstract return type
+
+
+
+
+   .. py:attribute:: propFromInterface
+
+      :type: string *(readonly)* *(abstract)*
 
 
 
@@ -1247,7 +1413,7 @@ Hello (interface)
 
    .. py:attribute:: foo
 
-      :type: number
+      :type: number *(abstract)*
 
 
 
@@ -1289,7 +1455,7 @@ Hello (interface)
 
    .. py:attribute:: foo
 
-      :type: number
+      :type: number *(abstract)*
 
 
 
@@ -1333,6 +1499,7 @@ InterfaceWithOptionalMethodArguments (interface)
       :type arg1: string
       :param arg2: 
       :type arg2: number or undefined
+      :abstract: Yes
 
 
 JSObjectLiteralForInterface
@@ -2213,12 +2380,13 @@ ReturnsNumber (interface)
 
    .. py:attribute:: numberProp
 
-      :type: number *(readonly)*
+      :type: number *(readonly)* *(abstract)*
 
 
    .. py:method:: obtainNumber() -> number
 
       :rtype: number
+      :abstract: Yes
 
 
 RuntimeTypeChecking
@@ -2652,12 +2820,12 @@ UnionProperties (interface)
 
    .. py:attribute:: bar
 
-      :type: string or number or :py:class:`~jsii-calc.AllTypes` *(readonly)*
+      :type: string or number or :py:class:`~jsii-calc.AllTypes` *(readonly)* *(abstract)*
 
 
    .. py:attribute:: foo
 
-      :type: string or number or undefined
+      :type: string or number or undefined *(abstract)*
 
 
 UseBundledDependency

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -12,10 +12,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -28,7 +28,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -36,7 +36,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -70,7 +70,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -88,7 +88,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -122,7 +122,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -140,12 +140,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -153,8 +153,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -162,7 +162,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -189,8 +189,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -238,8 +238,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -252,9 +252,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -277,7 +277,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -285,12 +285,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -313,8 +313,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"http-signature": {
@@ -322,9 +322,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -337,8 +337,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -372,8 +372,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -423,8 +423,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -437,7 +437,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -445,7 +445,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -458,8 +458,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -494,8 +494,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -503,42 +503,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -557,7 +557,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -600,74 +600,74 @@
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -682,43 +682,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -735,7 +735,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -743,23 +743,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -772,15 +772,15 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -793,9 +793,9 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -808,36 +808,36 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -851,8 +851,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -871,8 +871,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -903,8 +903,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -930,38 +930,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -978,14 +978,14 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1000,22 +1000,22 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1024,27 +1024,27 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1053,15 +1053,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1070,51 +1070,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1127,17 +1127,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1146,16 +1146,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1166,15 +1166,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1197,12 +1197,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1217,17 +1217,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1236,7 +1236,7 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1247,9 +1247,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1262,22 +1262,22 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1286,7 +1286,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1303,8 +1303,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1315,7 +1315,7 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1326,7 +1326,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1341,23 +1341,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1374,7 +1374,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1385,14 +1385,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1405,7 +1405,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1446,37 +1446,37 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1485,11 +1485,11 @@
 					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -1505,7 +1505,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -1520,7 +1520,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1532,26 +1532,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1572,15 +1572,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1591,14 +1591,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1609,14 +1609,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1629,19 +1629,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1658,7 +1658,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1669,15 +1669,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1697,18 +1697,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -1729,17 +1729,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1754,16 +1754,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1772,7 +1772,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1785,7 +1785,7 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1798,15 +1798,15 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -1817,9 +1817,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -1830,14 +1830,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -1848,7 +1848,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -1859,7 +1859,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -1878,9 +1878,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -1895,22 +1895,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -1927,25 +1927,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -1958,8 +1958,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -1974,7 +1974,7 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2002,21 +2002,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2031,17 +2031,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2050,7 +2050,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2069,28 +2069,28 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2099,39 +2099,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2148,7 +2148,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2159,11 +2159,11 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2174,20 +2174,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2198,8 +2198,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2210,22 +2210,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2234,8 +2234,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2246,7 +2246,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2255,14 +2255,14 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2277,11 +2277,11 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2296,23 +2296,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2321,41 +2321,41 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2364,14 +2364,14 @@
 									"version": "0.1.4",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2380,9 +2380,9 @@
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -2395,28 +2395,28 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2425,17 +2425,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2444,37 +2444,37 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2491,19 +2491,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -2516,32 +2516,32 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -2555,9 +2555,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2565,9 +2565,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2582,27 +2582,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2611,17 +2611,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2651,7 +2651,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2664,15 +2664,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2692,24 +2692,24 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2722,9 +2722,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2739,18 +2739,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2765,23 +2765,23 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2790,7 +2790,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2811,7 +2811,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -2834,7 +2834,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -2879,13 +2879,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -2893,26 +2893,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"rimraf": {
@@ -2920,7 +2920,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -2948,8 +2948,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"sprintf-js": {
@@ -2962,15 +2962,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -2984,7 +2984,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -2992,7 +2992,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"tap": {
@@ -3000,35 +3000,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			}
 		},
 		"tap-mocha-reporter": {
@@ -3036,15 +3036,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -3052,9 +3052,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -3064,9 +3064,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -3079,8 +3079,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -3098,7 +3098,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -3117,8 +3117,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -3137,9 +3137,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"wasm-loader": {
@@ -3147,8 +3147,8 @@
 			"resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
 			"integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
 			"requires": {
-				"loader-utils": "1.1.0",
-				"wasm-dce": "1.0.2"
+				"loader-utils": "^1.1.0",
+				"wasm-dce": "^1.0.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -3156,7 +3156,7 @@
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 					"requires": {
-						"@babel/highlight": "7.0.0"
+						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/core": {
@@ -3164,20 +3164,20 @@
 					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0.tgz",
 					"integrity": "sha512-nrvxS5u6QUN5gLl1GEakIcmOeoUHT1/gQtdMRq18WFURJ5osn4ppJLVSseMQo4zVWKJfBTF4muIYijXUnKlRLQ==",
 					"requires": {
-						"@babel/code-frame": "7.0.0",
-						"@babel/generator": "7.0.0",
-						"@babel/helpers": "7.0.0",
-						"@babel/parser": "7.0.0",
-						"@babel/template": "7.0.0",
-						"@babel/traverse": "7.0.0",
-						"@babel/types": "7.0.0",
-						"convert-source-map": "1.5.1",
-						"debug": "3.1.0",
-						"json5": "0.5.1",
-						"lodash": "4.17.10",
-						"resolve": "1.8.1",
-						"semver": "5.5.1",
-						"source-map": "0.5.7"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.0.0",
+						"@babel/helpers": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"convert-source-map": "^1.1.0",
+						"debug": "^3.1.0",
+						"json5": "^0.5.0",
+						"lodash": "^4.17.10",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/generator": {
@@ -3185,11 +3185,11 @@
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
 					"integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
 					"requires": {
-						"@babel/types": "7.0.0",
-						"jsesc": "2.5.1",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"@babel/types": "^7.0.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.10",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"@babel/helper-function-name": {
@@ -3197,9 +3197,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
 					"integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
 					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0",
-						"@babel/template": "7.0.0",
-						"@babel/types": "7.0.0"
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -3207,7 +3207,7 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
 					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 					"requires": {
-						"@babel/types": "7.0.0"
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -3215,7 +3215,7 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
 					"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 					"requires": {
-						"@babel/types": "7.0.0"
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/helpers": {
@@ -3223,9 +3223,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0.tgz",
 					"integrity": "sha512-jbvgR8iLZPnyk6m/UqdXYsSxbVtRi7Pd3CzB4OPwPBnmhNG1DWjiiy777NTuoyIcniszK51R40L5pgfXAfHDtw==",
 					"requires": {
-						"@babel/template": "7.0.0",
-						"@babel/traverse": "7.0.0",
-						"@babel/types": "7.0.0"
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/highlight": {
@@ -3233,9 +3233,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 					"requires": {
-						"chalk": "2.4.1",
-						"esutils": "2.0.2",
-						"js-tokens": "4.0.0"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
 					}
 				},
 				"@babel/parser": {
@@ -3248,9 +3248,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
 					"integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
 					"requires": {
-						"@babel/code-frame": "7.0.0",
-						"@babel/parser": "7.0.0",
-						"@babel/types": "7.0.0"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/traverse": {
@@ -3258,15 +3258,15 @@
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
 					"integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
 					"requires": {
-						"@babel/code-frame": "7.0.0",
-						"@babel/generator": "7.0.0",
-						"@babel/helper-function-name": "7.0.0",
-						"@babel/helper-split-export-declaration": "7.0.0",
-						"@babel/parser": "7.0.0",
-						"@babel/types": "7.0.0",
-						"debug": "3.1.0",
-						"globals": "11.7.0",
-						"lodash": "4.17.10"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.0.0",
+						"@babel/helper-function-name": "^7.0.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.10"
 					}
 				},
 				"@babel/types": {
@@ -3274,9 +3274,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
 					"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
 					"requires": {
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "2.0.0"
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.10",
+						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"ansi-styles": {
@@ -3284,7 +3284,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"babylon": {
@@ -3302,9 +3302,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"color-convert": {
@@ -3378,9 +3378,9 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
 					}
 				},
 				"lodash": {
@@ -3408,7 +3408,7 @@
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 					"requires": {
-						"path-parse": "1.0.6"
+						"path-parse": "^1.0.5"
 					}
 				},
 				"semver": {
@@ -3426,7 +3426,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"to-fast-properties": {
@@ -3444,10 +3444,10 @@
 					"resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
 					"integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
 					"requires": {
-						"@babel/core": "7.0.0",
-						"@babel/traverse": "7.0.0",
-						"@babel/types": "7.0.0",
-						"babylon": "7.0.0-beta.47",
+						"@babel/core": "^7.0.0-beta.39",
+						"@babel/traverse": "^7.0.0-beta.39",
+						"@babel/types": "^7.0.0-beta.39",
+						"babylon": "^7.0.0-beta.39",
 						"webassembly-interpreter": "0.0.30"
 					}
 				},
@@ -3461,8 +3461,8 @@
 					"resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
 					"integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
 					"requires": {
-						"@babel/code-frame": "7.0.0",
-						"long": "3.2.0",
+						"@babel/code-frame": "^7.0.0-beta.36",
+						"long": "^3.2.0",
 						"webassembly-floating-point-hex-parser": "0.1.2"
 					}
 				}
@@ -3478,26 +3478,26 @@
 				"@webassemblyjs/wasm-edit": "1.5.13",
 				"@webassemblyjs/wasm-opt": "1.5.13",
 				"@webassemblyjs/wasm-parser": "1.5.13",
-				"acorn": "5.7.2",
-				"acorn-dynamic-import": "3.0.0",
-				"ajv": "6.5.3",
-				"ajv-keywords": "3.2.0",
-				"chrome-trace-event": "1.0.0",
-				"enhanced-resolve": "4.1.0",
-				"eslint-scope": "4.0.0",
-				"json-parse-better-errors": "1.0.2",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"neo-async": "2.5.2",
-				"node-libs-browser": "2.1.0",
-				"schema-utils": "0.4.7",
-				"tapable": "1.0.0",
-				"uglifyjs-webpack-plugin": "1.3.0",
-				"watchpack": "1.6.0",
-				"webpack-sources": "1.1.0"
+				"acorn": "^5.6.2",
+				"acorn-dynamic-import": "^3.0.0",
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chrome-trace-event": "^1.0.0",
+				"enhanced-resolve": "^4.1.0",
+				"eslint-scope": "^4.0.0",
+				"json-parse-better-errors": "^1.0.2",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"micromatch": "^3.1.8",
+				"mkdirp": "~0.5.0",
+				"neo-async": "^2.5.0",
+				"node-libs-browser": "^2.0.0",
+				"schema-utils": "^0.4.4",
+				"tapable": "^1.0.0",
+				"uglifyjs-webpack-plugin": "^1.2.4",
+				"watchpack": "^1.5.0",
+				"webpack-sources": "^1.0.1"
 			},
 			"dependencies": {
 				"@webassemblyjs/ast": {
@@ -3508,8 +3508,8 @@
 						"@webassemblyjs/helper-module-context": "1.5.13",
 						"@webassemblyjs/helper-wasm-bytecode": "1.5.13",
 						"@webassemblyjs/wast-parser": "1.5.13",
-						"debug": "3.1.0",
-						"mamacro": "0.0.3"
+						"debug": "^3.1.0",
+						"mamacro": "^0.0.3"
 					}
 				},
 				"@webassemblyjs/floating-point-hex-parser": {
@@ -3527,7 +3527,7 @@
 					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.13.tgz",
 					"integrity": "sha512-v7igWf1mHcpJNbn4m7e77XOAWXCDT76Xe7Is1VQFXc4K5jRcFrl9D0NrqM4XifQ0bXiuTSkTKMYqDxu5MhNljA==",
 					"requires": {
-						"debug": "3.1.0"
+						"debug": "^3.1.0"
 					}
 				},
 				"@webassemblyjs/helper-code-frame": {
@@ -3548,8 +3548,8 @@
 					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.13.tgz",
 					"integrity": "sha512-zxJXULGPLB7r+k+wIlvGlXpT4CYppRz8fLUM/xobGHc9Z3T6qlmJD9ySJ2jknuktuuiR9AjnNpKYDECyaiX+QQ==",
 					"requires": {
-						"debug": "3.1.0",
-						"mamacro": "0.0.3"
+						"debug": "^3.1.0",
+						"mamacro": "^0.0.3"
 					}
 				},
 				"@webassemblyjs/helper-wasm-bytecode": {
@@ -3566,7 +3566,7 @@
 						"@webassemblyjs/helper-buffer": "1.5.13",
 						"@webassemblyjs/helper-wasm-bytecode": "1.5.13",
 						"@webassemblyjs/wasm-gen": "1.5.13",
-						"debug": "3.1.0"
+						"debug": "^3.1.0"
 					}
 				},
 				"@webassemblyjs/ieee754": {
@@ -3574,7 +3574,7 @@
 					"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.5.13.tgz",
 					"integrity": "sha512-TseswvXEPpG5TCBKoLx9tT7+/GMACjC1ruo09j46ULRZWYm8XHpDWaosOjTnI7kr4SRJFzA6MWoUkAB+YCGKKg==",
 					"requires": {
-						"ieee754": "1.1.12"
+						"ieee754": "^1.1.11"
 					}
 				},
 				"@webassemblyjs/leb128": {
@@ -3610,7 +3610,7 @@
 						"@webassemblyjs/wasm-opt": "1.5.13",
 						"@webassemblyjs/wasm-parser": "1.5.13",
 						"@webassemblyjs/wast-printer": "1.5.13",
-						"debug": "3.1.0"
+						"debug": "^3.1.0"
 					}
 				},
 				"@webassemblyjs/wasm-gen": {
@@ -3634,7 +3634,7 @@
 						"@webassemblyjs/helper-buffer": "1.5.13",
 						"@webassemblyjs/wasm-gen": "1.5.13",
 						"@webassemblyjs/wasm-parser": "1.5.13",
-						"debug": "3.1.0"
+						"debug": "^3.1.0"
 					}
 				},
 				"@webassemblyjs/wasm-parser": {
@@ -3660,8 +3660,8 @@
 						"@webassemblyjs/helper-api-error": "1.5.13",
 						"@webassemblyjs/helper-code-frame": "1.5.13",
 						"@webassemblyjs/helper-fsm": "1.5.13",
-						"long": "3.2.0",
-						"mamacro": "0.0.3"
+						"long": "^3.2.0",
+						"mamacro": "^0.0.3"
 					}
 				},
 				"@webassemblyjs/wast-printer": {
@@ -3671,7 +3671,7 @@
 					"requires": {
 						"@webassemblyjs/ast": "1.5.13",
 						"@webassemblyjs/wast-parser": "1.5.13",
-						"long": "3.2.0"
+						"long": "^3.2.0"
 					}
 				},
 				"acorn": {
@@ -3684,7 +3684,7 @@
 					"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 					"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 					"requires": {
-						"acorn": "5.7.2"
+						"acorn": "^5.0.0"
 					}
 				},
 				"ajv": {
@@ -3692,10 +3692,10 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
 					"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"ajv-keywords": {
@@ -3708,8 +3708,8 @@
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"requires": {
-						"micromatch": "3.1.10",
-						"normalize-path": "2.1.1"
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
 					}
 				},
 				"aproba": {
@@ -3742,9 +3742,9 @@
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 					"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.1"
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"assert": {
@@ -3795,13 +3795,13 @@
 					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3809,7 +3809,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3817,7 +3817,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -3825,7 +3825,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -3833,9 +3833,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						}
 					}
@@ -3870,7 +3870,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3879,16 +3879,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3896,7 +3896,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -3911,12 +3911,12 @@
 					"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 					"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 					"requires": {
-						"buffer-xor": "1.0.3",
-						"cipher-base": "1.0.4",
-						"create-hash": "1.2.0",
-						"evp_bytestokey": "1.0.3",
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.2"
+						"buffer-xor": "^1.0.3",
+						"cipher-base": "^1.0.0",
+						"create-hash": "^1.1.0",
+						"evp_bytestokey": "^1.0.3",
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"browserify-cipher": {
@@ -3924,9 +3924,9 @@
 					"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 					"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 					"requires": {
-						"browserify-aes": "1.2.0",
-						"browserify-des": "1.0.2",
-						"evp_bytestokey": "1.0.3"
+						"browserify-aes": "^1.0.4",
+						"browserify-des": "^1.0.0",
+						"evp_bytestokey": "^1.0.0"
 					}
 				},
 				"browserify-des": {
@@ -3934,10 +3934,10 @@
 					"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 					"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 					"requires": {
-						"cipher-base": "1.0.4",
-						"des.js": "1.0.0",
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.2"
+						"cipher-base": "^1.0.1",
+						"des.js": "^1.0.0",
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.1.2"
 					}
 				},
 				"browserify-rsa": {
@@ -3945,8 +3945,8 @@
 					"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 					"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"randombytes": "2.0.6"
+						"bn.js": "^4.1.0",
+						"randombytes": "^2.0.1"
 					}
 				},
 				"browserify-sign": {
@@ -3954,13 +3954,13 @@
 					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 					"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"browserify-rsa": "4.0.1",
-						"create-hash": "1.2.0",
-						"create-hmac": "1.1.7",
-						"elliptic": "6.4.1",
-						"inherits": "2.0.3",
-						"parse-asn1": "5.1.1"
+						"bn.js": "^4.1.1",
+						"browserify-rsa": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"create-hmac": "^1.1.2",
+						"elliptic": "^6.0.0",
+						"inherits": "^2.0.1",
+						"parse-asn1": "^5.0.0"
 					}
 				},
 				"browserify-zlib": {
@@ -3968,7 +3968,7 @@
 					"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 					"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 					"requires": {
-						"pako": "1.0.6"
+						"pako": "~1.0.5"
 					}
 				},
 				"buffer": {
@@ -3976,9 +3976,9 @@
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 					"requires": {
-						"base64-js": "1.3.0",
-						"ieee754": "1.1.12",
-						"isarray": "1.0.0"
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
 					}
 				},
 				"buffer-from": {
@@ -4001,19 +4001,19 @@
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 					"requires": {
-						"bluebird": "3.5.1",
-						"chownr": "1.0.1",
-						"glob": "7.1.3",
-						"graceful-fs": "4.1.11",
-						"lru-cache": "4.1.3",
-						"mississippi": "2.0.0",
-						"mkdirp": "0.5.1",
-						"move-concurrently": "1.0.1",
-						"promise-inflight": "1.0.1",
-						"rimraf": "2.6.2",
-						"ssri": "5.3.0",
-						"unique-filename": "1.1.0",
-						"y18n": "4.0.0"
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
 					}
 				},
 				"cache-base": {
@@ -4021,15 +4021,15 @@
 					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					}
 				},
 				"chokidar": {
@@ -4037,19 +4037,19 @@
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
 					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 					"requires": {
-						"anymatch": "2.0.0",
-						"async-each": "1.0.1",
-						"braces": "2.3.2",
-						"fsevents": "1.2.4",
-						"glob-parent": "3.1.0",
-						"inherits": "2.0.3",
-						"is-binary-path": "1.0.1",
-						"is-glob": "4.0.0",
-						"lodash.debounce": "4.0.8",
-						"normalize-path": "2.1.1",
-						"path-is-absolute": "1.0.1",
-						"readdirp": "2.1.0",
-						"upath": "1.1.0"
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.2.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"lodash.debounce": "^4.0.8",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.5"
 					}
 				},
 				"chownr": {
@@ -4062,7 +4062,7 @@
 					"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
 					"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
 					"requires": {
-						"tslib": "1.9.3"
+						"tslib": "^1.9.0"
 					}
 				},
 				"cipher-base": {
@@ -4070,8 +4070,8 @@
 					"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 					"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.2"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"class-utils": {
@@ -4079,10 +4079,10 @@
 					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4090,7 +4090,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -4100,8 +4100,8 @@
 					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commander": {
@@ -4129,10 +4129,10 @@
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"requires": {
-						"buffer-from": "1.1.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6",
-						"typedarray": "0.0.6"
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					}
 				},
 				"console-browserify": {
@@ -4140,7 +4140,7 @@
 					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 					"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 					"requires": {
-						"date-now": "0.1.4"
+						"date-now": "^0.1.4"
 					}
 				},
 				"constants-browserify": {
@@ -4153,12 +4153,12 @@
 					"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"requires": {
-						"aproba": "1.2.0",
-						"fs-write-stream-atomic": "1.0.10",
-						"iferr": "0.1.5",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
 					}
 				},
 				"copy-descriptor": {
@@ -4176,8 +4176,8 @@
 					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 					"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"elliptic": "6.4.1"
+						"bn.js": "^4.1.0",
+						"elliptic": "^6.0.0"
 					}
 				},
 				"create-hash": {
@@ -4185,11 +4185,11 @@
 					"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 					"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 					"requires": {
-						"cipher-base": "1.0.4",
-						"inherits": "2.0.3",
-						"md5.js": "1.3.4",
-						"ripemd160": "2.0.2",
-						"sha.js": "2.4.11"
+						"cipher-base": "^1.0.1",
+						"inherits": "^2.0.1",
+						"md5.js": "^1.3.4",
+						"ripemd160": "^2.0.1",
+						"sha.js": "^2.4.0"
 					}
 				},
 				"create-hmac": {
@@ -4197,12 +4197,12 @@
 					"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 					"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 					"requires": {
-						"cipher-base": "1.0.4",
-						"create-hash": "1.2.0",
-						"inherits": "2.0.3",
-						"ripemd160": "2.0.2",
-						"safe-buffer": "5.1.2",
-						"sha.js": "2.4.11"
+						"cipher-base": "^1.0.3",
+						"create-hash": "^1.1.0",
+						"inherits": "^2.0.1",
+						"ripemd160": "^2.0.0",
+						"safe-buffer": "^5.0.1",
+						"sha.js": "^2.4.8"
 					}
 				},
 				"crypto-browserify": {
@@ -4210,17 +4210,17 @@
 					"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 					"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 					"requires": {
-						"browserify-cipher": "1.0.1",
-						"browserify-sign": "4.0.4",
-						"create-ecdh": "4.0.3",
-						"create-hash": "1.2.0",
-						"create-hmac": "1.1.7",
-						"diffie-hellman": "5.0.3",
-						"inherits": "2.0.3",
-						"pbkdf2": "3.0.16",
-						"public-encrypt": "4.0.2",
-						"randombytes": "2.0.6",
-						"randomfill": "1.0.4"
+						"browserify-cipher": "^1.0.0",
+						"browserify-sign": "^4.0.0",
+						"create-ecdh": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"create-hmac": "^1.1.0",
+						"diffie-hellman": "^5.0.0",
+						"inherits": "^2.0.1",
+						"pbkdf2": "^3.0.3",
+						"public-encrypt": "^4.0.0",
+						"randombytes": "^2.0.0",
+						"randomfill": "^1.0.3"
 					}
 				},
 				"cyclist": {
@@ -4251,8 +4251,8 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
@@ -4260,7 +4260,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -4268,7 +4268,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -4276,9 +4276,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						}
 					}
@@ -4288,8 +4288,8 @@
 					"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 					"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 					"requires": {
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.1"
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"diffie-hellman": {
@@ -4297,9 +4297,9 @@
 					"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 					"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"miller-rabin": "4.0.1",
-						"randombytes": "2.0.6"
+						"bn.js": "^4.1.0",
+						"miller-rabin": "^4.0.0",
+						"randombytes": "^2.0.0"
 					}
 				},
 				"domain-browser": {
@@ -4312,10 +4312,10 @@
 					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
 					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"elliptic": {
@@ -4323,13 +4323,13 @@
 					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
 					"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"brorand": "1.1.0",
-						"hash.js": "1.1.5",
-						"hmac-drbg": "1.0.1",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.1",
-						"minimalistic-crypto-utils": "1.0.1"
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
 					}
 				},
 				"emojis-list": {
@@ -4342,7 +4342,7 @@
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"requires": {
-						"once": "1.4.0"
+						"once": "^1.4.0"
 					}
 				},
 				"enhanced-resolve": {
@@ -4350,9 +4350,9 @@
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
 					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"memory-fs": "0.4.1",
-						"tapable": "1.0.0"
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
 					}
 				},
 				"errno": {
@@ -4360,7 +4360,7 @@
 					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"requires": {
-						"prr": "1.0.1"
+						"prr": "~1.0.1"
 					}
 				},
 				"eslint-scope": {
@@ -4368,8 +4368,8 @@
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
 					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 					"requires": {
-						"esrecurse": "4.2.1",
-						"estraverse": "4.2.0"
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
 					}
 				},
 				"esrecurse": {
@@ -4377,7 +4377,7 @@
 					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 					"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 					"requires": {
-						"estraverse": "4.2.0"
+						"estraverse": "^4.1.0"
 					}
 				},
 				"estraverse": {
@@ -4395,8 +4395,8 @@
 					"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 					"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 					"requires": {
-						"md5.js": "1.3.4",
-						"safe-buffer": "5.1.2"
+						"md5.js": "^1.3.4",
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"expand-brackets": {
@@ -4404,13 +4404,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"debug": {
@@ -4426,7 +4426,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -4434,7 +4434,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4444,8 +4444,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -4453,7 +4453,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -4463,14 +4463,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4478,7 +4478,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -4486,7 +4486,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4494,7 +4494,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -4502,7 +4502,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -4510,9 +4510,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						}
 					}
@@ -4532,10 +4532,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4543,7 +4543,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4553,9 +4553,9 @@
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 					"requires": {
-						"commondir": "1.0.1",
-						"make-dir": "1.3.0",
-						"pkg-dir": "2.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -4563,7 +4563,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"flush-write-stream": {
@@ -4571,8 +4571,8 @@
 					"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
 					}
 				},
 				"for-in": {
@@ -4585,7 +4585,7 @@
 					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"from2": {
@@ -4593,8 +4593,8 @@
 					"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
 					}
 				},
 				"fs-write-stream-atomic": {
@@ -4602,10 +4602,10 @@
 					"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"iferr": "0.1.5",
-						"imurmurhash": "0.1.4",
-						"readable-stream": "2.3.6"
+						"graceful-fs": "^4.1.2",
+						"iferr": "^0.1.5",
+						"imurmurhash": "^0.1.4",
+						"readable-stream": "1 || 2"
 					}
 				},
 				"fs.realpath": {
@@ -4619,8 +4619,8 @@
 					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 					"optional": true,
 					"requires": {
-						"nan": "2.11.0",
-						"node-pre-gyp": "0.10.0"
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.10.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -4630,8 +4630,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4649,13 +4648,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4668,18 +4665,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4782,8 +4776,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4793,7 +4786,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4806,20 +4798,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4836,7 +4825,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4909,8 +4897,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4920,7 +4907,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4996,8 +4982,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -5027,7 +5012,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -5045,7 +5029,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -5084,13 +5067,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				},
@@ -5104,12 +5085,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"glob-parent": {
@@ -5117,8 +5098,8 @@
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -5126,7 +5107,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -5141,9 +5122,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					}
 				},
 				"has-values": {
@@ -5151,8 +5132,8 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5160,7 +5141,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5170,8 +5151,8 @@
 					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.2"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"hash.js": {
@@ -5179,8 +5160,8 @@
 					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
 					"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
 					"requires": {
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.1"
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.1"
 					}
 				},
 				"hmac-drbg": {
@@ -5188,9 +5169,9 @@
 					"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 					"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 					"requires": {
-						"hash.js": "1.1.5",
-						"minimalistic-assert": "1.0.1",
-						"minimalistic-crypto-utils": "1.0.1"
+						"hash.js": "^1.0.3",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.1"
 					}
 				},
 				"https-browserify": {
@@ -5223,8 +5204,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -5237,7 +5218,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5245,7 +5226,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5255,7 +5236,7 @@
 					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 					"requires": {
-						"binary-extensions": "1.11.0"
+						"binary-extensions": "^1.0.0"
 					}
 				},
 				"is-buffer": {
@@ -5268,7 +5249,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5276,7 +5257,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5286,9 +5267,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5313,7 +5294,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -5321,7 +5302,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5329,7 +5310,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5339,7 +5320,7 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"is-windows": {
@@ -5387,9 +5368,9 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
 					}
 				},
 				"locate-path": {
@@ -5397,8 +5378,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash.debounce": {
@@ -5416,8 +5397,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -5425,7 +5406,7 @@
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"mamacro": {
@@ -5443,7 +5424,7 @@
 					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5.js": {
@@ -5451,8 +5432,8 @@
 					"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 					"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 					"requires": {
-						"hash-base": "3.0.4",
-						"inherits": "2.0.3"
+						"hash-base": "^3.0.0",
+						"inherits": "^2.0.1"
 					}
 				},
 				"memory-fs": {
@@ -5460,8 +5441,8 @@
 					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 					"requires": {
-						"errno": "0.1.7",
-						"readable-stream": "2.3.6"
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
 					}
 				},
 				"micromatch": {
@@ -5469,19 +5450,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"miller-rabin": {
@@ -5489,8 +5470,8 @@
 					"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 					"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"brorand": "1.1.0"
+						"bn.js": "^4.0.0",
+						"brorand": "^1.0.1"
 					}
 				},
 				"minimalistic-assert": {
@@ -5508,7 +5489,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -5521,16 +5502,16 @@
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 					"requires": {
-						"concat-stream": "1.6.2",
-						"duplexify": "3.6.0",
-						"end-of-stream": "1.4.1",
-						"flush-write-stream": "1.0.3",
-						"from2": "2.3.0",
-						"parallel-transform": "1.1.0",
-						"pump": "2.0.1",
-						"pumpify": "1.5.1",
-						"stream-each": "1.2.3",
-						"through2": "2.0.3"
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"mixin-deep": {
@@ -5538,8 +5519,8 @@
 					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -5547,7 +5528,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -5565,12 +5546,12 @@
 					"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"requires": {
-						"aproba": "1.2.0",
-						"copy-concurrently": "1.0.5",
-						"fs-write-stream-atomic": "1.0.10",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"copy-concurrently": "^1.0.0",
+						"fs-write-stream-atomic": "^1.0.8",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.3"
 					}
 				},
 				"ms": {
@@ -5589,17 +5570,17 @@
 					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 					"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					}
 				},
 				"neo-async": {
@@ -5612,28 +5593,28 @@
 					"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 					"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 					"requires": {
-						"assert": "1.4.1",
-						"browserify-zlib": "0.2.0",
-						"buffer": "4.9.1",
-						"console-browserify": "1.1.0",
-						"constants-browserify": "1.0.0",
-						"crypto-browserify": "3.12.0",
-						"domain-browser": "1.2.0",
-						"events": "1.1.1",
-						"https-browserify": "1.0.0",
-						"os-browserify": "0.3.0",
+						"assert": "^1.1.1",
+						"browserify-zlib": "^0.2.0",
+						"buffer": "^4.3.0",
+						"console-browserify": "^1.1.0",
+						"constants-browserify": "^1.0.0",
+						"crypto-browserify": "^3.11.0",
+						"domain-browser": "^1.1.1",
+						"events": "^1.0.0",
+						"https-browserify": "^1.0.0",
+						"os-browserify": "^0.3.0",
 						"path-browserify": "0.0.0",
-						"process": "0.11.10",
-						"punycode": "1.4.1",
-						"querystring-es3": "0.2.1",
-						"readable-stream": "2.3.6",
-						"stream-browserify": "2.0.1",
-						"stream-http": "2.8.3",
-						"string_decoder": "1.1.1",
-						"timers-browserify": "2.0.10",
+						"process": "^0.11.10",
+						"punycode": "^1.2.4",
+						"querystring-es3": "^0.2.0",
+						"readable-stream": "^2.3.3",
+						"stream-browserify": "^2.0.1",
+						"stream-http": "^2.7.2",
+						"string_decoder": "^1.0.0",
+						"timers-browserify": "^2.0.4",
 						"tty-browserify": "0.0.0",
-						"url": "0.11.0",
-						"util": "0.10.4",
+						"url": "^0.11.0",
+						"util": "^0.10.3",
 						"vm-browserify": "0.0.4"
 					},
 					"dependencies": {
@@ -5649,7 +5630,7 @@
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"requires": {
-						"remove-trailing-separator": "1.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				},
 				"object-copy": {
@@ -5657,9 +5638,9 @@
 					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5667,7 +5648,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"kind-of": {
@@ -5675,7 +5656,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5685,7 +5666,7 @@
 					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					}
 				},
 				"object.pick": {
@@ -5693,7 +5674,7 @@
 					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"once": {
@@ -5701,7 +5682,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-browserify": {
@@ -5714,7 +5695,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -5722,7 +5703,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.3.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -5740,9 +5721,9 @@
 					"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"requires": {
-						"cyclist": "0.2.2",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6"
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
 					}
 				},
 				"parse-asn1": {
@@ -5750,11 +5731,11 @@
 					"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 					"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 					"requires": {
-						"asn1.js": "4.10.1",
-						"browserify-aes": "1.2.0",
-						"create-hash": "1.2.0",
-						"evp_bytestokey": "1.0.3",
-						"pbkdf2": "3.0.16"
+						"asn1.js": "^4.0.0",
+						"browserify-aes": "^1.0.0",
+						"create-hash": "^1.1.0",
+						"evp_bytestokey": "^1.0.0",
+						"pbkdf2": "^3.0.3"
 					}
 				},
 				"pascalcase": {
@@ -5787,11 +5768,11 @@
 					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
 					"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 					"requires": {
-						"create-hash": "1.2.0",
-						"create-hmac": "1.1.7",
-						"ripemd160": "2.0.2",
-						"safe-buffer": "5.1.2",
-						"sha.js": "2.4.11"
+						"create-hash": "^1.1.2",
+						"create-hmac": "^1.1.4",
+						"ripemd160": "^2.0.1",
+						"safe-buffer": "^5.0.1",
+						"sha.js": "^2.4.8"
 					}
 				},
 				"pify": {
@@ -5804,7 +5785,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"posix-character-classes": {
@@ -5842,11 +5823,11 @@
 					"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
 					"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"browserify-rsa": "4.0.1",
-						"create-hash": "1.2.0",
-						"parse-asn1": "5.1.1",
-						"randombytes": "2.0.6"
+						"bn.js": "^4.1.0",
+						"browserify-rsa": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"parse-asn1": "^5.0.0",
+						"randombytes": "^2.0.1"
 					}
 				},
 				"pump": {
@@ -5854,8 +5835,8 @@
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"once": "1.4.0"
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
 					}
 				},
 				"pumpify": {
@@ -5863,9 +5844,9 @@
 					"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 					"requires": {
-						"duplexify": "3.6.0",
-						"inherits": "2.0.3",
-						"pump": "2.0.1"
+						"duplexify": "^3.6.0",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
 					}
 				},
 				"punycode": {
@@ -5888,7 +5869,7 @@
 					"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 					"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 					"requires": {
-						"safe-buffer": "5.1.2"
+						"safe-buffer": "^5.1.0"
 					}
 				},
 				"randomfill": {
@@ -5896,8 +5877,8 @@
 					"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 					"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 					"requires": {
-						"randombytes": "2.0.6",
-						"safe-buffer": "5.1.2"
+						"randombytes": "^2.0.5",
+						"safe-buffer": "^5.1.0"
 					}
 				},
 				"readable-stream": {
@@ -5905,13 +5886,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.2",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"readdirp": {
@@ -5919,10 +5900,10 @@
 					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"minimatch": "3.0.4",
-						"readable-stream": "2.3.6",
-						"set-immediate-shim": "1.0.1"
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
 					}
 				},
 				"regex-not": {
@@ -5930,8 +5911,8 @@
 					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"remove-trailing-separator": {
@@ -5964,7 +5945,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.3"
+						"glob": "^7.0.5"
 					}
 				},
 				"ripemd160": {
@@ -5972,8 +5953,8 @@
 					"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 					"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 					"requires": {
-						"hash-base": "3.0.4",
-						"inherits": "2.0.3"
+						"hash-base": "^3.0.0",
+						"inherits": "^2.0.1"
 					}
 				},
 				"run-queue": {
@@ -5981,7 +5962,7 @@
 					"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"requires": {
-						"aproba": "1.2.0"
+						"aproba": "^1.1.1"
 					}
 				},
 				"safe-buffer": {
@@ -5994,7 +5975,7 @@
 					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"schema-utils": {
@@ -6002,8 +5983,8 @@
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
 					"requires": {
-						"ajv": "6.5.3",
-						"ajv-keywords": "3.2.0"
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0"
 					}
 				},
 				"serialize-javascript": {
@@ -6021,10 +6002,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6032,7 +6013,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -6047,8 +6028,8 @@
 					"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 					"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.2"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"snapdragon": {
@@ -6056,14 +6037,14 @@
 					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.2",
-						"use": "3.1.1"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -6079,7 +6060,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -6087,7 +6068,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -6097,9 +6078,9 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6107,7 +6088,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -6115,7 +6096,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -6123,7 +6104,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -6131,9 +6112,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						}
 					}
@@ -6143,7 +6124,7 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6151,7 +6132,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -6171,11 +6152,11 @@
 					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 					"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 					"requires": {
-						"atob": "2.1.2",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -6188,7 +6169,7 @@
 					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"ssri": {
@@ -6196,7 +6177,7 @@
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 					"requires": {
-						"safe-buffer": "5.1.2"
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"static-extend": {
@@ -6204,8 +6185,8 @@
 					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6213,7 +6194,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -6223,8 +6204,8 @@
 					"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 					"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6"
+						"inherits": "~2.0.1",
+						"readable-stream": "^2.0.2"
 					}
 				},
 				"stream-each": {
@@ -6232,8 +6213,8 @@
 					"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 					"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"stream-http": {
@@ -6241,11 +6222,11 @@
 					"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
 					"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
 					"requires": {
-						"builtin-status-codes": "3.0.0",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6",
-						"to-arraybuffer": "1.0.1",
-						"xtend": "4.0.1"
+						"builtin-status-codes": "^3.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.3.6",
+						"to-arraybuffer": "^1.0.0",
+						"xtend": "^4.0.0"
 					}
 				},
 				"stream-shift": {
@@ -6258,7 +6239,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
-						"safe-buffer": "5.1.2"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"tapable": {
@@ -6271,8 +6252,8 @@
 					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"requires": {
-						"readable-stream": "2.3.6",
-						"xtend": "4.0.1"
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
 					}
 				},
 				"timers-browserify": {
@@ -6280,7 +6261,7 @@
 					"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
 					"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 					"requires": {
-						"setimmediate": "1.0.5"
+						"setimmediate": "^1.0.4"
 					}
 				},
 				"to-arraybuffer": {
@@ -6293,7 +6274,7 @@
 					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6301,7 +6282,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -6311,10 +6292,10 @@
 					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -6322,8 +6303,8 @@
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					}
 				},
 				"tslib": {
@@ -6346,8 +6327,8 @@
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -6362,14 +6343,14 @@
 					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
 					"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
 					"requires": {
-						"cacache": "10.0.4",
-						"find-cache-dir": "1.0.0",
-						"schema-utils": "0.4.7",
-						"serialize-javascript": "1.5.0",
-						"source-map": "0.6.1",
-						"uglify-es": "3.3.9",
-						"webpack-sources": "1.1.0",
-						"worker-farm": "1.6.0"
+						"cacache": "^10.0.4",
+						"find-cache-dir": "^1.0.0",
+						"schema-utils": "^0.4.5",
+						"serialize-javascript": "^1.4.0",
+						"source-map": "^0.6.1",
+						"uglify-es": "^3.3.4",
+						"webpack-sources": "^1.1.0",
+						"worker-farm": "^1.5.2"
 					},
 					"dependencies": {
 						"source-map": {
@@ -6384,10 +6365,10 @@
 					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6395,7 +6376,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
@@ -6403,10 +6384,10 @@
 							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -6416,7 +6397,7 @@
 					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 					"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 					"requires": {
-						"unique-slug": "2.0.0"
+						"unique-slug": "^2.0.0"
 					}
 				},
 				"unique-slug": {
@@ -6424,7 +6405,7 @@
 					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"requires": {
-						"imurmurhash": "0.1.4"
+						"imurmurhash": "^0.1.4"
 					}
 				},
 				"unset-value": {
@@ -6432,8 +6413,8 @@
 					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
@@ -6441,9 +6422,9 @@
 							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -6473,7 +6454,7 @@
 					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 					"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 					"requires": {
-						"punycode": "2.1.1"
+						"punycode": "^2.1.0"
 					}
 				},
 				"urix": {
@@ -6528,9 +6509,9 @@
 					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 					"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 					"requires": {
-						"chokidar": "2.0.4",
-						"graceful-fs": "4.1.11",
-						"neo-async": "2.5.2"
+						"chokidar": "^2.0.2",
+						"graceful-fs": "^4.1.2",
+						"neo-async": "^2.5.0"
 					}
 				},
 				"webpack-sources": {
@@ -6538,8 +6519,8 @@
 					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
 					"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 					"requires": {
-						"source-list-map": "2.0.0",
-						"source-map": "0.6.1"
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -6554,7 +6535,7 @@
 					"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 					"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 					"requires": {
-						"errno": "0.1.7"
+						"errno": "~0.1.7"
 					}
 				},
 				"wrappy": {
@@ -6584,33 +6565,33 @@
 			"resolved": "https://registry.npmjs.org/webpack-command/-/webpack-command-0.2.1.tgz",
 			"integrity": "sha512-SLNUVd+kYS7IOwAN8z60xNiqn8pzFgtcVjkHY3qEzhZUiUCjiR8VD0c/bj43DDruekpT3ll/xVff4tHkX72hDg==",
 			"requires": {
-				"@webpack-contrib/config-loader": "1.2.1",
-				"@webpack-contrib/schema-utils": "1.0.0-beta.0",
-				"camelcase": "5.0.0",
-				"chalk": "2.4.1",
-				"debug": "3.1.0",
-				"decamelize": "2.0.0",
-				"enhanced-resolve": "4.1.0",
-				"import-local": "1.0.0",
-				"isobject": "3.0.1",
-				"loader-utils": "1.1.0",
-				"log-symbols": "2.2.0",
-				"loud-rejection": "1.6.0",
-				"meant": "1.0.1",
-				"meow": "5.0.0",
-				"merge-options": "1.0.1",
-				"object.values": "1.0.4",
-				"opn": "5.3.0",
-				"ora": "2.1.0",
-				"plur": "3.0.1",
-				"pretty-bytes": "5.1.0",
-				"strip-ansi": "4.0.0",
-				"text-table": "0.2.0",
-				"titleize": "1.0.1",
-				"update-notifier": "2.5.0",
-				"v8-compile-cache": "2.0.2",
-				"webpack-log": "1.2.0",
-				"wordwrap": "1.0.0"
+				"@webpack-contrib/config-loader": "^1.0.0",
+				"@webpack-contrib/schema-utils": "^1.0.0-beta.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.3.2",
+				"debug": "^3.1.0",
+				"decamelize": "^2.0.0",
+				"enhanced-resolve": "^4.0.0",
+				"import-local": "^1.0.0",
+				"isobject": "^3.0.1",
+				"loader-utils": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"loud-rejection": "^1.6.0",
+				"meant": "^1.0.1",
+				"meow": "^5.0.0",
+				"merge-options": "^1.0.0",
+				"object.values": "^1.0.4",
+				"opn": "^5.3.0",
+				"ora": "^2.1.0",
+				"plur": "^3.0.0",
+				"pretty-bytes": "^5.0.0",
+				"strip-ansi": "^4.0.0",
+				"text-table": "^0.2.0",
+				"titleize": "^1.0.1",
+				"update-notifier": "^2.3.0",
+				"v8-compile-cache": "^2.0.0",
+				"webpack-log": "^1.1.2",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
 				"@webpack-contrib/config-loader": {
@@ -6618,15 +6599,15 @@
 					"resolved": "https://registry.npmjs.org/@webpack-contrib/config-loader/-/config-loader-1.2.1.tgz",
 					"integrity": "sha512-C7XsS6bXft0aRlyt7YCLg+fm97Mb3tWd+i5fVVlEl0NW5HKy8LoXVKj3mB7ECcEHNEEdHhgzg8gxP+Or8cMj8Q==",
 					"requires": {
-						"@webpack-contrib/schema-utils": "1.0.0-beta.0",
-						"chalk": "2.4.1",
-						"cosmiconfig": "5.0.6",
-						"is-plain-obj": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"merge-options": "1.0.1",
-						"minimist": "1.2.0",
-						"resolve": "1.8.1",
-						"webpack-log": "1.2.0"
+						"@webpack-contrib/schema-utils": "^1.0.0-beta.0",
+						"chalk": "^2.1.0",
+						"cosmiconfig": "^5.0.2",
+						"is-plain-obj": "^1.1.0",
+						"loud-rejection": "^1.6.0",
+						"merge-options": "^1.0.1",
+						"minimist": "^1.2.0",
+						"resolve": "^1.6.0",
+						"webpack-log": "^1.1.2"
 					}
 				},
 				"@webpack-contrib/schema-utils": {
@@ -6634,12 +6615,12 @@
 					"resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
 					"integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
 					"requires": {
-						"ajv": "6.5.3",
-						"ajv-keywords": "3.2.0",
-						"chalk": "2.4.1",
-						"strip-ansi": "4.0.0",
-						"text-table": "0.2.0",
-						"webpack-log": "1.2.0"
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0",
+						"chalk": "^2.3.2",
+						"strip-ansi": "^4.0.0",
+						"text-table": "^0.2.0",
+						"webpack-log": "^1.1.2"
 					}
 				},
 				"ajv": {
@@ -6647,10 +6628,10 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
 					"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"ajv-keywords": {
@@ -6663,7 +6644,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 					"requires": {
-						"string-width": "2.1.1"
+						"string-width": "^2.0.0"
 					}
 				},
 				"ansi-regex": {
@@ -6676,7 +6657,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"argparse": {
@@ -6684,7 +6665,7 @@
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 					"requires": {
-						"sprintf-js": "1.0.3"
+						"sprintf-js": "~1.0.2"
 					}
 				},
 				"array-find-index": {
@@ -6707,13 +6688,13 @@
 					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 					"requires": {
-						"ansi-align": "2.0.0",
-						"camelcase": "4.1.0",
-						"chalk": "2.4.1",
-						"cli-boxes": "1.0.0",
-						"string-width": "2.1.1",
-						"term-size": "1.2.0",
-						"widest-line": "2.0.0"
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -6738,9 +6719,9 @@
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -6760,9 +6741,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"ci-info": {
@@ -6780,7 +6761,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"requires": {
-						"restore-cursor": "2.0.0"
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"cli-spinners": {
@@ -6811,12 +6792,12 @@
 					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 					"requires": {
-						"dot-prop": "4.2.0",
-						"graceful-fs": "4.1.11",
-						"make-dir": "1.3.0",
-						"unique-string": "1.0.0",
-						"write-file-atomic": "2.3.0",
-						"xdg-basedir": "3.0.0"
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
 					}
 				},
 				"core-util-is": {
@@ -6829,9 +6810,9 @@
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
 					"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
 					"requires": {
-						"is-directory": "0.3.1",
-						"js-yaml": "3.12.0",
-						"parse-json": "4.0.0"
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.9.0",
+						"parse-json": "^4.0.0"
 					}
 				},
 				"create-error-class": {
@@ -6839,7 +6820,7 @@
 					"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"requires": {
-						"capture-stack-trace": "1.0.0"
+						"capture-stack-trace": "^1.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -6847,9 +6828,9 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"crypto-random-string": {
@@ -6862,7 +6843,7 @@
 					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 					"requires": {
-						"array-find-index": "1.0.2"
+						"array-find-index": "^1.0.1"
 					}
 				},
 				"d": {
@@ -6870,7 +6851,7 @@
 					"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 					"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 					"requires": {
-						"es5-ext": "0.10.46"
+						"es5-ext": "^0.10.9"
 					}
 				},
 				"debug": {
@@ -6894,8 +6875,8 @@
 					"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 					"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 					"requires": {
-						"decamelize": "1.2.0",
-						"map-obj": "1.0.1"
+						"decamelize": "^1.1.0",
+						"map-obj": "^1.0.0"
 					},
 					"dependencies": {
 						"decamelize": {
@@ -6920,7 +6901,7 @@
 					"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"requires": {
-						"clone": "1.0.4"
+						"clone": "^1.0.2"
 					}
 				},
 				"define-properties": {
@@ -6928,7 +6909,7 @@
 					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 					"requires": {
-						"object-keys": "1.0.12"
+						"object-keys": "^1.0.12"
 					}
 				},
 				"dot-prop": {
@@ -6936,7 +6917,7 @@
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 					"requires": {
-						"is-obj": "1.0.1"
+						"is-obj": "^1.0.0"
 					}
 				},
 				"duplexer3": {
@@ -6954,9 +6935,9 @@
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
 					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"memory-fs": "0.4.1",
-						"tapable": "1.0.0"
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
 					}
 				},
 				"errno": {
@@ -6964,7 +6945,7 @@
 					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"requires": {
-						"prr": "1.0.1"
+						"prr": "~1.0.1"
 					}
 				},
 				"error-ex": {
@@ -6972,7 +6953,7 @@
 					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"es-abstract": {
@@ -6980,11 +6961,11 @@
 					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
 					"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 					"requires": {
-						"es-to-primitive": "1.1.1",
-						"function-bind": "1.1.1",
-						"has": "1.0.3",
-						"is-callable": "1.1.4",
-						"is-regex": "1.0.4"
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
 					}
 				},
 				"es-to-primitive": {
@@ -6992,9 +6973,9 @@
 					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 					"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 					"requires": {
-						"is-callable": "1.1.4",
-						"is-date-object": "1.0.1",
-						"is-symbol": "1.0.1"
+						"is-callable": "^1.1.1",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.1"
 					}
 				},
 				"es5-ext": {
@@ -7002,9 +6983,9 @@
 					"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
 					"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
 					"requires": {
-						"es6-iterator": "2.0.3",
-						"es6-symbol": "3.1.1",
-						"next-tick": "1.0.0"
+						"es6-iterator": "~2.0.3",
+						"es6-symbol": "~3.1.1",
+						"next-tick": "1"
 					}
 				},
 				"es6-iterator": {
@@ -7012,9 +6993,9 @@
 					"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 					"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 					"requires": {
-						"d": "1.0.0",
-						"es5-ext": "0.10.46",
-						"es6-symbol": "3.1.1"
+						"d": "1",
+						"es5-ext": "^0.10.35",
+						"es6-symbol": "^3.1.1"
 					}
 				},
 				"es6-symbol": {
@@ -7022,8 +7003,8 @@
 					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 					"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 					"requires": {
-						"d": "1.0.0",
-						"es5-ext": "0.10.46"
+						"d": "1",
+						"es5-ext": "~0.10.14"
 					}
 				},
 				"escape-string-regexp": {
@@ -7041,13 +7022,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"fast-deep-equal": {
@@ -7065,7 +7046,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"function-bind": {
@@ -7083,7 +7064,7 @@
 					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 					"requires": {
-						"ini": "1.3.5"
+						"ini": "^1.3.4"
 					}
 				},
 				"got": {
@@ -7091,17 +7072,17 @@
 					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"requires": {
-						"create-error-class": "3.0.2",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"is-redirect": "1.0.0",
-						"is-retry-allowed": "1.1.0",
-						"is-stream": "1.1.0",
-						"lowercase-keys": "1.0.1",
-						"safe-buffer": "5.1.2",
-						"timed-out": "4.0.1",
-						"unzip-response": "2.0.1",
-						"url-parse-lax": "1.0.0"
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -7114,7 +7095,7 @@
 					"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 					"requires": {
-						"function-bind": "1.1.1"
+						"function-bind": "^1.1.1"
 					}
 				},
 				"has-flag": {
@@ -7142,8 +7123,8 @@
 					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 					"requires": {
-						"pkg-dir": "2.0.0",
-						"resolve-cwd": "2.0.0"
+						"pkg-dir": "^2.0.0",
+						"resolve-cwd": "^2.0.0"
 					}
 				},
 				"imurmurhash": {
@@ -7181,7 +7162,7 @@
 					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-callable": {
@@ -7194,7 +7175,7 @@
 					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
 					"integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
 					"requires": {
-						"ci-info": "1.4.0"
+						"ci-info": "^1.3.0"
 					}
 				},
 				"is-date-object": {
@@ -7217,8 +7198,8 @@
 					"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 					"requires": {
-						"global-dirs": "0.1.1",
-						"is-path-inside": "1.0.1"
+						"global-dirs": "^0.1.0",
+						"is-path-inside": "^1.0.0"
 					}
 				},
 				"is-npm": {
@@ -7236,7 +7217,7 @@
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"requires": {
-						"path-is-inside": "1.0.2"
+						"path-is-inside": "^1.0.1"
 					}
 				},
 				"is-plain-obj": {
@@ -7254,7 +7235,7 @@
 					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 					"requires": {
-						"has": "1.0.3"
+						"has": "^1.0.1"
 					}
 				},
 				"is-retry-allowed": {
@@ -7297,8 +7278,8 @@
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 					"requires": {
-						"argparse": "1.0.10",
-						"esprima": "4.0.1"
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				},
 				"json-parse-better-errors": {
@@ -7321,7 +7302,7 @@
 					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 					"requires": {
-						"package-json": "4.0.1"
+						"package-json": "^4.0.0"
 					}
 				},
 				"load-json-file": {
@@ -7329,10 +7310,10 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"loader-utils": {
@@ -7340,9 +7321,9 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
 					}
 				},
 				"locate-path": {
@@ -7350,8 +7331,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"log-symbols": {
@@ -7359,7 +7340,7 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 					"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 					"requires": {
-						"chalk": "2.4.1"
+						"chalk": "^2.0.1"
 					}
 				},
 				"loglevelnext": {
@@ -7367,8 +7348,8 @@
 					"resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
 					"integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
 					"requires": {
-						"es6-symbol": "3.1.1",
-						"object.assign": "4.1.0"
+						"es6-symbol": "^3.1.1",
+						"object.assign": "^4.1.0"
 					}
 				},
 				"loud-rejection": {
@@ -7376,8 +7357,8 @@
 					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 					"requires": {
-						"currently-unhandled": "0.4.1",
-						"signal-exit": "3.0.2"
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"lowercase-keys": {
@@ -7390,8 +7371,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -7399,7 +7380,7 @@
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -7417,8 +7398,8 @@
 					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 					"requires": {
-						"errno": "0.1.7",
-						"readable-stream": "2.3.6"
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
 					}
 				},
 				"meow": {
@@ -7426,15 +7407,15 @@
 					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
 					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0",
-						"yargs-parser": "10.1.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
 					}
 				},
 				"merge-options": {
@@ -7442,7 +7423,7 @@
 					"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
 					"integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
 					"requires": {
-						"is-plain-obj": "1.1.0"
+						"is-plain-obj": "^1.1"
 					}
 				},
 				"mimic-fn": {
@@ -7460,8 +7441,8 @@
 					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 					"requires": {
-						"arrify": "1.0.1",
-						"is-plain-obj": "1.1.0"
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
 					}
 				},
 				"ms": {
@@ -7479,10 +7460,10 @@
 					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.1",
-						"validate-npm-package-license": "3.0.4"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -7490,7 +7471,7 @@
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"object-keys": {
@@ -7503,10 +7484,10 @@
 					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 					"requires": {
-						"define-properties": "1.1.3",
-						"function-bind": "1.1.1",
-						"has-symbols": "1.0.0",
-						"object-keys": "1.0.12"
+						"define-properties": "^1.1.2",
+						"function-bind": "^1.1.1",
+						"has-symbols": "^1.0.0",
+						"object-keys": "^1.0.11"
 					}
 				},
 				"object.values": {
@@ -7514,10 +7495,10 @@
 					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 					"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 					"requires": {
-						"define-properties": "1.1.3",
-						"es-abstract": "1.12.0",
-						"function-bind": "1.1.1",
-						"has": "1.0.3"
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.6.1",
+						"function-bind": "^1.1.0",
+						"has": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -7525,7 +7506,7 @@
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"opn": {
@@ -7533,7 +7514,7 @@
 					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 					"requires": {
-						"is-wsl": "1.1.0"
+						"is-wsl": "^1.1.0"
 					}
 				},
 				"ora": {
@@ -7541,12 +7522,12 @@
 					"resolved": "https://registry.npmjs.org/ora/-/ora-2.1.0.tgz",
 					"integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
 					"requires": {
-						"chalk": "2.4.1",
-						"cli-cursor": "2.1.0",
-						"cli-spinners": "1.3.1",
-						"log-symbols": "2.2.0",
-						"strip-ansi": "4.0.0",
-						"wcwidth": "1.0.1"
+						"chalk": "^2.3.1",
+						"cli-cursor": "^2.1.0",
+						"cli-spinners": "^1.1.0",
+						"log-symbols": "^2.2.0",
+						"strip-ansi": "^4.0.0",
+						"wcwidth": "^1.0.1"
 					}
 				},
 				"p-finally": {
@@ -7559,7 +7540,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -7567,7 +7548,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.3.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -7580,10 +7561,10 @@
 					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"requires": {
-						"got": "6.7.1",
-						"registry-auth-token": "3.3.2",
-						"registry-url": "3.1.0",
-						"semver": "5.5.1"
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
 					}
 				},
 				"parse-json": {
@@ -7591,8 +7572,8 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-exists": {
@@ -7620,7 +7601,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -7633,7 +7614,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"plur": {
@@ -7641,7 +7622,7 @@
 					"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
 					"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
 					"requires": {
-						"irregular-plurals": "2.0.0"
+						"irregular-plurals": "^2.0.0"
 					}
 				},
 				"prepend-http": {
@@ -7684,10 +7665,10 @@
 					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"requires": {
-						"deep-extend": "0.6.0",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					}
 				},
 				"read-pkg": {
@@ -7695,9 +7676,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -7705,8 +7686,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"readable-stream": {
@@ -7714,13 +7695,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.2",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"redent": {
@@ -7728,8 +7709,8 @@
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"registry-auth-token": {
@@ -7737,8 +7718,8 @@
 					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"requires": {
-						"rc": "1.2.8",
-						"safe-buffer": "5.1.2"
+						"rc": "^1.1.6",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"registry-url": {
@@ -7746,7 +7727,7 @@
 					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"requires": {
-						"rc": "1.2.8"
+						"rc": "^1.0.1"
 					}
 				},
 				"resolve": {
@@ -7754,7 +7735,7 @@
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 					"requires": {
-						"path-parse": "1.0.6"
+						"path-parse": "^1.0.5"
 					}
 				},
 				"resolve-cwd": {
@@ -7762,7 +7743,7 @@
 					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 					"requires": {
-						"resolve-from": "3.0.0"
+						"resolve-from": "^3.0.0"
 					}
 				},
 				"resolve-from": {
@@ -7775,8 +7756,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"safe-buffer": {
@@ -7794,7 +7775,7 @@
 					"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 					"requires": {
-						"semver": "5.5.1"
+						"semver": "^5.0.3"
 					}
 				},
 				"shebang-command": {
@@ -7802,7 +7783,7 @@
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -7820,8 +7801,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -7834,8 +7815,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -7853,8 +7834,8 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"string_decoder": {
@@ -7862,7 +7843,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
-						"safe-buffer": "5.1.2"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -7870,7 +7851,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -7898,7 +7879,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"tapable": {
@@ -7911,7 +7892,7 @@
 					"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 					"requires": {
-						"execa": "0.7.0"
+						"execa": "^0.7.0"
 					}
 				},
 				"text-table": {
@@ -7939,7 +7920,7 @@
 					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 					"requires": {
-						"crypto-random-string": "1.0.0"
+						"crypto-random-string": "^1.0.0"
 					}
 				},
 				"unzip-response": {
@@ -7952,16 +7933,16 @@
 					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
 					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 					"requires": {
-						"boxen": "1.3.0",
-						"chalk": "2.4.1",
-						"configstore": "3.1.2",
-						"import-lazy": "2.1.0",
-						"is-ci": "1.2.0",
-						"is-installed-globally": "0.1.0",
-						"is-npm": "1.0.0",
-						"latest-version": "3.1.0",
-						"semver-diff": "2.1.0",
-						"xdg-basedir": "3.0.0"
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
 					}
 				},
 				"uri-js": {
@@ -7969,7 +7950,7 @@
 					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 					"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 					"requires": {
-						"punycode": "2.1.1"
+						"punycode": "^2.1.0"
 					}
 				},
 				"url-parse-lax": {
@@ -7977,7 +7958,7 @@
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"requires": {
-						"prepend-http": "1.0.4"
+						"prepend-http": "^1.0.1"
 					}
 				},
 				"util-deprecate": {
@@ -8000,8 +7981,8 @@
 					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"wcwidth": {
@@ -8009,7 +7990,7 @@
 					"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"requires": {
-						"defaults": "1.0.3"
+						"defaults": "^1.0.3"
 					}
 				},
 				"webpack-log": {
@@ -8017,10 +7998,10 @@
 					"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
 					"integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
 					"requires": {
-						"chalk": "2.4.1",
-						"log-symbols": "2.2.0",
-						"loglevelnext": "1.0.5",
-						"uuid": "3.3.2"
+						"chalk": "^2.1.0",
+						"log-symbols": "^2.1.0",
+						"loglevelnext": "^1.0.1",
+						"uuid": "^3.1.0"
 					}
 				},
 				"which": {
@@ -8028,7 +8009,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"widest-line": {
@@ -8036,7 +8017,7 @@
 					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
 					"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 					"requires": {
-						"string-width": "2.1.1"
+						"string-width": "^2.1.1"
 					}
 				},
 				"wordwrap": {
@@ -8049,9 +8030,9 @@
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"signal-exit": "3.0.2"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"xdg-basedir": {
@@ -8074,7 +8055,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -8091,7 +8072,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -8104,9 +8085,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/packages/jsii-spec/package-lock.json
+++ b/packages/jsii-spec/package-lock.json
@@ -7,7 +7,7 @@
 			"resolved": "https://registry.npmjs.org/@types/jsonschema/-/jsonschema-1.1.1.tgz",
 			"integrity": "sha1-CHA9/gdAEOjoKRIxEVlK9zH1exo=",
 			"requires": {
-				"jsonschema": "1.2.4"
+				"jsonschema": "*"
 			}
 		},
 		"@types/node": {
@@ -25,10 +25,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -41,7 +41,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -49,7 +49,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -83,7 +83,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -101,7 +101,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -135,7 +135,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -153,12 +153,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -166,8 +166,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -175,7 +175,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -202,8 +202,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -251,8 +251,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -265,9 +265,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -290,7 +290,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -298,12 +298,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -326,8 +326,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"http-signature": {
@@ -335,9 +335,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -350,8 +350,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -385,8 +385,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -441,8 +441,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -455,7 +455,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -463,7 +463,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -476,8 +476,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -512,8 +512,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -521,42 +521,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -575,7 +575,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -618,74 +618,74 @@
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -700,43 +700,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -753,7 +753,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -761,23 +761,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -790,15 +790,15 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -811,9 +811,9 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -826,36 +826,36 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -869,8 +869,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -889,8 +889,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -921,8 +921,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -948,38 +948,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -996,14 +996,14 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1018,22 +1018,22 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1042,27 +1042,27 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1071,15 +1071,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1088,51 +1088,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1145,17 +1145,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1164,16 +1164,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1184,15 +1184,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1215,12 +1215,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1235,17 +1235,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1254,7 +1254,7 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1265,9 +1265,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1280,22 +1280,22 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1304,7 +1304,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1321,8 +1321,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1333,7 +1333,7 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1344,7 +1344,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1359,23 +1359,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1392,7 +1392,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1403,14 +1403,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1423,7 +1423,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1464,37 +1464,37 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1503,11 +1503,11 @@
 					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -1523,7 +1523,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -1538,7 +1538,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1550,26 +1550,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1590,15 +1590,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1609,14 +1609,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1627,14 +1627,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1647,19 +1647,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1676,7 +1676,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1687,15 +1687,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1715,18 +1715,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -1747,17 +1747,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1772,16 +1772,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1790,7 +1790,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1803,7 +1803,7 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1816,15 +1816,15 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -1835,9 +1835,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -1848,14 +1848,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -1866,7 +1866,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -1877,7 +1877,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -1896,9 +1896,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -1913,22 +1913,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -1945,25 +1945,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -1976,8 +1976,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -1992,7 +1992,7 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2020,21 +2020,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2049,17 +2049,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2068,7 +2068,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2087,28 +2087,28 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2117,39 +2117,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2166,7 +2166,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2177,11 +2177,11 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2192,20 +2192,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2216,8 +2216,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2228,22 +2228,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2252,8 +2252,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2264,7 +2264,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2273,14 +2273,14 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2295,11 +2295,11 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2314,23 +2314,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2339,41 +2339,41 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2382,14 +2382,14 @@
 									"version": "0.1.4",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -2398,9 +2398,9 @@
 									"version": "0.1.6",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -2413,28 +2413,28 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2443,17 +2443,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -2462,37 +2462,37 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2509,19 +2509,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -2534,32 +2534,32 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -2573,9 +2573,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2583,9 +2583,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2600,27 +2600,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2629,17 +2629,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2669,7 +2669,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2682,15 +2682,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2710,24 +2710,24 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2740,9 +2740,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2757,18 +2757,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2783,23 +2783,23 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2808,7 +2808,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2829,7 +2829,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -2852,7 +2852,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -2897,13 +2897,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -2911,26 +2911,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"rimraf": {
@@ -2938,7 +2938,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -2966,8 +2966,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"sprintf-js": {
@@ -2980,15 +2980,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -3002,7 +3002,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -3010,7 +3010,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"tap": {
@@ -3018,35 +3018,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			}
 		},
 		"tap-mocha-reporter": {
@@ -3054,15 +3054,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -3070,9 +3070,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -3082,9 +3082,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -3097,8 +3097,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -3116,7 +3116,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -3135,10 +3135,10 @@
 			"resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.27.0.tgz",
 			"integrity": "sha512-9JVb2J2OW7Ajd1ScijHmqUbbch9qAEKEk30BlkM/iYrVPuLP3X4PiA7YyX0X1FEngIhx6gVopT/uuILKg6mL2Q==",
 			"requires": {
-				"glob": "7.1.3",
-				"json-stable-stringify": "1.0.1",
-				"typescript": "2.8.4",
-				"yargs": "11.1.0"
+				"glob": "~7.1.2",
+				"json-stable-stringify": "^1.0.1",
+				"typescript": "~2.8.3",
+				"yargs": "^11.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3156,7 +3156,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3170,9 +3170,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
@@ -3190,9 +3190,9 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"decamelize": {
@@ -3205,13 +3205,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -3219,7 +3219,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"fs.realpath": {
@@ -3242,12 +3242,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"inflight": {
@@ -3255,8 +3255,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -3289,7 +3289,7 @@
 					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				},
 				"jsonify": {
@@ -3302,7 +3302,7 @@
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"locate-path": {
@@ -3310,8 +3310,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -3319,8 +3319,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"mem": {
@@ -3328,7 +3328,7 @@
 					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"mimic-fn": {
@@ -3341,7 +3341,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"npm-run-path": {
@@ -3349,7 +3349,7 @@
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3362,7 +3362,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-locale": {
@@ -3370,9 +3370,9 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -3385,7 +3385,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -3393,7 +3393,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.3.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -3441,7 +3441,7 @@
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -3459,8 +3459,8 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -3468,7 +3468,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-eof": {
@@ -3486,7 +3486,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -3499,8 +3499,8 @@
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3513,7 +3513,7 @@
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -3521,9 +3521,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -3531,7 +3531,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -3556,18 +3556,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
@@ -3575,7 +3575,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -3585,8 +3585,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -3605,9 +3605,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -3615,7 +3615,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -3628,9 +3628,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/packages/jsii/package-lock.json
+++ b/packages/jsii/package-lock.json
@@ -16,10 +16,10 @@
 			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
 			"requires": {
 				"@babel/types": "7.0.0-beta.51",
-				"jsesc": "2.5.1",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -60,9 +60,9 @@
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
 			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"@babel/parser": {
@@ -78,7 +78,7 @@
 				"@babel/code-frame": "7.0.0-beta.51",
 				"@babel/parser": "7.0.0-beta.51",
 				"@babel/types": "7.0.0-beta.51",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/traverse": {
@@ -92,10 +92,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
 				"@babel/parser": "7.0.0-beta.51",
 				"@babel/types": "7.0.0-beta.51",
-				"debug": "3.1.0",
-				"globals": "11.7.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
 			},
 			"dependencies": {
 				"debug": {
@@ -113,9 +113,9 @@
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
 			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
 			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "2.0.0"
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@types/clone": {
@@ -128,7 +128,7 @@
 			"resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
 			"integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
 			"requires": {
-				"colors": "1.3.2"
+				"colors": "*"
 			}
 		},
 		"@types/deep-equal": {
@@ -141,7 +141,7 @@
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
 			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
 			"requires": {
-				"@types/node": "8.10.28"
+				"@types/node": "*"
 			}
 		},
 		"@types/log4js": {
@@ -149,7 +149,7 @@
 			"resolved": "https://registry.npmjs.org/@types/log4js/-/log4js-2.3.5.tgz",
 			"integrity": "sha512-SwF8LkSHqHy9A8GQ67NAYJiGl8zzP4Qtx65Wa+IOxDGdMHxKeoQZjg7m2M1erIT6VK0DYHpu2aTbdLkdkuMHjw==",
 			"requires": {
-				"log4js": "3.0.5"
+				"log4js": "*"
 			}
 		},
 		"@types/node": {
@@ -177,10 +177,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -193,7 +193,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argparse": {
@@ -201,7 +201,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -209,7 +209,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -243,7 +243,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -261,7 +261,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -285,9 +285,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"clean-yaml-object": {
@@ -333,7 +333,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -351,12 +351,12 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -364,8 +364,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -373,7 +373,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -405,8 +405,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -459,8 +459,8 @@
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -473,9 +473,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -488,9 +488,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
 			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -503,7 +503,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"universalify": {
@@ -528,7 +528,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -536,12 +536,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"globals": {
@@ -569,8 +569,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -583,9 +583,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -598,8 +598,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -612,7 +612,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "1.4.0"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -651,8 +651,8 @@
 				"@babel/template": "7.0.0-beta.51",
 				"@babel/traverse": "7.0.0-beta.51",
 				"@babel/types": "7.0.0-beta.51",
-				"istanbul-lib-coverage": "2.0.1",
-				"semver": "5.5.1"
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
 			}
 		},
 		"js-tokens": {
@@ -665,8 +665,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -726,10 +726,10 @@
 			"resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.5.tgz",
 			"integrity": "sha512-IX5c3G/7fuTtdr0JjOT2OIR12aTESVhsH6cEsijloYwKgcPRlO6DgOU72v0UFhWcoV1HN6+M3dwT89qVPLXm0w==",
 			"requires": {
-				"circular-json": "0.5.5",
-				"date-format": "1.2.0",
-				"debug": "3.1.0",
-				"rfdc": "1.1.2",
+				"circular-json": "^0.5.5",
+				"date-format": "^1.2.0",
+				"debug": "^3.1.0",
+				"rfdc": "^1.1.2",
 				"streamroller": "0.7.0"
 			},
 			"dependencies": {
@@ -794,13 +794,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.2",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rfdc": {
@@ -818,10 +818,10 @@
 					"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
 					"integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
 					"requires": {
-						"date-format": "1.2.0",
-						"debug": "3.1.0",
-						"mkdirp": "0.5.1",
-						"readable-stream": "2.3.6"
+						"date-format": "^1.2.0",
+						"debug": "^3.1.0",
+						"mkdirp": "^0.5.1",
+						"readable-stream": "^2.3.0"
 					}
 				},
 				"string_decoder": {
@@ -829,7 +829,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
-						"safe-buffer": "5.1.2"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"util-deprecate": {
@@ -844,7 +844,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"lru-cache": {
@@ -852,8 +852,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -866,7 +866,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -874,7 +874,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -887,8 +887,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -923,8 +923,8 @@
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
@@ -932,42 +932,42 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
 			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "2.3.2",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.5",
-				"istanbul-reports": "1.4.1",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^2.1.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.5",
+				"istanbul-reports": "^1.4.1",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -982,7 +982,7 @@
 					"version": "0.4.0",
 					"bundled": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -1029,43 +1029,43 @@
 					"version": "0.11.2",
 					"bundled": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1078,7 +1078,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -1086,23 +1086,23 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1115,24 +1115,24 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -1145,25 +1145,25 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1173,8 +1173,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1193,8 +1193,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -1221,8 +1221,8 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1248,38 +1248,38 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1292,29 +1292,29 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.1"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1323,13 +1323,13 @@
 					"version": "2.1.4",
 					"bundled": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"debug": {
@@ -1343,14 +1343,14 @@
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1359,15 +1359,15 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1376,51 +1376,51 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1433,17 +1433,17 @@
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1452,16 +1452,16 @@
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1472,15 +1472,15 @@
 					"version": "1.5.6",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1503,12 +1503,12 @@
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -1519,17 +1519,17 @@
 					"version": "4.0.11",
 					"bundled": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1538,24 +1538,24 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1572,8 +1572,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1588,7 +1588,7 @@
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1603,23 +1603,23 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1640,14 +1640,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1660,7 +1660,7 @@
 					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"is-stream": {
@@ -1695,17 +1695,17 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"has-flag": {
@@ -1716,7 +1716,7 @@
 							"version": "3.2.3",
 							"bundled": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -1725,25 +1725,25 @@
 					"version": "1.2.5",
 					"bundled": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					}
 				},
 				"istanbul-reports": {
 					"version": "1.4.1",
 					"bundled": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1755,26 +1755,26 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -1791,8 +1791,8 @@
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -1803,14 +1803,14 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -1821,14 +1821,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1841,19 +1841,19 @@
 					"version": "3.1.10",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1870,7 +1870,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -1881,15 +1881,15 @@
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1909,18 +1909,18 @@
 					"version": "1.2.9",
 					"bundled": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1933,17 +1933,17 @@
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -1958,16 +1958,16 @@
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -1976,29 +1976,29 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2009,9 +2009,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -2022,14 +2022,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2040,7 +2040,7 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -2051,7 +2051,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2070,9 +2070,9 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2087,22 +2087,22 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2119,25 +2119,25 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2146,8 +2146,8 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2183,21 +2183,21 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2212,17 +2212,17 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2231,7 +2231,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2250,14 +2250,14 @@
 					"version": "0.8.2",
 					"bundled": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.2",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -2271,14 +2271,14 @@
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2287,39 +2287,39 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -2332,7 +2332,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2343,11 +2343,11 @@
 					"version": "0.5.2",
 					"bundled": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2358,20 +2358,20 @@
 					"version": "1.4.2",
 					"bundled": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.1"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2382,8 +2382,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2394,22 +2394,22 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2418,22 +2418,22 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -2444,36 +2444,36 @@
 					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					}
 				},
 				"uglify-js": {
@@ -2481,9 +2481,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -2491,9 +2491,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2508,27 +2508,27 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -2537,17 +2537,17 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -2573,7 +2573,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2586,15 +2586,15 @@
 					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -2614,8 +2614,8 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -2626,23 +2626,23 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -2655,9 +2655,9 @@
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -2672,18 +2672,18 @@
 					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2694,16 +2694,16 @@
 							"version": "4.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -2712,7 +2712,7 @@
 					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -2733,7 +2733,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -2756,7 +2756,7 @@
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -2801,13 +2801,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -2815,26 +2815,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"rimraf": {
@@ -2842,7 +2842,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -2870,9 +2870,9 @@
 			"resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.0.tgz",
 			"integrity": "sha512-OgXPErPJM/rBK5OhzIJ+etib/BmLQ1JY55Nb/ElhoWUec62pXNF/X6DrecHq3NW5OAGX0KxYD7m0HtgB9dvGeA==",
 			"requires": {
-				"detect-indent": "5.0.0",
-				"detect-newline": "2.1.0",
-				"minimist": "1.2.0"
+				"detect-indent": "^5.0.0",
+				"detect-newline": "^2.1.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -2902,8 +2902,8 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spdx-license-list": {
@@ -2921,15 +2921,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -2943,7 +2943,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -2951,7 +2951,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -2959,7 +2959,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"tap": {
@@ -2967,35 +2967,35 @@
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			},
 			"dependencies": {
 				"nyc": {
@@ -3003,42 +3003,42 @@
 					"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 					"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 					"requires": {
-						"archy": "1.0.0",
-						"arrify": "1.0.1",
-						"caching-transform": "1.0.1",
-						"convert-source-map": "1.5.1",
-						"debug-log": "1.0.1",
-						"default-require-extensions": "1.0.0",
-						"find-cache-dir": "0.1.1",
-						"find-up": "2.1.0",
-						"foreground-child": "1.5.6",
-						"glob": "7.1.2",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-hook": "1.1.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-report": "1.1.3",
-						"istanbul-lib-source-maps": "1.2.3",
-						"istanbul-reports": "1.4.0",
-						"md5-hex": "1.3.0",
-						"merge-source-map": "1.1.0",
-						"micromatch": "3.1.10",
-						"mkdirp": "0.5.1",
-						"resolve-from": "2.0.0",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"spawn-wrap": "1.4.2",
-						"test-exclude": "4.2.1",
+						"archy": "^1.0.0",
+						"arrify": "^1.0.1",
+						"caching-transform": "^1.0.0",
+						"convert-source-map": "^1.5.1",
+						"debug-log": "^1.0.1",
+						"default-require-extensions": "^1.0.0",
+						"find-cache-dir": "^0.1.1",
+						"find-up": "^2.1.0",
+						"foreground-child": "^1.5.3",
+						"glob": "^7.0.6",
+						"istanbul-lib-coverage": "^1.1.2",
+						"istanbul-lib-hook": "^1.1.0",
+						"istanbul-lib-instrument": "^1.10.0",
+						"istanbul-lib-report": "^1.1.3",
+						"istanbul-lib-source-maps": "^1.2.3",
+						"istanbul-reports": "^1.4.0",
+						"md5-hex": "^1.2.0",
+						"merge-source-map": "^1.1.0",
+						"micromatch": "^3.1.10",
+						"mkdirp": "^0.5.0",
+						"resolve-from": "^2.0.0",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.1",
+						"spawn-wrap": "^1.4.2",
+						"test-exclude": "^4.2.0",
 						"yargs": "11.1.0",
-						"yargs-parser": "8.1.0"
+						"yargs-parser": "^8.0.0"
 					},
 					"dependencies": {
 						"align-text": {
 							"version": "0.1.4",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2",
-								"longest": "1.0.1",
-								"repeat-string": "1.6.1"
+								"kind-of": "^3.0.2",
+								"longest": "^1.0.1",
+								"repeat-string": "^1.5.2"
 							}
 						},
 						"amdefine": {
@@ -3057,7 +3057,7 @@
 							"version": "0.4.0",
 							"bundled": true,
 							"requires": {
-								"default-require-extensions": "1.0.0"
+								"default-require-extensions": "^1.0.0"
 							}
 						},
 						"archy": {
@@ -3100,74 +3100,74 @@
 							"version": "6.26.0",
 							"bundled": true,
 							"requires": {
-								"chalk": "1.1.3",
-								"esutils": "2.0.2",
-								"js-tokens": "3.0.2"
+								"chalk": "^1.1.3",
+								"esutils": "^2.0.2",
+								"js-tokens": "^3.0.2"
 							}
 						},
 						"babel-generator": {
 							"version": "6.26.1",
 							"bundled": true,
 							"requires": {
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"detect-indent": "4.0.0",
-								"jsesc": "1.3.0",
-								"lodash": "4.17.10",
-								"source-map": "0.5.7",
-								"trim-right": "1.0.1"
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"detect-indent": "^4.0.0",
+								"jsesc": "^1.3.0",
+								"lodash": "^4.17.4",
+								"source-map": "^0.5.7",
+								"trim-right": "^1.0.1"
 							}
 						},
 						"babel-messages": {
 							"version": "6.23.0",
 							"bundled": true,
 							"requires": {
-								"babel-runtime": "6.26.0"
+								"babel-runtime": "^6.22.0"
 							}
 						},
 						"babel-runtime": {
 							"version": "6.26.0",
 							"bundled": true,
 							"requires": {
-								"core-js": "2.5.6",
-								"regenerator-runtime": "0.11.1"
+								"core-js": "^2.4.0",
+								"regenerator-runtime": "^0.11.0"
 							}
 						},
 						"babel-template": {
 							"version": "6.26.0",
 							"bundled": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"lodash": "4.17.10"
+								"babel-runtime": "^6.26.0",
+								"babel-traverse": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-traverse": {
 							"version": "6.26.0",
 							"bundled": true,
 							"requires": {
-								"babel-code-frame": "6.26.0",
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"debug": "2.6.9",
-								"globals": "9.18.0",
-								"invariant": "2.2.4",
-								"lodash": "4.17.10"
+								"babel-code-frame": "^6.26.0",
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"debug": "^2.6.8",
+								"globals": "^9.18.0",
+								"invariant": "^2.2.2",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-types": {
 							"version": "6.26.0",
 							"bundled": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"esutils": "2.0.2",
-								"lodash": "4.17.10",
-								"to-fast-properties": "1.0.3"
+								"babel-runtime": "^6.26.0",
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.4",
+								"to-fast-properties": "^1.0.3"
 							}
 						},
 						"babylon": {
@@ -3182,43 +3182,43 @@
 							"version": "0.11.2",
 							"bundled": true,
 							"requires": {
-								"cache-base": "1.0.1",
-								"class-utils": "0.3.6",
-								"component-emitter": "1.2.1",
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"mixin-deep": "1.3.1",
-								"pascalcase": "0.1.1"
+								"cache-base": "^1.0.1",
+								"class-utils": "^0.3.5",
+								"component-emitter": "^1.2.1",
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.1",
+								"mixin-deep": "^1.2.0",
+								"pascalcase": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -3235,7 +3235,7 @@
 							"version": "1.1.11",
 							"bundled": true,
 							"requires": {
-								"balanced-match": "1.0.0",
+								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
 							}
 						},
@@ -3243,23 +3243,23 @@
 							"version": "2.3.2",
 							"bundled": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3272,15 +3272,15 @@
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"collection-visit": "1.0.0",
-								"component-emitter": "1.2.1",
-								"get-value": "2.0.6",
-								"has-value": "1.0.0",
-								"isobject": "3.0.1",
-								"set-value": "2.0.0",
-								"to-object-path": "0.3.0",
-								"union-value": "1.0.0",
-								"unset-value": "1.0.0"
+								"collection-visit": "^1.0.0",
+								"component-emitter": "^1.2.1",
+								"get-value": "^2.0.6",
+								"has-value": "^1.0.0",
+								"isobject": "^3.0.1",
+								"set-value": "^2.0.0",
+								"to-object-path": "^0.3.0",
+								"union-value": "^1.0.0",
+								"unset-value": "^1.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3293,9 +3293,9 @@
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"md5-hex": "1.3.0",
-								"mkdirp": "0.5.1",
-								"write-file-atomic": "1.3.4"
+								"md5-hex": "^1.2.0",
+								"mkdirp": "^0.5.1",
+								"write-file-atomic": "^1.1.4"
 							}
 						},
 						"camelcase": {
@@ -3308,36 +3308,36 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4",
-								"lazy-cache": "1.0.4"
+								"align-text": "^0.1.3",
+								"lazy-cache": "^1.0.3"
 							}
 						},
 						"chalk": {
 							"version": "1.1.3",
 							"bundled": true,
 							"requires": {
-								"ansi-styles": "2.2.1",
-								"escape-string-regexp": "1.0.5",
-								"has-ansi": "2.0.0",
-								"strip-ansi": "3.0.1",
-								"supports-color": "2.0.0"
+								"ansi-styles": "^2.2.1",
+								"escape-string-regexp": "^1.0.2",
+								"has-ansi": "^2.0.0",
+								"strip-ansi": "^3.0.0",
+								"supports-color": "^2.0.0"
 							}
 						},
 						"class-utils": {
 							"version": "0.3.6",
 							"bundled": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"define-property": "0.2.5",
-								"isobject": "3.0.1",
-								"static-extend": "0.1.2"
+								"arr-union": "^3.1.0",
+								"define-property": "^0.2.5",
+								"isobject": "^3.0.0",
+								"static-extend": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"isobject": {
@@ -3351,8 +3351,8 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"center-align": "0.1.3",
-								"right-align": "0.1.3",
+								"center-align": "^0.1.1",
+								"right-align": "^0.1.1",
 								"wordwrap": "0.0.2"
 							},
 							"dependencies": {
@@ -3371,8 +3371,8 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"map-visit": "1.0.0",
-								"object-visit": "1.0.1"
+								"map-visit": "^1.0.0",
+								"object-visit": "^1.0.0"
 							}
 						},
 						"commondir": {
@@ -3403,8 +3403,8 @@
 							"version": "4.0.2",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"which": "^1.2.9"
 							}
 						},
 						"debug": {
@@ -3430,38 +3430,38 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"strip-bom": "2.0.0"
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"define-property": {
 							"version": "2.0.2",
 							"bundled": true,
 							"requires": {
-								"is-descriptor": "1.0.2",
-								"isobject": "3.0.1"
+								"is-descriptor": "^1.0.2",
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -3478,14 +3478,14 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"error-ex": {
 							"version": "1.3.1",
 							"bundled": true,
 							"requires": {
-								"is-arrayish": "0.2.1"
+								"is-arrayish": "^0.2.1"
 							}
 						},
 						"escape-string-regexp": {
@@ -3500,22 +3500,22 @@
 							"version": "0.7.0",
 							"bundled": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							},
 							"dependencies": {
 								"cross-spawn": {
 									"version": "5.1.0",
 									"bundled": true,
 									"requires": {
-										"lru-cache": "4.1.3",
-										"shebang-command": "1.2.0",
-										"which": "1.3.0"
+										"lru-cache": "^4.0.1",
+										"shebang-command": "^1.2.0",
+										"which": "^1.2.9"
 									}
 								}
 							}
@@ -3524,27 +3524,27 @@
 							"version": "2.1.4",
 							"bundled": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3553,15 +3553,15 @@
 							"version": "3.0.2",
 							"bundled": true,
 							"requires": {
-								"assign-symbols": "1.0.0",
-								"is-extendable": "1.0.1"
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
 									"version": "1.0.1",
 									"bundled": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -3570,51 +3570,51 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"kind-of": {
@@ -3627,17 +3627,17 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3646,16 +3646,16 @@
 							"version": "0.1.1",
 							"bundled": true,
 							"requires": {
-								"commondir": "1.0.1",
-								"mkdirp": "0.5.1",
-								"pkg-dir": "1.0.0"
+								"commondir": "^1.0.1",
+								"mkdirp": "^0.5.1",
+								"pkg-dir": "^1.0.0"
 							}
 						},
 						"find-up": {
 							"version": "2.1.0",
 							"bundled": true,
 							"requires": {
-								"locate-path": "2.0.0"
+								"locate-path": "^2.0.0"
 							}
 						},
 						"for-in": {
@@ -3666,15 +3666,15 @@
 							"version": "1.5.6",
 							"bundled": true,
 							"requires": {
-								"cross-spawn": "4.0.2",
-								"signal-exit": "3.0.2"
+								"cross-spawn": "^4",
+								"signal-exit": "^3.0.0"
 							}
 						},
 						"fragment-cache": {
 							"version": "0.2.1",
 							"bundled": true,
 							"requires": {
-								"map-cache": "0.2.2"
+								"map-cache": "^0.2.2"
 							}
 						},
 						"fs.realpath": {
@@ -3697,12 +3697,12 @@
 							"version": "7.1.2",
 							"bundled": true,
 							"requires": {
-								"fs.realpath": "1.0.0",
-								"inflight": "1.0.6",
-								"inherits": "2.0.3",
-								"minimatch": "3.0.4",
-								"once": "1.4.0",
-								"path-is-absolute": "1.0.1"
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
 							}
 						},
 						"globals": {
@@ -3717,17 +3717,17 @@
 							"version": "4.0.11",
 							"bundled": true,
 							"requires": {
-								"async": "1.5.2",
-								"optimist": "0.6.1",
-								"source-map": "0.4.4",
-								"uglify-js": "2.8.29"
+								"async": "^1.4.0",
+								"optimist": "^0.6.1",
+								"source-map": "^0.4.4",
+								"uglify-js": "^2.6"
 							},
 							"dependencies": {
 								"source-map": {
 									"version": "0.4.4",
 									"bundled": true,
 									"requires": {
-										"amdefine": "1.0.1"
+										"amdefine": ">=0.0.4"
 									}
 								}
 							}
@@ -3736,7 +3736,7 @@
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"has-flag": {
@@ -3747,9 +3747,9 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "1.0.0",
-								"isobject": "3.0.1"
+								"get-value": "^2.0.6",
+								"has-values": "^1.0.0",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3762,22 +3762,22 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"kind-of": "4.0.0"
+								"is-number": "^3.0.0",
+								"kind-of": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -3786,7 +3786,7 @@
 									"version": "4.0.0",
 									"bundled": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -3803,8 +3803,8 @@
 							"version": "1.0.6",
 							"bundled": true,
 							"requires": {
-								"once": "1.4.0",
-								"wrappy": "1.0.2"
+								"once": "^1.3.0",
+								"wrappy": "1"
 							}
 						},
 						"inherits": {
@@ -3815,7 +3815,7 @@
 							"version": "2.2.4",
 							"bundled": true,
 							"requires": {
-								"loose-envify": "1.3.1"
+								"loose-envify": "^1.0.0"
 							}
 						},
 						"invert-kv": {
@@ -3826,7 +3826,7 @@
 							"version": "0.1.6",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-arrayish": {
@@ -3841,23 +3841,23 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"builtin-modules": "1.1.1"
+								"builtin-modules": "^1.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3874,7 +3874,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"is-fullwidth-code-point": {
@@ -3885,14 +3885,14 @@
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-odd": {
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"is-number": "4.0.0"
+								"is-number": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
@@ -3905,7 +3905,7 @@
 							"version": "2.0.4",
 							"bundled": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3946,37 +3946,37 @@
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"append-transform": "0.4.0"
+								"append-transform": "^0.4.0"
 							}
 						},
 						"istanbul-lib-instrument": {
 							"version": "1.10.1",
 							"bundled": true,
 							"requires": {
-								"babel-generator": "6.26.1",
-								"babel-template": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"semver": "5.5.0"
+								"babel-generator": "^6.18.0",
+								"babel-template": "^6.16.0",
+								"babel-traverse": "^6.18.0",
+								"babel-types": "^6.18.0",
+								"babylon": "^6.18.0",
+								"istanbul-lib-coverage": "^1.2.0",
+								"semver": "^5.3.0"
 							}
 						},
 						"istanbul-lib-report": {
 							"version": "1.1.3",
 							"bundled": true,
 							"requires": {
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"path-parse": "1.0.5",
-								"supports-color": "3.2.3"
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"path-parse": "^1.0.5",
+								"supports-color": "^3.1.2"
 							},
 							"dependencies": {
 								"supports-color": {
 									"version": "3.2.3",
 									"bundled": true,
 									"requires": {
-										"has-flag": "1.0.0"
+										"has-flag": "^1.0.0"
 									}
 								}
 							}
@@ -3985,11 +3985,11 @@
 							"version": "1.2.3",
 							"bundled": true,
 							"requires": {
-								"debug": "3.1.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"rimraf": "2.6.2",
-								"source-map": "0.5.7"
+								"debug": "^3.1.0",
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"rimraf": "^2.6.1",
+								"source-map": "^0.5.3"
 							},
 							"dependencies": {
 								"debug": {
@@ -4005,7 +4005,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"requires": {
-								"handlebars": "4.0.11"
+								"handlebars": "^4.0.3"
 							}
 						},
 						"js-tokens": {
@@ -4020,7 +4020,7 @@
 							"version": "3.2.2",
 							"bundled": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						},
 						"lazy-cache": {
@@ -4032,26 +4032,26 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"invert-kv": "1.0.0"
+								"invert-kv": "^1.0.0"
 							}
 						},
 						"load-json-file": {
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"locate-path": {
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"p-locate": "2.0.0",
-								"path-exists": "3.0.0"
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
 							},
 							"dependencies": {
 								"path-exists": {
@@ -4072,15 +4072,15 @@
 							"version": "1.3.1",
 							"bundled": true,
 							"requires": {
-								"js-tokens": "3.0.2"
+								"js-tokens": "^3.0.0"
 							}
 						},
 						"lru-cache": {
 							"version": "4.1.3",
 							"bundled": true,
 							"requires": {
-								"pseudomap": "1.0.2",
-								"yallist": "2.1.2"
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
 							}
 						},
 						"map-cache": {
@@ -4091,14 +4091,14 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"object-visit": "1.0.1"
+								"object-visit": "^1.0.0"
 							}
 						},
 						"md5-hex": {
 							"version": "1.3.0",
 							"bundled": true,
 							"requires": {
-								"md5-o-matic": "0.1.1"
+								"md5-o-matic": "^0.1.1"
 							}
 						},
 						"md5-o-matic": {
@@ -4109,14 +4109,14 @@
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"mimic-fn": "1.2.0"
+								"mimic-fn": "^1.0.0"
 							}
 						},
 						"merge-source-map": {
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"source-map": "0.6.1"
+								"source-map": "^0.6.1"
 							},
 							"dependencies": {
 								"source-map": {
@@ -4129,19 +4129,19 @@
 							"version": "3.1.10",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4158,7 +4158,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"requires": {
-								"brace-expansion": "1.1.11"
+								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
@@ -4169,15 +4169,15 @@
 							"version": "1.3.1",
 							"bundled": true,
 							"requires": {
-								"for-in": "1.0.2",
-								"is-extendable": "1.0.1"
+								"for-in": "^1.0.2",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
 									"version": "1.0.1",
 									"bundled": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -4197,18 +4197,18 @@
 							"version": "1.2.9",
 							"bundled": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"fragment-cache": "0.2.1",
-								"is-odd": "2.0.0",
-								"is-windows": "1.0.2",
-								"kind-of": "6.0.2",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"fragment-cache": "^0.2.1",
+								"is-odd": "^2.0.0",
+								"is-windows": "^1.0.2",
+								"kind-of": "^6.0.2",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -4229,17 +4229,17 @@
 							"version": "2.4.0",
 							"bundled": true,
 							"requires": {
-								"hosted-git-info": "2.6.0",
-								"is-builtin-module": "1.0.0",
-								"semver": "5.5.0",
-								"validate-npm-package-license": "3.0.3"
+								"hosted-git-info": "^2.1.4",
+								"is-builtin-module": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
 							}
 						},
 						"npm-run-path": {
 							"version": "2.0.2",
 							"bundled": true,
 							"requires": {
-								"path-key": "2.0.1"
+								"path-key": "^2.0.0"
 							}
 						},
 						"number-is-nan": {
@@ -4254,16 +4254,16 @@
 							"version": "0.1.0",
 							"bundled": true,
 							"requires": {
-								"copy-descriptor": "0.1.1",
-								"define-property": "0.2.5",
-								"kind-of": "3.2.2"
+								"copy-descriptor": "^0.1.0",
+								"define-property": "^0.2.5",
+								"kind-of": "^3.0.3"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -4272,7 +4272,7 @@
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -4285,7 +4285,7 @@
 							"version": "1.3.0",
 							"bundled": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -4298,15 +4298,15 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"requires": {
-								"wrappy": "1.0.2"
+								"wrappy": "1"
 							}
 						},
 						"optimist": {
 							"version": "0.6.1",
 							"bundled": true,
 							"requires": {
-								"minimist": "0.0.8",
-								"wordwrap": "0.0.3"
+								"minimist": "~0.0.1",
+								"wordwrap": "~0.0.2"
 							}
 						},
 						"os-homedir": {
@@ -4317,9 +4317,9 @@
 							"version": "2.1.0",
 							"bundled": true,
 							"requires": {
-								"execa": "0.7.0",
-								"lcid": "1.0.0",
-								"mem": "1.1.0"
+								"execa": "^0.7.0",
+								"lcid": "^1.0.0",
+								"mem": "^1.1.0"
 							}
 						},
 						"p-finally": {
@@ -4330,14 +4330,14 @@
 							"version": "1.2.0",
 							"bundled": true,
 							"requires": {
-								"p-try": "1.0.0"
+								"p-try": "^1.0.0"
 							}
 						},
 						"p-locate": {
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"p-limit": "1.2.0"
+								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
@@ -4348,7 +4348,7 @@
 							"version": "2.2.0",
 							"bundled": true,
 							"requires": {
-								"error-ex": "1.3.1"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"pascalcase": {
@@ -4359,7 +4359,7 @@
 							"version": "2.1.0",
 							"bundled": true,
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-is-absolute": {
@@ -4378,9 +4378,9 @@
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -4395,22 +4395,22 @@
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"pinkie": "2.0.4"
+								"pinkie": "^2.0.0"
 							}
 						},
 						"pkg-dir": {
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"find-up": "1.1.2"
+								"find-up": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
 									"version": "1.1.2",
 									"bundled": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -4427,25 +4427,25 @@
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"read-pkg-up": {
 							"version": "1.0.1",
 							"bundled": true,
 							"requires": {
-								"find-up": "1.1.2",
-								"read-pkg": "1.1.0"
+								"find-up": "^1.0.0",
+								"read-pkg": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
 									"version": "1.1.2",
 									"bundled": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -4458,8 +4458,8 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "3.0.2",
-								"safe-regex": "1.1.0"
+								"extend-shallow": "^3.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"repeat-element": {
@@ -4474,7 +4474,7 @@
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"is-finite": "1.0.2"
+								"is-finite": "^1.0.0"
 							}
 						},
 						"require-directory": {
@@ -4502,21 +4502,21 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4"
+								"align-text": "^0.1.1"
 							}
 						},
 						"rimraf": {
 							"version": "2.6.2",
 							"bundled": true,
 							"requires": {
-								"glob": "7.1.2"
+								"glob": "^7.0.5"
 							}
 						},
 						"safe-regex": {
 							"version": "1.1.0",
 							"bundled": true,
 							"requires": {
-								"ret": "0.1.15"
+								"ret": "~0.1.10"
 							}
 						},
 						"semver": {
@@ -4531,17 +4531,17 @@
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"split-string": "3.1.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.3",
+								"split-string": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -4550,7 +4550,7 @@
 							"version": "1.2.0",
 							"bundled": true,
 							"requires": {
-								"shebang-regex": "1.0.0"
+								"shebang-regex": "^1.0.0"
 							}
 						},
 						"shebang-regex": {
@@ -4569,28 +4569,28 @@
 							"version": "0.8.2",
 							"bundled": true,
 							"requires": {
-								"base": "0.11.2",
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"map-cache": "0.2.2",
-								"source-map": "0.5.7",
-								"source-map-resolve": "0.5.1",
-								"use": "3.1.0"
+								"base": "^0.11.1",
+								"debug": "^2.2.0",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"map-cache": "^0.2.2",
+								"source-map": "^0.5.6",
+								"source-map-resolve": "^0.5.0",
+								"use": "^3.1.0"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -4599,39 +4599,39 @@
 							"version": "2.1.1",
 							"bundled": true,
 							"requires": {
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"snapdragon-util": "3.0.1"
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.0",
+								"snapdragon-util": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -4648,7 +4648,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.2.0"
 							}
 						},
 						"source-map": {
@@ -4659,11 +4659,11 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"requires": {
-								"atob": "2.1.1",
-								"decode-uri-component": "0.2.0",
-								"resolve-url": "0.2.1",
-								"source-map-url": "0.4.0",
-								"urix": "0.1.0"
+								"atob": "^2.0.0",
+								"decode-uri-component": "^0.2.0",
+								"resolve-url": "^0.2.1",
+								"source-map-url": "^0.4.0",
+								"urix": "^0.1.0"
 							}
 						},
 						"source-map-url": {
@@ -4674,20 +4674,20 @@
 							"version": "1.4.2",
 							"bundled": true,
 							"requires": {
-								"foreground-child": "1.5.6",
-								"mkdirp": "0.5.1",
-								"os-homedir": "1.0.2",
-								"rimraf": "2.6.2",
-								"signal-exit": "3.0.2",
-								"which": "1.3.0"
+								"foreground-child": "^1.5.6",
+								"mkdirp": "^0.5.0",
+								"os-homedir": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"signal-exit": "^3.0.2",
+								"which": "^1.3.0"
 							}
 						},
 						"spdx-correct": {
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"spdx-expression-parse": "3.0.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-expression-parse": "^3.0.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-exceptions": {
@@ -4698,8 +4698,8 @@
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"spdx-exceptions": "2.1.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-license-ids": {
@@ -4710,22 +4710,22 @@
 							"version": "3.1.0",
 							"bundled": true,
 							"requires": {
-								"extend-shallow": "3.0.2"
+								"extend-shallow": "^3.0.0"
 							}
 						},
 						"static-extend": {
 							"version": "0.1.2",
 							"bundled": true,
 							"requires": {
-								"define-property": "0.2.5",
-								"object-copy": "0.1.0"
+								"define-property": "^0.2.5",
+								"object-copy": "^0.1.0"
 							},
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -4734,8 +4734,8 @@
 							"version": "2.1.1",
 							"bundled": true,
 							"requires": {
-								"is-fullwidth-code-point": "2.0.0",
-								"strip-ansi": "4.0.0"
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -4746,7 +4746,7 @@
 									"version": "4.0.0",
 									"bundled": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								}
 							}
@@ -4755,14 +4755,14 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"strip-bom": {
 							"version": "2.0.0",
 							"bundled": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						},
 						"strip-eof": {
@@ -4777,11 +4777,11 @@
 							"version": "4.2.1",
 							"bundled": true,
 							"requires": {
-								"arrify": "1.0.1",
-								"micromatch": "3.1.10",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"require-main-filename": "1.0.1"
+								"arrify": "^1.0.1",
+								"micromatch": "^3.1.8",
+								"object-assign": "^4.1.0",
+								"read-pkg-up": "^1.0.1",
+								"require-main-filename": "^1.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -4796,23 +4796,23 @@
 									"version": "2.3.2",
 									"bundled": true,
 									"requires": {
-										"arr-flatten": "1.1.0",
-										"array-unique": "0.3.2",
-										"extend-shallow": "2.0.1",
-										"fill-range": "4.0.0",
-										"isobject": "3.0.1",
-										"repeat-element": "1.1.2",
-										"snapdragon": "0.8.2",
-										"snapdragon-node": "2.1.1",
-										"split-string": "3.1.0",
-										"to-regex": "3.0.2"
+										"arr-flatten": "^1.1.0",
+										"array-unique": "^0.3.2",
+										"extend-shallow": "^2.0.1",
+										"fill-range": "^4.0.0",
+										"isobject": "^3.0.1",
+										"repeat-element": "^1.1.2",
+										"snapdragon": "^0.8.1",
+										"snapdragon-node": "^2.0.1",
+										"split-string": "^3.0.2",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -4821,41 +4821,41 @@
 									"version": "2.1.4",
 									"bundled": true,
 									"requires": {
-										"debug": "2.6.9",
-										"define-property": "0.2.5",
-										"extend-shallow": "2.0.1",
-										"posix-character-classes": "0.1.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"debug": "^2.3.3",
+										"define-property": "^0.2.5",
+										"extend-shallow": "^2.0.1",
+										"posix-character-classes": "^0.1.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
 											"version": "0.2.5",
 											"bundled": true,
 											"requires": {
-												"is-descriptor": "0.1.6"
+												"is-descriptor": "^0.1.0"
 											}
 										},
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										},
 										"is-accessor-descriptor": {
 											"version": "0.1.6",
 											"bundled": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
 													"version": "3.2.2",
 													"bundled": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -4864,14 +4864,14 @@
 											"version": "0.1.4",
 											"bundled": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
 													"version": "3.2.2",
 													"bundled": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -4880,9 +4880,9 @@
 											"version": "0.1.6",
 											"bundled": true,
 											"requires": {
-												"is-accessor-descriptor": "0.1.6",
-												"is-data-descriptor": "0.1.4",
-												"kind-of": "5.1.0"
+												"is-accessor-descriptor": "^0.1.6",
+												"is-data-descriptor": "^0.1.4",
+												"kind-of": "^5.0.0"
 											}
 										},
 										"kind-of": {
@@ -4895,28 +4895,28 @@
 									"version": "2.0.4",
 									"bundled": true,
 									"requires": {
-										"array-unique": "0.3.2",
-										"define-property": "1.0.0",
-										"expand-brackets": "2.1.4",
-										"extend-shallow": "2.0.1",
-										"fragment-cache": "0.2.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"array-unique": "^0.3.2",
+										"define-property": "^1.0.0",
+										"expand-brackets": "^2.1.4",
+										"extend-shallow": "^2.0.1",
+										"fragment-cache": "^0.2.1",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
 											"version": "1.0.0",
 											"bundled": true,
 											"requires": {
-												"is-descriptor": "1.0.2"
+												"is-descriptor": "^1.0.0"
 											}
 										},
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -4925,17 +4925,17 @@
 									"version": "4.0.0",
 									"bundled": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-number": "3.0.0",
-										"repeat-string": "1.6.1",
-										"to-regex-range": "2.1.1"
+										"extend-shallow": "^2.0.1",
+										"is-number": "^3.0.0",
+										"repeat-string": "^1.6.1",
+										"to-regex-range": "^2.1.0"
 									},
 									"dependencies": {
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -4944,37 +4944,37 @@
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -4991,19 +4991,19 @@
 									"version": "3.1.10",
 									"bundled": true,
 									"requires": {
-										"arr-diff": "4.0.0",
-										"array-unique": "0.3.2",
-										"braces": "2.3.2",
-										"define-property": "2.0.2",
-										"extend-shallow": "3.0.2",
-										"extglob": "2.0.4",
-										"fragment-cache": "0.2.1",
-										"kind-of": "6.0.2",
-										"nanomatch": "1.2.9",
-										"object.pick": "1.3.0",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"arr-diff": "^4.0.0",
+										"array-unique": "^0.3.2",
+										"braces": "^2.3.1",
+										"define-property": "^2.0.2",
+										"extend-shallow": "^3.0.2",
+										"extglob": "^2.0.4",
+										"fragment-cache": "^0.2.1",
+										"kind-of": "^6.0.2",
+										"nanomatch": "^1.2.9",
+										"object.pick": "^1.3.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.2"
 									}
 								}
 							}
@@ -5016,32 +5016,32 @@
 							"version": "0.3.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"to-regex": {
 							"version": "3.0.2",
 							"bundled": true,
 							"requires": {
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"regex-not": "1.0.2",
-								"safe-regex": "1.1.0"
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"regex-not": "^1.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"to-regex-range": {
 							"version": "2.1.1",
 							"bundled": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1"
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1"
 							},
 							"dependencies": {
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									}
 								}
 							}
@@ -5055,9 +5055,9 @@
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"source-map": "0.5.7",
-								"uglify-to-browserify": "1.0.2",
-								"yargs": "3.10.0"
+								"source-map": "~0.5.1",
+								"uglify-to-browserify": "~1.0.0",
+								"yargs": "~3.10.0"
 							},
 							"dependencies": {
 								"yargs": {
@@ -5065,9 +5065,9 @@
 									"bundled": true,
 									"optional": true,
 									"requires": {
-										"camelcase": "1.2.1",
-										"cliui": "2.1.0",
-										"decamelize": "1.2.0",
+										"camelcase": "^1.0.2",
+										"cliui": "^2.1.0",
+										"decamelize": "^1.0.0",
 										"window-size": "0.1.0"
 									}
 								}
@@ -5082,27 +5082,27 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"get-value": "2.0.6",
-								"is-extendable": "0.1.1",
-								"set-value": "0.4.3"
+								"arr-union": "^3.1.0",
+								"get-value": "^2.0.6",
+								"is-extendable": "^0.1.1",
+								"set-value": "^0.4.3"
 							},
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"set-value": {
 									"version": "0.4.3",
 									"bundled": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-extendable": "0.1.1",
-										"is-plain-object": "2.0.4",
-										"to-object-path": "0.3.0"
+										"extend-shallow": "^2.0.1",
+										"is-extendable": "^0.1.1",
+										"is-plain-object": "^2.0.1",
+										"to-object-path": "^0.3.0"
 									}
 								}
 							}
@@ -5111,17 +5111,17 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"requires": {
-								"has-value": "0.3.1",
-								"isobject": "3.0.1"
+								"has-value": "^0.3.1",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"has-value": {
 									"version": "0.3.1",
 									"bundled": true,
 									"requires": {
-										"get-value": "2.0.6",
-										"has-values": "0.1.4",
-										"isobject": "2.1.0"
+										"get-value": "^2.0.3",
+										"has-values": "^0.1.4",
+										"isobject": "^2.0.0"
 									},
 									"dependencies": {
 										"isobject": {
@@ -5151,7 +5151,7 @@
 							"version": "3.1.0",
 							"bundled": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -5164,15 +5164,15 @@
 							"version": "3.0.3",
 							"bundled": true,
 							"requires": {
-								"spdx-correct": "3.0.0",
-								"spdx-expression-parse": "3.0.0"
+								"spdx-correct": "^3.0.0",
+								"spdx-expression-parse": "^3.0.0"
 							}
 						},
 						"which": {
 							"version": "1.3.0",
 							"bundled": true,
 							"requires": {
-								"isexe": "2.0.0"
+								"isexe": "^2.0.0"
 							}
 						},
 						"which-module": {
@@ -5192,24 +5192,24 @@
 							"version": "2.1.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1"
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1"
 							},
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "1.0.0",
 									"bundled": true,
 									"requires": {
-										"number-is-nan": "1.0.1"
+										"number-is-nan": "^1.0.0"
 									}
 								},
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
 									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
 									}
 								}
 							}
@@ -5222,9 +5222,9 @@
 							"version": "1.3.4",
 							"bundled": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"imurmurhash": "0.1.4",
-								"slide": "1.1.6"
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"slide": "^1.1.5"
 							}
 						},
 						"y18n": {
@@ -5239,18 +5239,18 @@
 							"version": "11.1.0",
 							"bundled": true,
 							"requires": {
-								"cliui": "4.1.0",
-								"decamelize": "1.2.0",
-								"find-up": "2.1.0",
-								"get-caller-file": "1.0.2",
-								"os-locale": "2.1.0",
-								"require-directory": "2.1.1",
-								"require-main-filename": "1.0.1",
-								"set-blocking": "2.0.0",
-								"string-width": "2.1.1",
-								"which-module": "2.0.0",
-								"y18n": "3.2.1",
-								"yargs-parser": "9.0.2"
+								"cliui": "^4.0.0",
+								"decamelize": "^1.1.1",
+								"find-up": "^2.1.0",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^2.0.0",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^2.0.0",
+								"which-module": "^2.0.0",
+								"y18n": "^3.2.1",
+								"yargs-parser": "^9.0.2"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -5265,23 +5265,23 @@
 									"version": "4.1.0",
 									"bundled": true,
 									"requires": {
-										"string-width": "2.1.1",
-										"strip-ansi": "4.0.0",
-										"wrap-ansi": "2.1.0"
+										"string-width": "^2.1.1",
+										"strip-ansi": "^4.0.0",
+										"wrap-ansi": "^2.0.0"
 									}
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
 									"bundled": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								},
 								"yargs-parser": {
 									"version": "9.0.2",
 									"bundled": true,
 									"requires": {
-										"camelcase": "4.1.0"
+										"camelcase": "^4.1.0"
 									}
 								}
 							}
@@ -5290,7 +5290,7 @@
 							"version": "8.1.0",
 							"bundled": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							},
 							"dependencies": {
 								"camelcase": {
@@ -5308,15 +5308,15 @@
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -5324,9 +5324,9 @@
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -5336,9 +5336,9 @@
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -5356,8 +5356,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trim-right": {
@@ -5380,7 +5380,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -5399,8 +5399,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -5419,9 +5419,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -5429,7 +5429,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -5442,9 +5442,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {
@@ -5462,18 +5462,18 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
 			"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "2.0.0",
-				"find-up": "3.0.0",
-				"get-caller-file": "1.0.3",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "4.0.0",
-				"yargs-parser": "10.1.0"
+				"cliui": "^4.0.0",
+				"decamelize": "^2.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^10.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5491,9 +5491,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
@@ -5506,9 +5506,9 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"decamelize": {
@@ -5524,13 +5524,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -5538,7 +5538,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"requires": {
-						"locate-path": "3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"get-caller-file": {
@@ -5576,7 +5576,7 @@
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"locate-path": {
@@ -5584,8 +5584,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"requires": {
-						"p-locate": "3.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -5593,8 +5593,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"mem": {
@@ -5602,7 +5602,7 @@
 					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"mimic-fn": {
@@ -5615,7 +5615,7 @@
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -5628,9 +5628,9 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -5643,7 +5643,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 					"requires": {
-						"p-try": "2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
@@ -5651,7 +5651,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"requires": {
-						"p-limit": "2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
@@ -5694,7 +5694,7 @@
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -5712,8 +5712,8 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -5721,7 +5721,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-eof": {
@@ -5734,7 +5734,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -5747,8 +5747,8 @@
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -5761,7 +5761,7 @@
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -5769,9 +5769,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -5779,7 +5779,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -5804,7 +5804,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}


### PR DESCRIPTION
Generate a $proxy class for all abstract classes and use them when the return type is abstract,
similar to interface proxies.

This change also adds `abstract: true` to all interface members, so the proxy generator can treat interfaces and classes polymorphically.

Added a compliance test "returnAbstract" which verifies this behavior.

Fixes #220
Related to #223 (.NET)
Related to awslabs/aws-cdk#680 (require jsii update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.