### PR TITLE
feat: Document overriden/inherited members

### DIFF
--- a/packages/jsii-pacmak/lib/targets/sphinx.ts
+++ b/packages/jsii-pacmak/lib/targets/sphinx.ts
@@ -388,13 +388,13 @@ class SphinxDocsGenerator extends Generator {
         for (const parent of parents) {
             const parentType = this.findType(parent.fqn) as spec.ClassType | spec.InterfaceType;
             for (const method of parentType.methods || []) {
-                if (knownMembers.has(method.name!)) { continue; }
+                if (method.static || knownMembers.has(method.name!)) { continue; }
                 result[parentType.fqn] = result[parentType.fqn] || { methods: [], properties: [] };
                 result[parentType.fqn].methods.push(method);
                 knownMembers.add(method.name!);
             }
             for (const property of parentType.properties || []) {
-                if (knownMembers.has(property.name!)) { continue; }
+                if (property.static || knownMembers.has(property.name!)) { continue; }
                 result[parentType.fqn] = result[parentType.fqn] || { methods: [], properties: [] };
                 result[parentType.fqn].properties.push(property);
                 knownMembers.add(property.name);

--- a/packages/jsii-pacmak/lib/targets/sphinx.ts
+++ b/packages/jsii-pacmak/lib/targets/sphinx.ts
@@ -505,7 +505,7 @@ class SphinxDocsGenerator extends Generator {
 
         if (inheritedFrom) {
             this.code.line();
-            this.code.line(`*Inherited from* :py:meth:\`${inheritedFrom}.${method.name}\``);
+            this.code.line(`*Inherited from* :py:meth:\`${inheritedFrom} <${inheritedFrom}.${method.name}>\``);
         } else if (method.overrides) {
             this.code.line();
             const superType = this.findType(method.overrides.fqn) as spec.ClassType | spec.InterfaceType;
@@ -634,7 +634,7 @@ class SphinxDocsGenerator extends Generator {
         this.code.openBlock(`.. py:attribute:: ${prop.name}`);
         if (inheritedFrom) {
             this.code.line();
-            this.code.line(`*Inherited from* :py:attr:\`${inheritedFrom}.${prop.name}\``);
+            this.code.line(`*Inherited from* :py:attr:\`${inheritedFrom} <${inheritedFrom}.${prop.name}>\``);
         } else if (prop.overrides) {
             this.code.line();
             const superType = this.findType(prop.overrides.fqn) as spec.ClassType | spec.InterfaceType;

--- a/packages/jsii-pacmak/lib/targets/sphinx.ts
+++ b/packages/jsii-pacmak/lib/targets/sphinx.ts
@@ -233,7 +233,8 @@ class SphinxDocsGenerator extends Generator {
         this.namespaceStack.push({ name: className, underClass: true });
     }
 
-    protected onEndClass(_cls: spec.ClassType) {
+    protected onEndClass(cls: spec.ClassType) {
+        this.renderInheritedMembers(cls);
         this.code.closeBlock();
         this.namespaceStack.pop();
         if (!this.topNamespace.underClass) { this.closeSection(); }
@@ -342,7 +343,8 @@ class SphinxDocsGenerator extends Generator {
         this.code.line();
     }
 
-    protected onEndInterface(_ifc: spec.InterfaceType) {
+    protected onEndInterface(ifc: spec.InterfaceType) {
+        this.renderInheritedMembers(ifc);
         this.code.closeBlock();
         if (!this.topNamespace.underClass) { this.closeSection(); }
     }
@@ -357,6 +359,62 @@ class SphinxDocsGenerator extends Generator {
 
     protected onInterfaceProperty(_ifc: spec.InterfaceType, property: spec.Property) {
         this.renderProperty(property);
+    }
+
+    private renderInheritedMembers(entity: spec.ClassType | spec.InterfaceType) {
+        const inherited = this.getInheritedMembers(entity);
+        if (Object.keys(inherited).length === 0) { return; }
+        for (const source of Object.keys(inherited).sort()) {
+            const entities = inherited[source];
+            for (const method of entities.methods) {
+                this.renderMethod(method, source);
+                for (const overload of this.createOverloadsForOptionals(method)) {
+                    this.renderMethod(overload, source);
+                }
+            }
+            for (const property of entities.properties) {
+                this.renderProperty(property, source);
+            }
+        }
+    }
+
+    private getInheritedMembers(entity: spec.ClassType | spec.InterfaceType): InheritedMembers {
+        const parents = parentTypes(entity);
+        const knownMembers = new Set<string>([
+            ...(entity.methods || []).map(m => m.name!),
+            ...(entity.properties || []).map(p => p.name)
+        ]);
+        const result: InheritedMembers = {};
+        for (const parent of parents) {
+            const parentType = this.findType(parent.fqn) as spec.ClassType | spec.InterfaceType;
+            for (const method of parentType.methods || []) {
+                if (knownMembers.has(method.name!)) { continue; }
+                result[parentType.fqn] = result[parentType.fqn] || { methods: [], properties: [] };
+                result[parentType.fqn].methods.push(method);
+                knownMembers.add(method.name!);
+            }
+            for (const property of parentType.properties || []) {
+                if (knownMembers.has(property.name!)) { continue; }
+                result[parentType.fqn] = result[parentType.fqn] || { methods: [], properties: [] };
+                result[parentType.fqn].properties.push(property);
+                knownMembers.add(property.name);
+            }
+            for (const superType of parentTypes(parentType)) {
+                parents.push(superType);
+            }
+        }
+        return result;
+
+        function parentTypes(type: spec.ClassType | spec.InterfaceType) {
+            const types = new Array<spec.NamedTypeReference>();
+            if (spec.isClassType(type) && type.base) {
+                types.push(type.base);
+            }
+            if (type.interfaces) {
+                types.push(...type.interfaces);
+            }
+            return types;
+        }
     }
 
     /**
@@ -402,7 +460,7 @@ class SphinxDocsGenerator extends Generator {
                 signature += ', ';
             }
 
-            if (p.type.optional) {
+            if (p.type.optional && !params.slice(idx + 1).find(e => !e.type.optional)) {
                 signature += '[';
                 signaturePosfix += ']';
             }
@@ -437,7 +495,7 @@ class SphinxDocsGenerator extends Generator {
         }
     }
 
-    private renderMethod(method: spec.Method) {
+    private renderMethod(method: spec.Method, inheritedFrom?: string) {
         const signature = this.renderMethodSignature(method);
 
         const type = method.static ? `py:staticmethod` : `py:method`;
@@ -445,14 +503,32 @@ class SphinxDocsGenerator extends Generator {
         this.code.line();
         this.code.openBlock(`.. ${type}:: ${method.name}${signature}`);
 
+        if (inheritedFrom) {
+            this.code.line();
+            this.code.line(`*Inherited from* :py:meth:\`${inheritedFrom}.${method.name}\``);
+        } else if (method.overrides) {
+            this.code.line();
+            const superType = this.findType(method.overrides.fqn) as spec.ClassType | spec.InterfaceType;
+            if (spec.isInterfaceType(superType) || superType.methods!.find(m => m.name === method.name && !!m.abstract)) {
+                this.code.line(`*Implements* :py:meth:\`${method.overrides.fqn}.${method.name}\``);
+            } else {
+                this.code.line(`*Overrides* :py:meth:\`${method.overrides.fqn}.${method.name}\``);
+            }
+        }
         this.renderDocsLine(method);
         this.code.line();
+        if (method.protected) {
+            this.code.line('*Protected method*');
+            this.code.line();
+        }
 
         this.renderMethodParameters(method);
 
         // @return doc
         if (method.docs && method.docs.return) {
-            this.code.line(`:return: ${method.docs.return}`);
+            const [firstLine, ...rest] = method.docs.return.split('\n');
+            this.code.line(`:return: ${firstLine}`);
+            rest.forEach(line => this.code.line(`   ${line}`));
         }
 
         if (method.returns) {
@@ -542,7 +618,7 @@ class SphinxDocsGenerator extends Generator {
         } else {
             throw new Error('Unexpected type ref');
         }
-        if (type.optional) { result.ref = `${result.ref} or undefined`; }
+        if (type.optional) { result.ref = `${result.ref} or \`\`undefined\`\``; }
         return result;
 
         // Wrap a string between parenthesis if it contains " or "
@@ -552,12 +628,28 @@ class SphinxDocsGenerator extends Generator {
         }
     }
 
-    private renderProperty(prop: spec.Property) {
+    private renderProperty(prop: spec.Property, inheritedFrom?: string) {
         this.code.line();
         const type = this.renderTypeRef(prop.type);
         this.code.openBlock(`.. py:attribute:: ${prop.name}`);
+        if (inheritedFrom) {
+            this.code.line();
+            this.code.line(`*Inherited from* :py:attr:\`${inheritedFrom}.${prop.name}\``);
+        } else if (prop.overrides) {
+            this.code.line();
+            const superType = this.findType(prop.overrides.fqn) as spec.ClassType | spec.InterfaceType;
+            if (spec.isInterfaceType(superType) || superType.properties!.find(p => p.name === prop.name && !!p.abstract)) {
+                this.code.line(`*Implements* :py:meth:\`${prop.overrides.fqn}.${prop.name}\``);
+            } else {
+                this.code.line(`*Overrides* :py:attr:\`${prop.overrides.fqn}.${prop.name}\``);
+            }
+        }
         this.renderDocsLine(prop);
         this.code.line();
+        if (prop.protected) {
+            this.code.line('*Protected property*');
+            this.code.line();
+        }
         const readonly = prop.immutable ? ' *(readonly)*' : '';
         const abs = prop.abstract ? ' *(abstract)*' : '';
         const stat = prop.static ? ' *(static)*' : '';
@@ -665,3 +757,5 @@ function formatLanguage(language: string): string {
         return language;
     }
 }
+
+type InheritedMembers = { [typeFqn: string]: { methods: spec.Method[], properties: spec.Property[] } };

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -196,3 +196,10 @@ BaseProps (interface)
       :type: string *(abstract)*
 
 
+   .. py:attribute:: foo
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps.foo`
+
+      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
+
+

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -198,7 +198,7 @@ BaseProps (interface)
 
    .. py:attribute:: foo
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps.foo`
+      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps <@scope/jsii-calc-base-of-base.VeryBaseProps.foo>`
 
       :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -249,7 +249,7 @@ MyFirstStruct (interface)
 
    .. py:attribute:: firstOptional
 
-      :type: string[] or undefined *(abstract)*
+      :type: string[] or ``undefined`` *(abstract)*
 
 
 Number
@@ -296,10 +296,30 @@ Number
 
    .. py:attribute:: value
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
+
       The number.
 
 
       :type: number *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Value.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
 
 
 Operation
@@ -337,11 +357,31 @@ Operation
 
    .. py:method:: toString() -> string
 
+      *Overrides* :py:meth:`@scope/jsii-calc-lib.Value.toString`
+
       String representation of the value.
 
 
       :rtype: string
       :abstract: Yes
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+
+      The value.
+
+
+      :type: number *(readonly)* *(abstract)*
 
 
 StructWithOnlyOptionals (interface)
@@ -381,17 +421,17 @@ StructWithOnlyOptionals (interface)
       The first optional!
 
 
-      :type: string or undefined *(abstract)*
+      :type: string or ``undefined`` *(abstract)*
 
 
    .. py:attribute:: optional2
 
-      :type: number or undefined *(abstract)*
+      :type: number or ``undefined`` *(abstract)*
 
 
    .. py:attribute:: optional3
 
-      :type: boolean or undefined *(abstract)*
+      :type: boolean or ``undefined`` *(abstract)*
 
 
 Value
@@ -441,5 +481,13 @@ Value
 
 
       :type: number *(readonly)* *(abstract)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -306,7 +306,7 @@ Number
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -314,7 +314,7 @@ Number
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Value.toString`
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.toString>`
 
       String representation of the value.
 
@@ -368,7 +368,7 @@ Operation
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -376,7 +376,7 @@ Operation
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
 
@@ -485,7 +485,7 @@ Value
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -178,7 +178,7 @@ AbstractClass
 
    .. py:attribute:: abstractProperty
 
-      *Inherited from* :py:attr:`jsii-calc.AbstractClassBase.abstractProperty`
+      *Inherited from* :py:attr:`jsii-calc.AbstractClassBase <jsii-calc.AbstractClassBase.abstractProperty>`
 
       :type: string *(readonly)* *(abstract)*
 
@@ -318,7 +318,7 @@ Add
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -326,7 +326,7 @@ Add
 
    .. py:method:: hello() -> string
 
-      *Inherited from* :py:meth:`jsii-calc.BinaryOperation.hello`
+      *Inherited from* :py:meth:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.hello>`
 
       Say hello!
 
@@ -336,7 +336,7 @@ Add
 
    .. py:attribute:: lhs
 
-      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.lhs`
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.lhs>`
 
       Left-hand side operand
 
@@ -346,7 +346,7 @@ Add
 
    .. py:attribute:: rhs
 
-      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.rhs`
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.rhs>`
 
       Right-hand side operand
 
@@ -720,7 +720,7 @@ BinaryOperation
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -728,7 +728,7 @@ BinaryOperation
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation <@scope/jsii-calc-lib.Operation.toString>`
 
       String representation of the value.
 
@@ -739,7 +739,7 @@ BinaryOperation
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
 
@@ -875,7 +875,7 @@ Calculator
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -883,7 +883,7 @@ Calculator
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.toString>`
 
       String representation of the value.
 
@@ -893,7 +893,7 @@ Calculator
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
 
@@ -903,7 +903,7 @@ Calculator
 
    .. py:attribute:: decorationPostfixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPostfixes>`
 
       A set of postfixes to include in a decorated .toString().
 
@@ -913,7 +913,7 @@ Calculator
 
    .. py:attribute:: decorationPrefixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPrefixes>`
 
       A set of prefixes to include in a decorated .toString().
 
@@ -923,7 +923,7 @@ Calculator
 
    .. py:attribute:: stringStyle
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
 
@@ -1091,7 +1091,7 @@ Derived
 
    .. py:attribute:: prop
 
-      *Inherited from* :py:attr:`jsii-calc.DerivedClassHasNoProperties.Base.prop`
+      *Inherited from* :py:attr:`jsii-calc.DerivedClassHasNoProperties.Base <jsii-calc.DerivedClassHasNoProperties.Base.prop>`
 
       :type: string
 
@@ -1165,7 +1165,7 @@ DerivedStruct (interface)
 
    .. py:attribute:: anumber
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.anumber`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct <@scope/jsii-calc-lib.MyFirstStruct.anumber>`
 
       An awesome number value
 
@@ -1175,7 +1175,7 @@ DerivedStruct (interface)
 
    .. py:attribute:: astring
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.astring`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct <@scope/jsii-calc-lib.MyFirstStruct.astring>`
 
       A string value
 
@@ -1185,7 +1185,7 @@ DerivedStruct (interface)
 
    .. py:attribute:: firstOptional
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.firstOptional`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct <@scope/jsii-calc-lib.MyFirstStruct.firstOptional>`
 
       :type: string[] or ``undefined`` *(abstract)*
 
@@ -1356,7 +1356,7 @@ IFriendlier (interface)
 
    .. py:method:: hello() -> string
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly <@scope/jsii-calc-lib.IFriendly.hello>`
 
       Say hello!
 
@@ -1398,7 +1398,7 @@ IFriendlyRandomGenerator (interface)
 
    .. py:method:: hello() -> string
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly <@scope/jsii-calc-lib.IFriendly.hello>`
 
       Say hello!
 
@@ -1409,7 +1409,7 @@ IFriendlyRandomGenerator (interface)
 
    .. py:method:: next() -> number
 
-      *Inherited from* :py:meth:`jsii-calc.IRandomNumberGenerator.next`
+      *Inherited from* :py:meth:`jsii-calc.IRandomNumberGenerator <jsii-calc.IRandomNumberGenerator.next>`
 
       Returns another random number.
 
@@ -1495,14 +1495,14 @@ IInterfaceWithPropertiesExtension (interface)
 
    .. py:attribute:: readOnlyString
 
-      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties.readOnlyString`
+      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties <jsii-calc.IInterfaceWithProperties.readOnlyString>`
 
       :type: string *(readonly)* *(abstract)*
 
 
    .. py:attribute:: readWriteString
 
-      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties.readWriteString`
+      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties <jsii-calc.IInterfaceWithProperties.readWriteString>`
 
       :type: string *(abstract)*
 
@@ -1586,14 +1586,14 @@ ImplictBaseOfBase (interface)
 
    .. py:attribute:: foo
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps.foo`
+      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps <@scope/jsii-calc-base-of-base.VeryBaseProps.foo>`
 
       :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
 
 
    .. py:attribute:: bar
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-base.BaseProps.bar`
+      *Inherited from* :py:attr:`@scope/jsii-calc-base.BaseProps <@scope/jsii-calc-base.BaseProps.bar>`
 
       :type: string *(abstract)*
 
@@ -2233,7 +2233,7 @@ Multiply
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -2241,7 +2241,7 @@ Multiply
 
    .. py:method:: hello() -> string
 
-      *Inherited from* :py:meth:`jsii-calc.BinaryOperation.hello`
+      *Inherited from* :py:meth:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.hello>`
 
       Say hello!
 
@@ -2251,7 +2251,7 @@ Multiply
 
    .. py:attribute:: lhs
 
-      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.lhs`
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.lhs>`
 
       Left-hand side operand
 
@@ -2261,7 +2261,7 @@ Multiply
 
    .. py:attribute:: rhs
 
-      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.rhs`
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.rhs>`
 
       Right-hand side operand
 
@@ -2356,7 +2356,7 @@ Negate
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -2364,7 +2364,7 @@ Negate
 
    .. py:attribute:: operand
 
-      *Inherited from* :py:attr:`jsii-calc.UnaryOperation.operand`
+      *Inherited from* :py:attr:`jsii-calc.UnaryOperation <jsii-calc.UnaryOperation.operand>`
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
@@ -2719,7 +2719,7 @@ Power
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -2727,7 +2727,7 @@ Power
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.toString>`
 
       String representation of the value.
 
@@ -2737,7 +2737,7 @@ Power
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
 
@@ -2747,7 +2747,7 @@ Power
 
    .. py:attribute:: decorationPostfixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPostfixes>`
 
       A set of postfixes to include in a decorated .toString().
 
@@ -2757,7 +2757,7 @@ Power
 
    .. py:attribute:: decorationPrefixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPrefixes>`
 
       A set of prefixes to include in a decorated .toString().
 
@@ -2767,7 +2767,7 @@ Power
 
    .. py:attribute:: stringStyle
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
 
@@ -3091,7 +3091,7 @@ Sum
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -3099,7 +3099,7 @@ Sum
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.toString>`
 
       String representation of the value.
 
@@ -3109,7 +3109,7 @@ Sum
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
 
@@ -3119,7 +3119,7 @@ Sum
 
    .. py:attribute:: decorationPostfixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPostfixes>`
 
       A set of postfixes to include in a decorated .toString().
 
@@ -3129,7 +3129,7 @@ Sum
 
    .. py:attribute:: decorationPrefixes
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.decorationPrefixes>`
 
       A set of prefixes to include in a decorated .toString().
 
@@ -3139,7 +3139,7 @@ Sum
 
    .. py:attribute:: stringStyle
 
-      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
 
@@ -3334,7 +3334,7 @@ UnaryOperation
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any
@@ -3342,7 +3342,7 @@ UnaryOperation
 
    .. py:method:: toString() -> string
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation <@scope/jsii-calc-lib.Operation.toString>`
 
       String representation of the value.
 
@@ -3353,7 +3353,7 @@ UnaryOperation
 
    .. py:attribute:: value
 
-      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
 
@@ -3755,7 +3755,7 @@ CompositeOperation
 
    .. py:method:: typeName() -> any
 
-      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base <@scope/jsii-calc-base.Base.typeName>`
 
       :return: the name of the class (to verify native type names are created for derived classes).
       :rtype: any

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -171,7 +171,16 @@ AbstractClass
 
    .. py:attribute:: propFromInterface
 
+      *Implements* :py:meth:`jsii-calc.InterfaceImplementedByAbstractClass.propFromInterface`
+
       :type: string *(readonly)*
+
+
+   .. py:attribute:: abstractProperty
+
+      *Inherited from* :py:attr:`jsii-calc.AbstractClassBase.abstractProperty`
+
+      :type: string *(readonly)* *(abstract)*
 
 
 AbstractClassBase
@@ -289,6 +298,8 @@ Add
 
    .. py:method:: toString() -> string
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+
       String representation of the value.
 
 
@@ -297,10 +308,50 @@ Add
 
    .. py:attribute:: value
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
+
       The value.
 
 
       :type: number *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: hello() -> string
+
+      *Inherited from* :py:meth:`jsii-calc.BinaryOperation.hello`
+
+      Say hello!
+
+
+      :rtype: string
+
+
+   .. py:attribute:: lhs
+
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.lhs`
+
+      Left-hand side operand
+
+
+      :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
+
+
+   .. py:attribute:: rhs
+
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.rhs`
+
+      Right-hand side operand
+
+
+      :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
 AllTypes
@@ -433,7 +484,7 @@ AllTypes
 
    .. py:attribute:: optionalEnumValue
 
-      :type: :py:class:`~jsii-calc.StringEnum`\  or undefined
+      :type: :py:class:`~jsii-calc.StringEnum`\  or ``undefined``
 
 
 AllTypesEnum (enum)
@@ -643,6 +694,8 @@ BinaryOperation
 
    .. py:method:: hello() -> string
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+
       Say hello!
 
 
@@ -663,6 +716,35 @@ BinaryOperation
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
+      :abstract: Yes
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+
+      The value.
+
+
+      :type: number *(readonly)* *(abstract)*
 
 
 Calculator
@@ -697,7 +779,7 @@ Calculator
 
    :extends: :py:class:`~jsii-calc.composition.CompositeOperation`\ 
    :param props: Initialization properties.
-   :type props: :py:class:`~jsii-calc.CalculatorProps`\  or undefined
+   :type props: :py:class:`~jsii-calc.CalculatorProps`\  or ``undefined``
 
    .. py:method:: add(value)
 
@@ -743,6 +825,8 @@ Calculator
 
    .. py:attribute:: expression
 
+      *Implements* :py:meth:`jsii-calc.composition.CompositeOperation.expression`
+
       Returns the expression.
 
 
@@ -778,7 +862,7 @@ Calculator
       The maximum value allows in this calculator.
 
 
-      :type: number or undefined
+      :type: number or ``undefined``
 
 
    .. py:attribute:: unionProperty
@@ -786,7 +870,65 @@ Calculator
       Example of a property that accepts a union of types.
 
 
-      :type: :py:class:`~jsii-calc.Add`\  or :py:class:`~jsii-calc.Multiply`\  or :py:class:`~jsii-calc.Power`\  or undefined
+      :type: :py:class:`~jsii-calc.Add`\  or :py:class:`~jsii-calc.Multiply`\  or :py:class:`~jsii-calc.Power`\  or ``undefined``
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+
+      The value.
+
+
+      :type: number *(readonly)*
+
+
+   .. py:attribute:: decorationPostfixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+
+      A set of postfixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: decorationPrefixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+
+      A set of prefixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: stringStyle
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+
+      The .toString() style.
+
+
+      :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
 
 
 CalculatorProps (interface)
@@ -823,18 +965,18 @@ CalculatorProps (interface)
 
    .. py:attribute:: initialValue
 
-      :type: number or undefined *(abstract)*
+      :type: number or ``undefined`` *(abstract)*
 
 
    .. py:attribute:: maximumValue
 
-      :type: number or undefined *(abstract)*
+      :type: number or ``undefined`` *(abstract)*
 
 
 DefaultedConstructorArgument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:class:: DefaultedConstructorArgument([arg1, arg2, [arg3]])
+.. py:class:: DefaultedConstructorArgument(arg1, arg2, [arg3])
 
    **Language-specific names:**
 
@@ -859,11 +1001,11 @@ DefaultedConstructorArgument
 
 
    :param arg1: 
-   :type arg1: number or undefined
+   :type arg1: number or ``undefined``
    :param arg2: 
    :type arg2: string
    :param arg3: 
-   :type arg3: date or undefined
+   :type arg3: date or ``undefined``
 
    .. py:attribute:: arg1
 
@@ -947,6 +1089,13 @@ Derived
 
    :extends: :py:class:`~jsii-calc.DerivedClassHasNoProperties.Base`\ 
 
+   .. py:attribute:: prop
+
+      *Inherited from* :py:attr:`jsii-calc.DerivedClassHasNoProperties.Base.prop`
+
+      :type: string
+
+
 
 .. py:currentmodule:: jsii-calc
 
@@ -1006,12 +1155,39 @@ DerivedStruct (interface)
       This is optional.
 
 
-      :type: string => :py:class:`@scope/jsii-calc-lib.Value`\  or undefined *(abstract)*
+      :type: string => :py:class:`@scope/jsii-calc-lib.Value`\  or ``undefined`` *(abstract)*
 
 
    .. py:attribute:: optionalArray
 
-      :type: string[] or undefined *(abstract)*
+      :type: string[] or ``undefined`` *(abstract)*
+
+
+   .. py:attribute:: anumber
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.anumber`
+
+      An awesome number value
+
+
+      :type: number *(abstract)*
+
+
+   .. py:attribute:: astring
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.astring`
+
+      A string value
+
+
+      :type: string *(abstract)*
+
+
+   .. py:attribute:: firstOptional
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct.firstOptional`
+
+      :type: string[] or ``undefined`` *(abstract)*
 
 
 DoubleTrouble
@@ -1045,6 +1221,8 @@ DoubleTrouble
 
    .. py:method:: hello() -> string
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+
       Say hello!
 
 
@@ -1052,6 +1230,8 @@ DoubleTrouble
 
 
    .. py:method:: next() -> number
+
+      *Implements* :py:meth:`jsii-calc.IRandomNumberGenerator.next`
 
       Returns another random number.
 
@@ -1174,6 +1354,17 @@ IFriendlier (interface)
       :abstract: Yes
 
 
+   .. py:method:: hello() -> string
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+
+      Say hello!
+
+
+      :rtype: string
+      :abstract: Yes
+
+
 IFriendlyRandomGenerator (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1203,6 +1394,29 @@ IFriendlyRandomGenerator (interface)
 
    :extends: :py:class:`~jsii-calc.IRandomNumberGenerator`\ 
    :extends: :py:class:`@scope/jsii-calc-lib.IFriendly`\ 
+
+
+   .. py:method:: hello() -> string
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+
+      Say hello!
+
+
+      :rtype: string
+      :abstract: Yes
+
+
+   .. py:method:: next() -> number
+
+      *Inherited from* :py:meth:`jsii-calc.IRandomNumberGenerator.next`
+
+      Returns another random number.
+
+
+      :return: A random number.
+      :rtype: number
+      :abstract: Yes
 
 
 IInterfaceWithProperties (interface)
@@ -1277,6 +1491,20 @@ IInterfaceWithPropertiesExtension (interface)
    .. py:attribute:: foo
 
       :type: number *(abstract)*
+
+
+   .. py:attribute:: readOnlyString
+
+      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties.readOnlyString`
+
+      :type: string *(readonly)* *(abstract)*
+
+
+   .. py:attribute:: readWriteString
+
+      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithProperties.readWriteString`
+
+      :type: string *(abstract)*
 
 
 IRandomNumberGenerator (interface)
@@ -1356,6 +1584,20 @@ ImplictBaseOfBase (interface)
       :type: date *(abstract)*
 
 
+   .. py:attribute:: foo
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps.foo`
+
+      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
+
+
+   .. py:attribute:: bar
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-base.BaseProps.bar`
+
+      :type: string *(abstract)*
+
+
 InterfaceImplementedByAbstractClass (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1428,7 +1670,7 @@ Foo
 
    .. py:attribute:: bar
 
-      :type: string or undefined
+      :type: string or ``undefined``
 
 
 Hello (interface)
@@ -1547,7 +1789,7 @@ InterfaceWithOptionalMethodArguments (interface)
       :param arg1: 
       :type arg1: string
       :param arg2: 
-      :type arg2: number or undefined
+      :type arg2: number or ``undefined``
       :abstract: Yes
 
 
@@ -1941,6 +2183,8 @@ Multiply
 
    .. py:method:: farewell() -> string
 
+      *Implements* :py:meth:`jsii-calc.IFriendlier.farewell`
+
       Say farewell.
 
 
@@ -1948,6 +2192,8 @@ Multiply
 
 
    .. py:method:: goodbye() -> string
+
+      *Implements* :py:meth:`jsii-calc.IFriendlier.goodbye`
 
       Say goodbye.
 
@@ -1957,6 +2203,8 @@ Multiply
 
    .. py:method:: next() -> number
 
+      *Implements* :py:meth:`jsii-calc.IRandomNumberGenerator.next`
+
       Returns another random number.
 
 
@@ -1964,6 +2212,8 @@ Multiply
 
 
    .. py:method:: toString() -> string
+
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
 
       String representation of the value.
 
@@ -1973,10 +2223,50 @@ Multiply
 
    .. py:attribute:: value
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
+
       The value.
 
 
       :type: number *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: hello() -> string
+
+      *Inherited from* :py:meth:`jsii-calc.BinaryOperation.hello`
+
+      Say hello!
+
+
+      :rtype: string
+
+
+   .. py:attribute:: lhs
+
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.lhs`
+
+      Left-hand side operand
+
+
+      :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
+
+
+   .. py:attribute:: rhs
+
+      *Inherited from* :py:attr:`jsii-calc.BinaryOperation.rhs`
+
+      Right-hand side operand
+
+
+      :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
 Negate
@@ -2016,6 +2306,8 @@ Negate
 
    .. py:method:: farewell() -> string
 
+      *Implements* :py:meth:`jsii-calc.IFriendlier.farewell`
+
       Say farewell.
 
 
@@ -2023,6 +2315,8 @@ Negate
 
 
    .. py:method:: goodbye() -> string
+
+      *Implements* :py:meth:`jsii-calc.IFriendlier.goodbye`
 
       Say goodbye.
 
@@ -2032,6 +2326,8 @@ Negate
 
    .. py:method:: hello() -> string
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.IFriendly.hello`
+
       Say hello!
 
 
@@ -2039,6 +2335,8 @@ Negate
 
 
    .. py:method:: toString() -> string
+
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
 
       String representation of the value.
 
@@ -2048,10 +2346,27 @@ Negate
 
    .. py:attribute:: value
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
+
       The value.
 
 
       :type: number *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:attribute:: operand
+
+      *Inherited from* :py:attr:`jsii-calc.UnaryOperation.operand`
+
+      :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
 NodeStandardLibrary
@@ -2253,7 +2568,7 @@ OptionalConstructorArgument
    :param arg2: 
    :type arg2: string
    :param arg3: 
-   :type arg3: date or undefined
+   :type arg3: date or ``undefined``
 
    .. py:attribute:: arg1
 
@@ -2267,7 +2582,7 @@ OptionalConstructorArgument
 
    .. py:attribute:: arg3
 
-      :type: date or undefined *(readonly)*
+      :type: date or ``undefined`` *(readonly)*
 
 
 OverrideReturnsObject
@@ -2386,6 +2701,8 @@ Power
 
    .. py:attribute:: expression
 
+      *Implements* :py:meth:`jsii-calc.composition.CompositeOperation.expression`
+
       The expression that this operation consists of. Must be implemented by derived classes.
 
 
@@ -2398,6 +2715,64 @@ Power
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+
+      The value.
+
+
+      :type: number *(readonly)*
+
+
+   .. py:attribute:: decorationPostfixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+
+      A set of postfixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: decorationPrefixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+
+      A set of prefixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: stringStyle
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+
+      The .toString() style.
+
+
+      :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
 
 
 ReferenceEnumFromScopedPackage
@@ -2433,7 +2808,7 @@ ReferenceEnumFromScopedPackage
 
    .. py:method:: loadFoo() -> @scope/jsii-calc-lib.EnumFromScopedModule
 
-      :rtype: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or undefined
+      :rtype: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or ``undefined``
 
 
    .. py:method:: saveFoo(value)
@@ -2444,7 +2819,7 @@ ReferenceEnumFromScopedPackage
 
    .. py:attribute:: foo
 
-      :type: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or undefined
+      :type: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or ``undefined``
 
 
 ReturnsNumber (interface)
@@ -2515,14 +2890,14 @@ RuntimeTypeChecking
 
 
 
-   .. py:method:: methodWithDefaultedArguments([arg1, arg2, [arg3]])
+   .. py:method:: methodWithDefaultedArguments(arg1, arg2, [arg3])
 
       :param arg1: 
-      :type arg1: number or undefined
+      :type arg1: number or ``undefined``
       :param arg2: 
       :type arg2: string
       :param arg3: 
-      :type arg3: date or undefined
+      :type arg3: date or ``undefined``
 
 
    .. py:method:: methodWithOptionalArguments(arg1, arg2, [arg3])
@@ -2535,7 +2910,7 @@ RuntimeTypeChecking
       :param arg2: 
       :type arg2: string
       :param arg3: 
-      :type arg3: date or undefined
+      :type arg3: date or ``undefined``
 
 
 Statics
@@ -2698,6 +3073,8 @@ Sum
 
    .. py:attribute:: expression
 
+      *Implements* :py:meth:`jsii-calc.composition.CompositeOperation.expression`
+
       The expression that this operation consists of. Must be implemented by derived classes.
 
 
@@ -2710,6 +3087,64 @@ Sum
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\ []
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`jsii-calc.composition.CompositeOperation.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.value`
+
+      The value.
+
+
+      :type: number *(readonly)*
+
+
+   .. py:attribute:: decorationPostfixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPostfixes`
+
+      A set of postfixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: decorationPrefixes
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.decorationPrefixes`
+
+      A set of prefixes to include in a decorated .toString().
+
+
+      :type: string[]
+
+
+   .. py:attribute:: stringStyle
+
+      *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation.stringStyle`
+
+      The .toString() style.
+
+
+      :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
 
 
 SyncVirtualMethods
@@ -2897,6 +3332,35 @@ UnaryOperation
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
+
+
+   .. py:method:: toString() -> string
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+
+      String representation of the value.
+
+
+      :rtype: string
+      :abstract: Yes
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value.value`
+
+      The value.
+
+
+      :type: number *(readonly)* *(abstract)*
+
+
 UnionProperties (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2933,7 +3397,7 @@ UnionProperties (interface)
 
    .. py:attribute:: foo
 
-      :type: string or number or undefined *(abstract)*
+      :type: string or number or ``undefined`` *(abstract)*
 
 
 UseBundledDependency
@@ -3201,6 +3665,8 @@ CompositeOperation
 
    .. py:method:: toString() -> string
 
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Operation.toString`
+
       String representation of the value.
 
 
@@ -3216,6 +3682,8 @@ CompositeOperation
 
 
    .. py:attribute:: value
+
+      *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
 
       The value.
 
@@ -3283,6 +3751,14 @@ CompositeOperation
       Decorated string expression 
 
 
+
+
+   .. py:method:: typeName() -> any
+
+      *Inherited from* :py:meth:`@scope/jsii-calc-base.Base.typeName`
+
+      :return: the name of the class (to verify native type names are created for derived classes).
+      :rtype: any
 
 
 


### PR DESCRIPTION
Add a documentation line outlining the parent declaration of overridden
members as well as inherited members that are not overridden locally.
This should make browsing the documentation a lot nicer.

Inherited and overridden statements in the documentation always refer to
the fully qualified name of the super statement.

Fixes #196