### PR TITLE
fix(jsii): Defaulted parameters were not rendered as optional

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -240,6 +240,10 @@ export class RuntimeTypeChecking {
     public methodWithOptionalArguments(arg1: number, arg2: string, arg3?: Date) {
         arg1; arg2; arg3;
     }
+
+    public methodWithDefaultedArguments(arg1: number = 2, arg2: string, arg3: Date = new Date()) {
+        arg1; arg2; arg3;
+    }
 }
 
 export namespace DerivedClassHasNoProperties {

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -246,6 +246,18 @@ export class RuntimeTypeChecking {
     }
 }
 
+export class OptionalConstructorArgument {
+    public constructor(public readonly arg1: number,
+                       public readonly arg2: string,
+                       public readonly arg3?: Date) {}
+}
+
+export class DefaultedConstructorArgument {
+    public constructor(public readonly arg1: number = 2,
+                       public readonly arg2: string,
+                       public readonly arg3: Date = new Date()) {}
+}
+
 export namespace DerivedClassHasNoProperties {
 
     export class Base {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -2271,6 +2271,31 @@
       "kind": "class",
       "methods": [
         {
+          "name": "methodWithDefaultedArguments",
+          "parameters": [
+            {
+              "name": "arg1",
+              "type": {
+                "optional": true,
+                "primitive": "number"
+              }
+            },
+            {
+              "name": "arg2",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "arg3",
+              "type": {
+                "optional": true,
+                "primitive": "date"
+              }
+            }
+          ]
+        },
+        {
           "docs": {
             "comment": "Used to verify verification of number of method arguments."
           },
@@ -3070,5 +3095,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "XrmsNUcNdYiHEC6BRVT5XoeVmYQZzjYgiu6MyibgOwk="
+  "fingerprint": "Ywp3EW+cv1wVMiKbYcuDGIc5pIYI3RQtcVzwVBMg0aM="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1012,6 +1012,60 @@
         }
       ]
     },
+    "jsii-calc.DefaultedConstructorArgument": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DefaultedConstructorArgument",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "arg1",
+            "type": {
+              "optional": true,
+              "primitive": "number"
+            }
+          },
+          {
+            "name": "arg2",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "arg3",
+            "type": {
+              "optional": true,
+              "primitive": "date"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "DefaultedConstructorArgument",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "arg1",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg2",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg3",
+          "type": {
+            "primitive": "date"
+          }
+        }
+      ]
+    },
     "jsii-calc.DerivedClassHasNoProperties.Base": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Base",
@@ -2073,6 +2127,60 @@
       ],
       "name": "ObjectRefsInCollections"
     },
+    "jsii-calc.OptionalConstructorArgument": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.OptionalConstructorArgument",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "arg1",
+            "type": {
+              "primitive": "number"
+            }
+          },
+          {
+            "name": "arg2",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "arg3",
+            "type": {
+              "optional": true,
+              "primitive": "date"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "OptionalConstructorArgument",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "arg1",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg2",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg3",
+          "type": {
+            "optional": true,
+            "primitive": "date"
+          }
+        }
+      ]
+    },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.OverrideReturnsObject",
@@ -3095,5 +3203,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "Ywp3EW+cv1wVMiKbYcuDGIc5pIYI3RQtcVzwVBMg0aM="
+  "fingerprint": "PrLv57d+5ukv/bps1DvjB9DpM5DS6TpCEld13gQUTe8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -2271,6 +2271,31 @@
       "kind": "class",
       "methods": [
         {
+          "name": "methodWithDefaultedArguments",
+          "parameters": [
+            {
+              "name": "arg1",
+              "type": {
+                "optional": true,
+                "primitive": "number"
+              }
+            },
+            {
+              "name": "arg2",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "arg3",
+              "type": {
+                "optional": true,
+                "primitive": "date"
+              }
+            }
+          ]
+        },
+        {
           "docs": {
             "comment": "Used to verify verification of number of method arguments."
           },
@@ -3070,5 +3095,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "XrmsNUcNdYiHEC6BRVT5XoeVmYQZzjYgiu6MyibgOwk="
+  "fingerprint": "Ywp3EW+cv1wVMiKbYcuDGIc5pIYI3RQtcVzwVBMg0aM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1012,6 +1012,60 @@
         }
       ]
     },
+    "jsii-calc.DefaultedConstructorArgument": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DefaultedConstructorArgument",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "arg1",
+            "type": {
+              "optional": true,
+              "primitive": "number"
+            }
+          },
+          {
+            "name": "arg2",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "arg3",
+            "type": {
+              "optional": true,
+              "primitive": "date"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "DefaultedConstructorArgument",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "arg1",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg2",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg3",
+          "type": {
+            "primitive": "date"
+          }
+        }
+      ]
+    },
     "jsii-calc.DerivedClassHasNoProperties.Base": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Base",
