### PR TITLE
fix(jsii): Don't skip emit on TS errors when in "watch" mode

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -83,7 +83,7 @@ export class Compiler implements Emitter {
             const projectRoot = this.options.projectInfo.projectRoot;
             const host = ts.createWatchCompilerHost(
                 await this._writeTypeScriptConfig(),
-                COMPILER_OPTIONS,
+                { ...COMPILER_OPTIONS, noEmitOnError: false },
                 { ...ts.sys, getCurrentDirectory() { return projectRoot; } }
             );
             const orig = host.afterProgramCreate;


### PR DESCRIPTION
In watch mode, users expect to be able to be a little more drafty than when doing a plain compile cycle, as
they may edit code as part of a troubleshooting loop, that may involve for example leaving out unused
imports and the like. This change makes sure the `noEmitOnError` compiler option is set to false when
operating in `watch` mode, so the `.js` files get updated unconditionally.

Fixes #235