### PR TITLE
fix(jsii): Optional `any` represented as required

### DIFF
--- a/packages/jsii-calc-base/test/assembly.jsii
+++ b/packages/jsii-calc-base/test/assembly.jsii
@@ -72,6 +72,7 @@
           },
           "name": "typeName",
           "returns": {
+            "optional": true,
             "primitive": "any"
           }
         }
@@ -101,5 +102,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "Kzm7bNzxYO6frB7BwjqVBKhzTiCRwVG5aqgQrz7MOnE="
+  "fingerprint": "kazFxdH9DydCwjHvToTbXzqqXE0CytJ5qNmGO1NlGAM="
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -244,6 +244,10 @@ export class RuntimeTypeChecking {
     public methodWithDefaultedArguments(arg1: number = 2, arg2: string, arg3: Date = new Date()) {
         arg1; arg2; arg3;
     }
+
+    public methodWithOptionalAnyArgument(arg?: any) {
+        arg;
+    }
 }
 
 export class OptionalConstructorArgument {
@@ -479,6 +483,7 @@ export interface DerivedStruct extends MyFirstStruct {
     bool: boolean
     anotherRequired: Date
     optionalArray?: string[]
+    optionalAny?: any
     /**
      * This is optional.
      */

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1154,6 +1154,14 @@
         },
         {
           "abstract": true,
+          "name": "optionalAny",
+          "type": {
+            "optional": true,
+            "primitive": "any"
+          }
+        },
+        {
+          "abstract": true,
           "name": "optionalArray",
           "type": {
             "collection": {
@@ -2404,6 +2412,18 @@
           ]
         },
         {
+          "name": "methodWithOptionalAnyArgument",
+          "parameters": [
+            {
+              "name": "arg",
+              "type": {
+                "optional": true,
+                "primitive": "any"
+              }
+            }
+          ]
+        },
+        {
           "docs": {
             "comment": "Used to verify verification of number of method arguments."
           },
@@ -3203,5 +3223,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "PrLv57d+5ukv/bps1DvjB9DpM5DS6TpCEld13gQUTe8="
+  "fingerprint": "E87+31Zrd9jEqf4+WTZ2u/A6uHS/HQFxOau1yxxuecM="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -377,6 +377,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "array"
@@ -388,16 +389,11 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "map"
             }
-          }
-        },
-        {
-          "name": "anyProperty",
-          "type": {
-            "primitive": "any"
           }
         },
         {
@@ -521,6 +517,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "array"
@@ -532,6 +529,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "map"
@@ -539,8 +537,9 @@
           }
         },
         {
-          "name": "unknownProperty",
+          "name": "anyProperty",
           "type": {
+            "optional": true,
             "primitive": "any"
           }
         },
@@ -549,6 +548,13 @@
           "type": {
             "fqn": "jsii-calc.StringEnum",
             "optional": true
+          }
+        },
+        {
+          "name": "unknownProperty",
+          "type": {
+            "optional": true,
+            "primitive": "any"
           }
         }
       ]
@@ -2874,6 +2880,7 @@
         {
           "name": "value",
           "returns": {
+            "optional": true,
             "primitive": "any"
           }
         }
@@ -3223,5 +3230,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "E87+31Zrd9jEqf4+WTZ2u/A6uHS/HQFxOau1yxxuecM="
+  "fingerprint": "Zt3ElcP9k7ABYhwmP1xNZBni1sFj9iw0FZwWOe8n+L8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/.jsii
@@ -72,6 +72,7 @@
           },
           "name": "typeName",
           "returns": {
+            "optional": true,
             "primitive": "any"
           }
         }
@@ -101,5 +102,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "Kzm7bNzxYO6frB7BwjqVBKhzTiCRwVG5aqgQrz7MOnE="
+  "fingerprint": "kazFxdH9DydCwjHvToTbXzqqXE0CytJ5qNmGO1NlGAM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/Base.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/Base.cs
@@ -19,7 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
         }
 
         /// <returns>the name of the class (to verify native type names are created for derived classes).</returns>