@@ -2073,6 +2127,60 @@
       ],
       "name": "ObjectRefsInCollections"
     },
+    "jsii-calc.OptionalConstructorArgument": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.OptionalConstructorArgument",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "arg1",
+            "type": {
+              "primitive": "number"
+            }
+          },
+          {
+            "name": "arg2",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "arg3",
+            "type": {
+              "optional": true,
+              "primitive": "date"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "OptionalConstructorArgument",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "arg1",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg2",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "arg3",
+          "type": {
+            "optional": true,
+            "primitive": "date"
+          }
+        }
+      ]
+    },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.OverrideReturnsObject",
@@ -3095,5 +3203,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "Ywp3EW+cv1wVMiKbYcuDGIc5pIYI3RQtcVzwVBMg0aM="
+  "fingerprint": "PrLv57d+5ukv/bps1DvjB9DpM5DS6TpCEld13gQUTe8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
@@ -1,0 +1,39 @@
+using Amazon.JSII.Runtime.Deputy;
+using System;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(DefaultedConstructorArgument), "jsii-calc.DefaultedConstructorArgument", "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
+    public class DefaultedConstructorArgument : DeputyBase
+    {
+        public DefaultedConstructorArgument(double? arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))
+        {
+        }
+
+        protected DefaultedConstructorArgument(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected DefaultedConstructorArgument(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("arg1", "{\"primitive\":\"number\"}")]
+        public virtual double Arg1
+        {
+            get => GetInstanceProperty<double>();
+        }
+
+        [JsiiProperty("arg2", "{\"primitive\":\"string\"}")]
+        public virtual string Arg2
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiProperty("arg3", "{\"primitive\":\"date\"}")]
+        public virtual DateTime Arg3
+        {
+            get => GetInstanceProperty<DateTime>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
@@ -1,0 +1,39 @@
+using Amazon.JSII.Runtime.Deputy;
+using System;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(OptionalConstructorArgument), "jsii-calc.OptionalConstructorArgument", "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
+    public class OptionalConstructorArgument : DeputyBase
+    {
+        public OptionalConstructorArgument(double arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))
+        {
+        }
+
+        protected OptionalConstructorArgument(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected OptionalConstructorArgument(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("arg1", "{\"primitive\":\"number\"}")]
+        public virtual double Arg1
+        {
+            get => GetInstanceProperty<double>();
+        }
+
+        [JsiiProperty("arg2", "{\"primitive\":\"string\"}")]
+        public virtual string Arg2
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiProperty("arg3", "{\"primitive\":\"date\",\"optional\":true}")]
+        public virtual DateTime? Arg3
+        {
+            get => GetInstanceProperty<DateTime? >();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
@@ -18,6 +18,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        [JsiiMethod("methodWithDefaultedArguments", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
+        public virtual void MethodWithDefaultedArguments(double? arg1, string arg2, DateTime? arg3)
+        {
+            InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});
+        }
+
         /// <summary>Used to verify verification of number of method arguments.</summary>
         [JsiiMethod("methodWithOptionalArguments", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
         public virtual void MethodWithOptionalArguments(double arg1, string arg2, DateTime? arg3)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -29,6 +29,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.BinaryOperation": return software.amazon.jsii.tests.calculator.BinaryOperation.class;
             case "jsii-calc.Calculator": return software.amazon.jsii.tests.calculator.Calculator.class;
             case "jsii-calc.CalculatorProps": return software.amazon.jsii.tests.calculator.CalculatorProps.class;
+            case "jsii-calc.DefaultedConstructorArgument": return software.amazon.jsii.tests.calculator.DefaultedConstructorArgument.class;
             case "jsii-calc.DerivedClassHasNoProperties.Base": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base.class;
             case "jsii-calc.DerivedClassHasNoProperties.Derived": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived.class;
             case "jsii-calc.DerivedStruct": return software.amazon.jsii.tests.calculator.DerivedStruct.class;
@@ -54,6 +55,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.NodeStandardLibrary": return software.amazon.jsii.tests.calculator.NodeStandardLibrary.class;
             case "jsii-calc.NumberGenerator": return software.amazon.jsii.tests.calculator.NumberGenerator.class;
             case "jsii-calc.ObjectRefsInCollections": return software.amazon.jsii.tests.calculator.ObjectRefsInCollections.class;
+            case "jsii-calc.OptionalConstructorArgument": return software.amazon.jsii.tests.calculator.OptionalConstructorArgument.class;
             case "jsii-calc.OverrideReturnsObject": return software.amazon.jsii.tests.calculator.OverrideReturnsObject.class;
             case "jsii-calc.Polymorphism": return software.amazon.jsii.tests.calculator.Polymorphism.class;
             case "jsii-calc.Power": return software.amazon.jsii.tests.calculator.Power.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -1,0 +1,29 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DefaultedConstructorArgument")
+public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObject {
+    protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+    }
+    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+    }
+
+    public java.lang.Number getArg1() {
+        return this.jsiiGet("arg1", java.lang.Number.class);
+    }
+
+    public java.lang.String getArg2() {
+        return this.jsiiGet("arg2", java.lang.String.class);
+    }
+
+    public java.time.Instant getArg3() {
+        return this.jsiiGet("arg3", java.time.Instant.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -1,0 +1,30 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalConstructorArgument")
+public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject {
+    protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+    }
+    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+    }
+
+    public java.lang.Number getArg1() {
+        return this.jsiiGet("arg1", java.lang.Number.class);
+    }
+
+    public java.lang.String getArg2() {
+        return this.jsiiGet("arg2", java.lang.String.class);
+    }
+
+    @javax.annotation.Nullable
+    public java.time.Instant getArg3() {
+        return this.jsiiGet("arg3", java.time.Instant.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -11,6 +11,14 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+    }
+
+    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2) {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+    }
+
     /**
      * Used to verify verification of number of method arguments.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -2417,6 +2417,16 @@ RuntimeTypeChecking
 
 
 
+   .. py:method:: methodWithDefaultedArguments([arg1, arg2, [arg3]])
+
+      :param arg1: 
+      :type arg1: number or undefined
+      :param arg2: 
+      :type arg2: string
+      :param arg3: 
+      :type arg3: date or undefined
+
+
    .. py:method:: methodWithOptionalArguments(arg1, arg2, [arg3])
 
       Used to verify verification of number of method arguments.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -831,6 +831,55 @@ CalculatorProps (interface)
       :type: number or undefined *(abstract)*
 
 
+DefaultedConstructorArgument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DefaultedConstructorArgument([arg1, arg2, [arg3]])
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DefaultedConstructorArgument;
+
+      .. code-tab:: javascript
+
+         const { DefaultedConstructorArgument } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { DefaultedConstructorArgument } from 'jsii-calc';
+
+
+
+   :param arg1: 
+   :type arg1: number or undefined
+   :param arg2: 
+   :type arg2: string
+   :param arg3: 
+   :type arg3: date or undefined
+
+   .. py:attribute:: arg1
+
+      :type: number *(readonly)*
+
+
+   .. py:attribute:: arg2
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: arg3
+
+      :type: date *(readonly)*
+
+
 
 DerivedClassHasNoProperties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2170,6 +2219,55 @@ ObjectRefsInCollections
       :param values: 
       :type values: string => :py:class:`@scope/jsii-calc-lib.Value`\ 
       :rtype: number
+
+
+OptionalConstructorArgument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: OptionalConstructorArgument(arg1, arg2, [arg3])
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.OptionalConstructorArgument;
+
+      .. code-tab:: javascript
+
+         const { OptionalConstructorArgument } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { OptionalConstructorArgument } from 'jsii-calc';
+
+
+
+   :param arg1: 
+   :type arg1: number
+   :param arg2: 
+   :type arg2: string
+   :param arg3: 
+   :type arg3: date or undefined
+
+   .. py:attribute:: arg1
+
+      :type: number *(readonly)*
+
+
+   .. py:attribute:: arg2
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: arg3
+
+      :type: date or undefined *(readonly)*
 
 
 OverrideReturnsObject

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -618,13 +618,17 @@ export class Assembler implements Emitter {
         if (LOG.isTraceEnabled()) {
             LOG.trace(`Processing parameter: ${colors.cyan(paramSymbol.name)}`);
         }
+        const paramDeclaration = paramSymbol.valueDeclaration as ts.ParameterDeclaration;
         const parameter: spec.Parameter = {
             name: paramSymbol.name,
             type: await this._typeReference(this._typeChecker.getTypeAtLocation(paramSymbol.valueDeclaration), paramSymbol.valueDeclaration),
-            variadic: !!(paramSymbol.valueDeclaration as ts.ParameterDeclaration).dotDotDotToken
+            variadic: !!paramDeclaration.dotDotDotToken
         };
         if (parameter.variadic) {
             parameter.type = (parameter.type as spec.CollectionTypeReference).collection.elementtype;
+        }
+        if (paramDeclaration.initializer != null) {
+            parameter.type.optional = true;
         }
         this._visitDocumentation(paramSymbol, parameter);
         return parameter;


### PR DESCRIPTION
Parameters with a default value were not represented as optional in the assembly
documents due to an oversight when re-writing `jsii`. There was also no coverage
in the test corpus for this use-case, so I've added some.

Fixes #233