-        [JsiiMethod("typeName", "{\"primitive\":\"any\"}", "[]")]
+        [JsiiMethod("typeName", "{\"primitive\":\"any\",\"optional\":true}", "[]")]
         public virtual object TypeName()
         {
             return InvokeInstanceMethod<object>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -13,6 +13,7 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
     /**
      * @return the name of the class (to verify native type names are created for derived classes).
      */
+    @javax.annotation.Nullable
     public java.lang.Object typeName() {
         return this.jsiiCall("typeName", java.lang.Object.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -158,7 +158,7 @@ Base
    .. py:method:: typeName() -> any
 
       :return: the name of the class (to verify native type names are created for derived classes).
-      :rtype: any
+      :rtype: any or undefined
 
 
 BaseProps (interface)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1154,6 +1154,14 @@
         },
         {
           "abstract": true,
+          "name": "optionalAny",
+          "type": {
+            "optional": true,
+            "primitive": "any"
+          }
+        },
+        {
+          "abstract": true,
           "name": "optionalArray",
           "type": {
             "collection": {
@@ -2404,6 +2412,18 @@
           ]
         },
         {
+          "name": "methodWithOptionalAnyArgument",
+          "parameters": [
+            {
+              "name": "arg",
+              "type": {
+                "optional": true,
+                "primitive": "any"
+              }
+            }
+          ]
+        },
+        {
           "docs": {
             "comment": "Used to verify verification of number of method arguments."
           },
@@ -3203,5 +3223,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "PrLv57d+5ukv/bps1DvjB9DpM5DS6TpCEld13gQUTe8="
+  "fingerprint": "E87+31Zrd9jEqf4+WTZ2u/A6uHS/HQFxOau1yxxuecM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -377,6 +377,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "array"
@@ -388,16 +389,11 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "map"
             }
-          }
-        },
-        {
-          "name": "anyProperty",
-          "type": {
-            "primitive": "any"
           }
         },
         {
@@ -521,6 +517,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "array"
@@ -532,6 +529,7 @@
           "type": {
             "collection": {
               "elementtype": {
+                "optional": true,
                 "primitive": "any"
               },
               "kind": "map"
@@ -539,8 +537,9 @@
           }
         },
         {
-          "name": "unknownProperty",
+          "name": "anyProperty",
           "type": {
+            "optional": true,
             "primitive": "any"
           }
         },
@@ -549,6 +548,13 @@
           "type": {
             "fqn": "jsii-calc.StringEnum",
             "optional": true
+          }
+        },
+        {
+          "name": "unknownProperty",
+          "type": {
+            "optional": true,
+            "primitive": "any"
           }
         }
       ]
@@ -2874,6 +2880,7 @@
         {
           "name": "value",
           "returns": {
+            "optional": true,
             "primitive": "any"
           }
         }
@@ -3223,5 +3230,5 @@
     }
   },
   "version": "0.7.5",
-  "fingerprint": "E87+31Zrd9jEqf4+WTZ2u/A6uHS/HQFxOau1yxxuecM="
+  "fingerprint": "Zt3ElcP9k7ABYhwmP1xNZBni1sFj9iw0FZwWOe8n+L8="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
@@ -31,24 +31,17 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             get => GetInstanceProperty<double>();
         }
 
-        [JsiiProperty("anyArrayProperty", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
+        [JsiiProperty("anyArrayProperty", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\",\"optional\":true}}}")]
         public virtual object[] AnyArrayProperty
         {
             get => GetInstanceProperty<object[]>();
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("anyMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\"}}}")]
+        [JsiiProperty("anyMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\",\"optional\":true}}}")]
         public virtual IDictionary<string, object> AnyMapProperty
         {
             get => GetInstanceProperty<IDictionary<string, object>>();
-            set => SetInstanceProperty(value);
-        }
-
-        [JsiiProperty("anyProperty", "{\"primitive\":\"any\"}")]
-        public virtual object AnyProperty
-        {
-            get => GetInstanceProperty<object>();
             set => SetInstanceProperty(value);
         }
 
@@ -129,22 +122,22 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("unknownArrayProperty", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
+        [JsiiProperty("unknownArrayProperty", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\",\"optional\":true}}}")]
         public virtual object[] UnknownArrayProperty
         {
             get => GetInstanceProperty<object[]>();
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("unknownMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\"}}}")]
+        [JsiiProperty("unknownMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\",\"optional\":true}}}")]
         public virtual IDictionary<string, object> UnknownMapProperty
         {
             get => GetInstanceProperty<IDictionary<string, object>>();
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("unknownProperty", "{\"primitive\":\"any\"}")]
-        public virtual object UnknownProperty
+        [JsiiProperty("anyProperty", "{\"primitive\":\"any\",\"optional\":true}")]
+        public virtual object AnyProperty
         {
             get => GetInstanceProperty<object>();
             set => SetInstanceProperty(value);
@@ -154,6 +147,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         public virtual StringEnum OptionalEnumValue
         {
             get => GetInstanceProperty<StringEnum>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("unknownProperty", "{\"primitive\":\"any\",\"optional\":true}")]
+        public virtual object UnknownProperty
+        {
+            get => GetInstanceProperty<object>();
             set => SetInstanceProperty(value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
@@ -38,6 +38,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        [JsiiProperty("optionalAny", "{\"primitive\":\"any\",\"optional\":true}", true)]
+        public object OptionalAny
+        {
+            get;
+            set;
+        }
+
         [JsiiProperty("optionalArray", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}", true)]
         public string[] OptionalArray
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
@@ -43,6 +43,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        [JsiiProperty("optionalAny", "{\"primitive\":\"any\",\"optional\":true}")]
+        public virtual object OptionalAny
+        {
+            get => GetInstanceProperty<object>();
+            set => SetInstanceProperty(value);
+        }
+
         [JsiiProperty("optionalArray", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}")]
         public virtual string[] OptionalArray
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
@@ -39,6 +39,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        [JsiiProperty("optionalAny", "{\"primitive\":\"any\",\"optional\":true}")]
+        object OptionalAny
+        {
+            get;
+            set;
+        }
+
         [JsiiProperty("optionalArray", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}")]
         string[] OptionalArray
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
@@ -24,6 +24,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});
         }
 
+        [JsiiMethod("methodWithOptionalAnyArgument", null, "[{\"name\":\"arg\",\"type\":{\"primitive\":\"any\",\"optional\":true}}]")]
+        public virtual void MethodWithOptionalAnyArgument(object arg)
+        {
+            InvokeInstanceVoidMethod(new object[]{arg});
+        }
+
         /// <summary>Used to verify verification of number of method arguments.</summary>
         [JsiiMethod("methodWithOptionalArguments", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
         public virtual void MethodWithOptionalArguments(double arg1, string arg2, DateTime? arg3)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseBundledDependency.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseBundledDependency.cs
@@ -17,7 +17,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod("value", "{\"primitive\":\"any\"}", "[]")]
+        [JsiiMethod("value", "{\"primitive\":\"any\",\"optional\":true}", "[]")]
         public virtual object Value()
         {
             return InvokeInstanceMethod<object>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -39,14 +39,6 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
         this.jsiiSet("anyMapProperty", java.util.Objects.requireNonNull(value, "anyMapProperty is required"));
     }
 
-    public java.lang.Object getAnyProperty() {
-        return this.jsiiGet("anyProperty", java.lang.Object.class);
-    }
-
-    public void setAnyProperty(final java.lang.Object value) {
-        this.jsiiSet("anyProperty", java.util.Objects.requireNonNull(value, "anyProperty is required"));
-    }
-
     public java.util.List<java.lang.String> getArrayProperty() {
         return this.jsiiGet("arrayProperty", java.util.List.class);
     }
@@ -159,12 +151,13 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
         this.jsiiSet("unknownMapProperty", java.util.Objects.requireNonNull(value, "unknownMapProperty is required"));
     }
 
-    public java.lang.Object getUnknownProperty() {
-        return this.jsiiGet("unknownProperty", java.lang.Object.class);
+    @javax.annotation.Nullable
+    public java.lang.Object getAnyProperty() {
+        return this.jsiiGet("anyProperty", java.lang.Object.class);
     }
 
-    public void setUnknownProperty(final java.lang.Object value) {
-        this.jsiiSet("unknownProperty", java.util.Objects.requireNonNull(value, "unknownProperty is required"));
+    public void setAnyProperty(@javax.annotation.Nullable final java.lang.Object value) {
+        this.jsiiSet("anyProperty", value);
     }
 
     @javax.annotation.Nullable
@@ -174,5 +167,14 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
 
     public void setOptionalEnumValue(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.StringEnum value) {
         this.jsiiSet("optionalEnumValue", value);
+    }
+
+    @javax.annotation.Nullable
+    public java.lang.Object getUnknownProperty() {
+        return this.jsiiGet("unknownProperty", java.lang.Object.class);
+    }
+
+    public void setUnknownProperty(@javax.annotation.Nullable final java.lang.Object value) {
+        this.jsiiSet("unknownProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -25,6 +25,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * This is optional.
      */
     void setAnotherOptional(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value);
+    java.lang.Object getOptionalAny();
+    void setOptionalAny(final java.lang.Object value);
     java.util.List<java.lang.String> getOptionalArray();
     void setOptionalArray(final java.util.List<java.lang.String> value);
 
@@ -44,6 +46,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         private software.amazon.jsii.tests.calculator.DoubleTrouble _nonPrimitive;
         @javax.annotation.Nullable
         private java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> _anotherOptional;
+        @javax.annotation.Nullable
+        private java.lang.Object _optionalAny;
         @javax.annotation.Nullable
         private java.util.List<java.lang.String> _optionalArray;
         private java.lang.Number _anumber;
@@ -85,6 +89,15 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          */
         public Builder withAnotherOptional(@javax.annotation.Nullable final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value) {
             this._anotherOptional = value;
+            return this;
+        }
+        /**
+         * Sets the value of OptionalAny
+         * @param value the value to be set
+         * @return {@code this}
+         */
+        public Builder withOptionalAny(@javax.annotation.Nullable final java.lang.Object value) {
+            this._optionalAny = value;
             return this;
         }
         /**
@@ -137,6 +150,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
                 @javax.annotation.Nullable
                 private java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> $anotherOptional = _anotherOptional;
                 @javax.annotation.Nullable
+                private java.lang.Object $optionalAny = _optionalAny;
+                @javax.annotation.Nullable
                 private java.util.List<java.lang.String> $optionalArray = _optionalArray;
                 private java.lang.Number $anumber = java.util.Objects.requireNonNull(_anumber, "anumber is required");
                 private java.lang.String $astring = java.util.Objects.requireNonNull(_astring, "astring is required");
@@ -181,6 +196,16 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
                 @Override
                 public void setAnotherOptional(@javax.annotation.Nullable final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value) {
                     this.$anotherOptional = value;
+                }
+
+                @Override
+                public java.lang.Object getOptionalAny() {
+                    return this.$optionalAny;
+                }
+
+                @Override
+                public void setOptionalAny(@javax.annotation.Nullable final java.lang.Object value) {
+                    this.$optionalAny = value;
                 }
 
                 @Override
@@ -286,6 +311,17 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         @Override
         public void setAnotherOptional(@javax.annotation.Nullable final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value) {
             this.jsiiSet("anotherOptional", value);
+        }
+
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.Object getOptionalAny() {
+            return this.jsiiGet("optionalAny", java.lang.Object.class);
+        }
+
+        @Override
+        public void setOptionalAny(@javax.annotation.Nullable final java.lang.Object value) {
+            this.jsiiSet("optionalAny", value);
         }
 
         @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -19,6 +19,14 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
     }
 
+    public void methodWithOptionalAnyArgument(@javax.annotation.Nullable final java.lang.Object arg) {
+        this.jsiiCall("methodWithOptionalAnyArgument", Void.class, java.util.stream.Stream.of(arg).toArray());
+    }
+
+    public void methodWithOptionalAnyArgument() {
+        this.jsiiCall("methodWithOptionalAnyArgument", Void.class);
+    }
+
     /**
      * Used to verify verification of number of method arguments.
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -11,6 +11,7 @@ public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    @javax.annotation.Nullable
     public java.lang.Object value() {
         return this.jsiiCall("value", java.lang.Object.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1009,6 +1009,11 @@ DerivedStruct (interface)
       :type: string => :py:class:`@scope/jsii-calc-lib.Value`\  or undefined *(abstract)*
 
 
+   .. py:attribute:: optionalAny
+
+      :type: any or undefined *(abstract)*
+
+
    .. py:attribute:: optionalArray
 
       :type: string[] or undefined *(abstract)*
@@ -2523,6 +2528,12 @@ RuntimeTypeChecking
       :type arg2: string
       :param arg3: 
       :type arg3: date or undefined
+
+
+   .. py:method:: methodWithOptionalAnyArgument([arg])
+
+      :param arg: 
+      :type arg: any or undefined
 
 
    .. py:method:: methodWithOptionalArguments(arg1, arg2, [arg3])

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -348,17 +348,12 @@ AllTypes
 
    .. py:attribute:: anyArrayProperty
 
-      :type: any[]
+      :type: (any or undefined)[]
 
 
    .. py:attribute:: anyMapProperty
 
-      :type: string => any
-
-
-   .. py:attribute:: anyProperty
-
-      :type: any
+      :type: string => (any or undefined)
 
 
    .. py:attribute:: arrayProperty
@@ -418,22 +413,27 @@ AllTypes
 
    .. py:attribute:: unknownArrayProperty
 
-      :type: any[]
+      :type: (any or undefined)[]
 
 
    .. py:attribute:: unknownMapProperty
 
-      :type: string => any
+      :type: string => (any or undefined)
 
 
-   .. py:attribute:: unknownProperty
+   .. py:attribute:: anyProperty
 
-      :type: any
+      :type: any or undefined
 
 
    .. py:attribute:: optionalEnumValue
 
       :type: :py:class:`~jsii-calc.StringEnum`\  or undefined
+
+
+   .. py:attribute:: unknownProperty
+
+      :type: any or undefined
 
 
 AllTypesEnum (enum)
@@ -2977,7 +2977,7 @@ UseBundledDependency
 
    .. py:method:: value() -> any
 
-      :rtype: any
+      :rtype: any or undefined
 
 
 UseCalcBase

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -604,6 +604,10 @@ export class Assembler implements Emitter {
             property.immutable = (ts.getCombinedModifierFlags(signature) & ts.ModifierFlags.Readonly) !== 0;
         }
 
+        if (signature.questionToken) {
+            property.type.optional = true;
+        }
+
         if (property.static && property.immutable && ts.isPropertyDeclaration(signature) && signature.initializer) {
             property.const = true;
         }
@@ -627,7 +631,7 @@ export class Assembler implements Emitter {
         if (parameter.variadic) {
             parameter.type = (parameter.type as spec.CollectionTypeReference).collection.elementtype;
         }
-        if (paramDeclaration.initializer != null) {
+        if (paramDeclaration.initializer || paramDeclaration.questionToken) {
             parameter.type.optional = true;
         }
         this._visitDocumentation(paramSymbol, parameter);

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -654,7 +654,7 @@ export class Assembler implements Emitter {
 
         if (!type.symbol) {
             this._diagnostic(declaration, ts.DiagnosticCategory.Error, `Non-primitive types must have a symbol`);
-            return { primitive: spec.PrimitiveType.Any };
+            return { primitive: spec.PrimitiveType.Any, optional: true };
         }
 
         if (type.symbol.name === 'Array') {
@@ -671,7 +671,7 @@ export class Assembler implements Emitter {
                 this._diagnostic(declaration,
                                  ts.DiagnosticCategory.Error,
                                  `Un-specified promise type (need to specify as Promise<T>)`);
-                return { primitive: spec.PrimitiveType.Any, promise: true };
+                return { primitive: spec.PrimitiveType.Any, optional: true, promise: true };
             } else {
                 return {
                     ...await this._typeReference(typeRef.typeArguments[0], declaration),
@@ -693,7 +693,7 @@ export class Assembler implements Emitter {
                 this._diagnostic(declaration,
                                  ts.DiagnosticCategory.Error,
                                  `Array references must have exactly one type argument (found ${count})`);
-                elementtype = { primitive: spec.PrimitiveType.Any };
+                elementtype = { primitive: spec.PrimitiveType.Any, optional: true };
             }
 
             return {
@@ -713,7 +713,7 @@ export class Assembler implements Emitter {
                 this._diagnostic(declaration,
                                  ts.DiagnosticCategory.Error,
                                  `Only string index maps are supported`);
-                elementtype = { primitive: spec.PrimitiveType.Any };
+                elementtype = { primitive: spec.PrimitiveType.Any, optional: true };
             }
             return {
                 collection: {
@@ -731,7 +731,7 @@ export class Assembler implements Emitter {
                 }
                 // tslint:disable-next-line:no-bitwise
                 if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
-                    return { primitive: spec.PrimitiveType.Any };
+                    return { primitive: spec.PrimitiveType.Any, optional: true };
                 }
             } else {
                 switch (type.symbol.name) {


### PR DESCRIPTION
Optional parameters and properties typed `any` would be represented as
required, despite the code unambiguously suggests the opposite. This is
due to the fact that `any` implicitly covers `null` and `undefined`.
This change fixes this by adding a specific provision for the question
mark token in the declarations of those, and adds compliance test
coverage for the same.

Fixes #230