### PR TITLE
fix: dotnet abstract classes should have proxy implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,6 @@ jspm_packages/
 # that NuGet uses for external packages. We don't want to ignore the
 # lerna packages.
 !/packages/*
+
+#MacOS metadata
+.DS_Store

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/AbstractClassProxyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/AbstractClassProxyGeneratorTests.cs
@@ -1,0 +1,188 @@
+using Amazon.JSII.Generator.Class;
+using Amazon.JSII.JsonModel.Spec;
+using Xunit;
+
+namespace Amazon.JSII.Generator.UnitTests.Class
+{
+    public class AbstractClassProxyGeneratorTests : GeneratorTestBase
+    {
+        private const string Prefix = nameof(Generator) + "." + nameof(AbstractClassProxyGenerator) + ".";
+
+        private string Render(ClassType classType)
+        {
+            Symbols.MapTypeToPackage("myFqn", classType.Assembly);
+            Symbols.MapNamespace(classType.QualifiedNamespace, "MyNamespace");
+            Symbols.MapTypeName("myFqn", "MyClass", TypeKind.Class);
+
+            var generator = new AbstractClassProxyGenerator(classType.Assembly, classType, Symbols, Namespaces);
+
+            var syntaxTree = generator.CreateSyntaxTree();
+            return syntaxTree.ToString();
+        }
+
+        [Fact(DisplayName = Prefix + nameof(IncludesAttribute))]
+        public void IncludesAttribute()
+        {
+            var classType = new ClassType
+            (
+                "myFqn",
+                "myPackage",
+                "myClass",
+                true,
+                initializer: new Method(true, false, false)
+            );
+
+            var actual = Render(classType);
+            var expected =
+                @"namespace MyNamespace
+{
+    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
+    internal class MyClassProxy : MyClass
+    {
+        private MyClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}";
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
+
+        [Fact(DisplayName = Prefix + nameof(IncludesDocs))]
+        public void IncludesDocs()
+        {
+            // Docs are not currently generated as part of the C# code.
+            ClassType classType = new ClassType
+            (
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: true,
+                initializer: new Method(true, false, false),
+                docs: new Docs {{"foo", "bar"}}
+            );
+
+            string actual = Render(classType);
+            string expected =
+                @"namespace MyNamespace
+{
+    /// <remarks>foo: bar</remarks>
+    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
+    internal class MyClassProxy : MyClass
+    {
+        private MyClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}";
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
+
+        [Fact(DisplayName = Prefix + nameof(IncludesProperties))]
+        public void IncludesProperties()
+        {
+            ClassType classType = new ClassType
+            (
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: true,
+                initializer: new Method(true, false, false),
+                properties: new[]
+                {
+                    new Property
+                    (
+                        name: "myProp",
+                        type: new TypeReference("myPropTypeFqn"),
+                        isImmutable: false,
+                        isAbstract: true,
+                        isProtected: false
+                    ),
+                    new Property
+                    (
+                        name: "notMyProp",
+                        type: new TypeReference("myPropTypeFqn"),
+                        isImmutable: false,
+                        isAbstract: false,
+                        isProtected: false
+                    )
+                }
+            );
+
+            Symbols.MapTypeName("myPropTypeFqn", "MyPropType", TypeKind.Class);
+            Symbols.MapPropertyName("myFqn", "myProp", "MyProp");
+
+            string actual = Render(classType);
+            string expected =
+                @"namespace MyNamespace
+{
+    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
+    internal class MyClassProxy : MyClass
+    {
+        private MyClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty(""myProp"", ""{\""fqn\"":\""myPropTypeFqn\""}"")]
+        public override MyPropType MyProp
+        {
+            get => GetInstanceProperty<MyPropType>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}";
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
+
+        [Fact(DisplayName = Prefix + nameof(IncludesMethods))]
+        public void IncludesMethods()
+        {
+            ClassType classType = new ClassType
+            (
+                fullyQualifiedName: "myFqn",
+                assembly: "myPackage",
+                name: "myClass",
+                isAbstract: true,
+                initializer: new Method(true, false, false),
+                methods: new[]
+                {
+                    new Method
+                    (
+                        false,
+                        false,
+                        true,
+                        name: "myMethod"
+                    ),
+                    new Method
+                    (
+                        false,
+                        false,
+                        false,
+                        name: "notMyMethod"
+                    )
+                }
+            );
+
+            Symbols.MapMethodName("myFqn", "myMethod", "MyMethod");
+
+            string actual = Render(classType);
+            string expected =
+                @"namespace MyNamespace
+{
+    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
+    internal class MyClassProxy : MyClass
+    {
+        private MyClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiMethod(""myMethod"", null, ""[]"")]
+        public override void MyMethod()
+        {
+            InvokeInstanceVoidMethod(new object[]{});
+        }
+    }
+}";
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
+    }
+}

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/AbstractClassProxyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/AbstractClassProxyGeneratorTests.cs
@@ -36,8 +36,8 @@ namespace Amazon.JSII.Generator.UnitTests.Class
             var expected =
                 @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
-    internal class MyClassProxy : MyClass
+    [JsiiTypeProxy(typeof(MyClass), ""myFqn"")]
+    internal sealed class MyClassProxy : MyClass
     {
         private MyClassProxy(ByRefValue reference): base(reference)
         {
@@ -66,8 +66,8 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 @"namespace MyNamespace
 {
     /// <remarks>foo: bar</remarks>
-    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
-    internal class MyClassProxy : MyClass
+    [JsiiTypeProxy(typeof(MyClass), ""myFqn"")]
+    internal sealed class MyClassProxy : MyClass
     {
         private MyClassProxy(ByRefValue reference): base(reference)
         {
@@ -115,8 +115,8 @@ namespace Amazon.JSII.Generator.UnitTests.Class
             string expected =
                 @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
-    internal class MyClassProxy : MyClass
+    [JsiiTypeProxy(typeof(MyClass), ""myFqn"")]
+    internal sealed class MyClassProxy : MyClass
     {
         private MyClassProxy(ByRefValue reference): base(reference)
         {
@@ -168,8 +168,8 @@ namespace Amazon.JSII.Generator.UnitTests.Class
             string expected =
                 @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(MyClass), ""myFqn"")]
-    internal class MyClassProxy : MyClass
+    [JsiiTypeProxy(typeof(MyClass), ""myFqn"")]
+    internal sealed class MyClassProxy : MyClass
     {
         private MyClassProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Class/ClassGeneratorTests.cs
@@ -1,20 +1,20 @@
 ﻿using Amazon.JSII.Generator.Class;
-using Amazon.JSII.Generator.Interface;
 using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
 using Xunit;
+using TypeKind = Amazon.JSII.JsonModel.Spec.TypeKind;
 
 namespace Amazon.JSII.Generator.UnitTests.Class
 {
     public class ClassGeneratorTests : GeneratorTestBase
     {
-        const string Prefix = nameof(Generator) + "." + nameof(InterfaceGenerator) + ".";
+        const string Prefix = nameof(Generator) + "." + nameof(ClassGenerator) + ".";
 
-        string Render(ClassType classType)
+        private string Render(ClassType classType)
         {
             Symbols.MapTypeToPackage("myFqn", classType.Assembly);
             Symbols.MapNamespace(classType.QualifiedNamespace, "MyNamespace");
-            Symbols.MapTypeName("myFqn", "MyClass", JsonModel.Spec.TypeKind.Class);
+            Symbols.MapTypeName("myFqn", "MyClass", TypeKind.Class);
 
             ClassGenerator generator = new ClassGenerator(classType.Assembly, classType, Symbols, Namespaces);
 
@@ -36,7 +36,7 @@ namespace Amazon.JSII.Generator.UnitTests.Class
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public class MyClass : DeputyBase
@@ -71,7 +71,7 @@ namespace Amazon.JSII.Generator.UnitTests.Class
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public abstract class MyClass : DeputyBase
@@ -103,12 +103,12 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 name: "myClass",
                 isAbstract: false,
                 initializer: new Method(true, false, false),
-                docs: new Docs { { "foo", "bar" } }
+                docs: new Docs {{"foo", "bar"}}
             );
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     /// <remarks>foo: bar</remarks>
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
@@ -144,7 +144,7 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 {
                     new Property
                     (
-                        name: "myProp", 
+                        name: "myProp",
                         type: new TypeReference("myPropTypeFqn"),
                         isImmutable: false,
                         isAbstract: false,
@@ -153,12 +153,12 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 }
             );
 
-            Symbols.MapTypeName("myPropTypeFqn", "MyPropType", JsonModel.Spec.TypeKind.Class);
+            Symbols.MapTypeName("myPropTypeFqn", "MyPropType", TypeKind.Class);
             Symbols.MapPropertyName("myFqn", "myProp", "MyProp");
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public class MyClass : DeputyBase
@@ -212,7 +212,7 @@ namespace Amazon.JSII.Generator.UnitTests.Class
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public class MyClass : DeputyBase
@@ -252,11 +252,11 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 @base: new TypeReference("myBaseTypeFqn")
             );
 
-            Symbols.MapTypeName("myBaseTypeFqn", "MyBaseType", JsonModel.Spec.TypeKind.Class);
+            Symbols.MapTypeName("myBaseTypeFqn", "MyBaseType", TypeKind.Class);
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public class MyClass : MyBaseType
@@ -294,12 +294,12 @@ namespace Amazon.JSII.Generator.UnitTests.Class
                 }
             );
 
-            Symbols.MapTypeName("myInterfaceFqn1", "MyInterface1", JsonModel.Spec.TypeKind.Interface);
-            Symbols.MapTypeName("myInterfaceFqn2", "MyInterface2", JsonModel.Spec.TypeKind.Interface);
+            Symbols.MapTypeName("myInterfaceFqn1", "MyInterface1", TypeKind.Interface);
+            Symbols.MapTypeName("myInterfaceFqn2", "MyInterface2", TypeKind.Interface);
 
             string actual = Render(classType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     [JsiiClass(typeof(MyClass), ""myFqn"", ""[]"")]
     public class MyClass : DeputyBase, IMyInterface1, IMyInterface2

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyGeneratorTests.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 using Xunit;
+using TypeKind = Amazon.JSII.JsonModel.Spec.TypeKind;
 
 namespace Amazon.JSII.Generator.UnitTests.Interface
 {
@@ -10,12 +11,13 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
     {
         const string Prefix = nameof(Generator) + "." + nameof(InterfaceProxyGenerator) + ".";
 
-        string Render(InterfaceType interfaceType, string package = "myPackage", string @namespace = "MyNamespace", string typeName = "MyInterface")
+        string Render(InterfaceType interfaceType, string package = "myPackage", string @namespace = "MyNamespace",
+            string typeName = "MyInterface")
         {
             Symbols.MapTypeToPackage(interfaceType.FullyQualifiedName, package);
             string suffix = interfaceType.Namespace != null ? "." + interfaceType.Namespace : "";
             Symbols.MapNamespace(interfaceType.Assembly + suffix, @namespace);
-            Symbols.MapTypeName(interfaceType.FullyQualifiedName, typeName, JsonModel.Spec.TypeKind.Interface);
+            Symbols.MapTypeName(interfaceType.FullyQualifiedName, typeName, TypeKind.Interface);
 
             var generator = new InterfaceProxyGenerator(package, interfaceType, Symbols, Namespaces);
 
@@ -37,10 +39,10 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
             string actual = Render(interfaceType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
-    internal class MyInterfaceProxy : DeputyBase, IMyInterface
+    [JsiiTypeProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
+    internal sealed class MyInterfaceProxy : DeputyBase, IMyInterface
     {
         private MyInterfaceProxy(ByRefValue reference): base(reference)
         {
@@ -59,24 +61,24 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myInterface",
                 "myNamespace",
-                methods: new Method[] { new Method(false, false, true, name: "myMethod") }
+                methods: new Method[] {new Method(false, false, true, name: "myMethod")}
             );
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");
 
             string actual = Render(interfaceType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
-    internal class MyInterfaceProxy : DeputyBase, IMyInterface
+    [JsiiTypeProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
+    internal sealed class MyInterfaceProxy : DeputyBase, IMyInterface
     {
         private MyInterfaceProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiMethod(""myMethod"", null, ""[]"")]
-        public virtual void MyMethod()
+        public void MyMethod()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
@@ -94,7 +96,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myAncestorInterface",
                 "myNamespace",
-                methods: new [] { new Method(false, false, true, name: "myAncestorMethod") }
+                methods: new[] {new Method(false, false, true, name: "myAncestorMethod")}
             );
             InterfaceType baseInterface = new InterfaceType
             (
@@ -102,8 +104,8 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myBaseInterface",
                 "myNamespace",
-                methods: new[] { new Method(false, false, true, name: "myBaseMethod") },
-                interfaces: new[] { new TypeReference("myAncestorInterfaceFqn") }
+                methods: new[] {new Method(false, false, true, name: "myBaseMethod")},
+                interfaces: new[] {new TypeReference("myAncestorInterfaceFqn")}
             );
             InterfaceType interfaceType = new InterfaceType
             (
@@ -111,36 +113,36 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myInterface",
                 "myNamespace",
-                interfaces: new[] { new TypeReference("myBaseInterfaceFqn") }
+                interfaces: new[] {new TypeReference("myBaseInterfaceFqn")}
             );
 
-            Symbols.MapTypeName("myAncestorInterfaceFqn", "MyAncestorInterface", JsonModel.Spec.TypeKind.Interface);
+            Symbols.MapTypeName("myAncestorInterfaceFqn", "MyAncestorInterface", TypeKind.Interface);
             Symbols.MapFullyQualifiedNameToType("myAncestorInterfaceFqn", ancestorInterface);
             Symbols.MapMethodName("myInterfaceFqn", "myAncestorMethod", "MyAncestorMethod");
 
-            Symbols.MapTypeName("myBaseInterfaceFqn", "MyBaseInterface", JsonModel.Spec.TypeKind.Interface);
+            Symbols.MapTypeName("myBaseInterfaceFqn", "MyBaseInterface", TypeKind.Interface);
             Symbols.MapFullyQualifiedNameToType("myBaseInterfaceFqn", baseInterface);
             Symbols.MapMethodName("myInterfaceFqn", "myBaseMethod", "MyBaseMethod");
 
             string actual = Render(interfaceType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
-    [JsiiInterfaceProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
-    internal class MyInterfaceProxy : DeputyBase, IMyInterface
+    [JsiiTypeProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
+    internal sealed class MyInterfaceProxy : DeputyBase, IMyInterface
     {
         private MyInterfaceProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiMethod(""myBaseMethod"", null, ""[]"")]
-        public virtual void MyBaseMethod()
+        public void MyBaseMethod()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
         [JsiiMethod(""myAncestorMethod"", null, ""[]"")]
-        public virtual void MyAncestorMethod()
+        public void MyAncestorMethod()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
@@ -158,16 +160,16 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
                 "myPackage",
                 "myInterface",
                 "myNamespace",
-                docs: new Docs { { "foo", "bar" } }
+                docs: new Docs {{"foo", "bar"}}
             );
 
             string actual = Render(interfaceType);
             string expected =
-@"namespace MyNamespace
+                @"namespace MyNamespace
 {
     /// <remarks>foo: bar</remarks>
-    [JsiiInterfaceProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
-    internal class MyInterfaceProxy : DeputyBase, IMyInterface
+    [JsiiTypeProxy(typeof(IMyInterface), ""myInterfaceFqn"")]
+    internal sealed class MyInterfaceProxy : DeputyBase, IMyInterface
     {
         private MyInterfaceProxy(ByRefValue reference): base(reference)
         {
@@ -181,7 +183,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
         public void EnvironmentRegression()
         {
             const string json =
-@"    {
+                @"    {
       ""docs"": {
         ""comment"": ""Models an AWS execution environment, for use within the CDK toolkit.""
       },
@@ -231,13 +233,14 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             Symbols.MapPropertyName("jsii$aws_cdk_cx_api$.Environment", "account", "Account");
             Symbols.MapPropertyName("jsii$aws_cdk_cx_api$.Environment", "region", "Region");
 
-            string actual = Render(interfaceType, package: "aws-cdk-cx-api", @namespace: "Aws.Cdk.CxApi", typeName: "Environment");
+            string actual = Render(interfaceType, package: "aws-cdk-cx-api", @namespace: "Aws.Cdk.CxApi",
+                typeName: "Environment");
             string expected =
-@"namespace Aws.Cdk.CxApi
+                @"namespace Aws.Cdk.CxApi
 {
     /// <summary>Models an AWS execution environment, for use within the CDK toolkit.</summary>
-    [JsiiInterfaceProxy(typeof(IEnvironment), ""jsii$aws_cdk_cx_api$.Environment"")]
-    internal class EnvironmentProxy : DeputyBase, IEnvironment
+    [JsiiTypeProxy(typeof(IEnvironment), ""jsii$aws_cdk_cx_api$.Environment"")]
+    internal sealed class EnvironmentProxy : DeputyBase, IEnvironment
     {
         private EnvironmentProxy(ByRefValue reference): base(reference)
         {
@@ -245,7 +248,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
         /// <summary>The arbitrary name of this environment (user-set, or at least user-meaningful) </summary>
         [JsiiProperty(""name"", ""{\""primitive\"":\""string\""}"")]
-        public virtual string Name
+        public string Name
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
@@ -253,7 +256,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
         /// <summary>The 12-digit AWS account ID for the account this environment deploys into </summary>
         [JsiiProperty(""account"", ""{\""primitive\"":\""string\""}"")]
-        public virtual string Account
+        public string Account
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
@@ -261,7 +264,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
         /// <summary>The AWS region name where this environment deploys into </summary>
         [JsiiProperty(""region"", ""{\""primitive\"":\""string\""}"")]
-        public virtual string Region
+        public string Region
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/Interface/InterfaceProxyMethodGeneratorTests.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
+using TypeKind = Amazon.JSII.JsonModel.Spec.TypeKind;
 
 namespace Amazon.JSII.Generator.UnitTests.Interface
 {
@@ -23,7 +24,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
 
             Symbols.MapTypeToPackage("myInterfaceFqn", "myPackage");
             Symbols.MapNamespace("", "MyNamespace");
-            Symbols.MapTypeName("myInterfaceFqn", "MyInterface", JsonModel.Spec.TypeKind.Interface);
+            Symbols.MapTypeName("myInterfaceFqn", "MyInterface", TypeKind.Interface);
 
             var generator = new InterfaceProxyMethodGenerator(interfaceType, method, Symbols, Namespaces);
 
@@ -41,7 +42,7 @@ namespace Amazon.JSII.Generator.UnitTests.Interface
             string actual = Render(method);
             string expected =
 @"[JsiiMethod(""myMethod"", null, ""[]"")]
-public virtual void MyMethod()
+public void MyMethod()
 {
     InvokeInstanceVoidMethod(new object[]{});
 }";
@@ -62,14 +63,14 @@ public virtual void MyMethod()
             );
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");
-            Symbols.MapTypeName("myParamTypeFqn", "MyParamType", JsonModel.Spec.TypeKind.Class);
+            Symbols.MapTypeName("myParamTypeFqn", "MyParamType", TypeKind.Class);
             Symbols.MapParameterName("myParam", "myParam");
             Symbols.MapParameterName("event", "@event");
 
             string actual = Render(method);
             string expected =
 @"[JsiiMethod(""myMethod"", null, ""[{\""name\"":\""myParam\"",\""type\"":{\""fqn\"":\""myParamTypeFqn\""}},{\""name\"":\""event\"",\""type\"":{\""primitive\"":\""string\""}}]"")]
-public virtual void MyMethod(MyParamType myParam, string @event)
+public void MyMethod(MyParamType myParam, string @event)
 {
     InvokeInstanceVoidMethod(new object[]{myParam, @event});
 }";
@@ -90,7 +91,7 @@ public virtual void MyMethod(MyParamType myParam, string @event)
             string actual = Render(method);
             string expected =
 @"[JsiiMethod(""myMethod"", null, ""[]"")]
-public virtual void MyMethod()
+public void MyMethod()
 {
     InvokeInstanceVoidMethod(new object[]{});
 }";
@@ -107,12 +108,12 @@ public virtual void MyMethod()
             );
 
             Symbols.MapMethodName("myInterfaceFqn", "myMethod", "MyMethod");
-            Symbols.MapTypeName("myReturnTypeFqn", "MyReturnType", JsonModel.Spec.TypeKind.Class);
+            Symbols.MapTypeName("myReturnTypeFqn", "MyReturnType", TypeKind.Class);
 
             string actual = Render(method);
             string expected =
 @"[JsiiMethod(""myMethod"", ""{\""fqn\"":\""myReturnTypeFqn\""}"", ""[]"")]
-public virtual MyReturnType MyMethod()
+public MyReturnType MyMethod()
 {
     return InvokeInstanceMethod<MyReturnType>(new object[]{});
 }";

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using Amazon.JSII.JsonModel.Spec;
 using NSubstitute;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using Type = Amazon.JSII.JsonModel.Spec.Type;
 
 namespace Amazon.JSII.Generator.UnitTests
 {
@@ -89,6 +88,15 @@ namespace Amazon.JSII.Generator.UnitTests
                     .Returns(SF.ParseName(defaultName));
 
                 frameworkName = $"I{frameworkName}";
+            }
+            
+            if (kind == TypeKind.Class)
+            {
+                string proxyName = $"{frameworkName}Proxy";
+
+                symbols
+                    .GetAbstractClassProxyName(Arg.Is<ClassType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                    .Returns(proxyName);
             }
             
             symbols

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/AssemblyGenerator.cs
@@ -281,25 +281,47 @@ namespace Amazon.JSII.Generator
                 switch (type.Kind)
                 {
                     case TypeKind.Class:
-                        SaveTypeFile($"{symbols.GetName(type)}.cs", new ClassGenerator(assembly.Name, (ClassType)type, symbols).CreateSyntaxTree());
-                        return;
-                    case TypeKind.Enum:
-                        SaveTypeFile($"{symbols.GetName(type)}.cs", new EnumGenerator(assembly.Name, (EnumType)type, symbols).CreateSyntaxTree());
-                        return;
-                    case TypeKind.Interface:
-                        InterfaceType interfaceType = (InterfaceType)type;
+                    {
+                        var classType = (ClassType) type;
+                        
+                        if (classType.IsAbstract)
+                        {
+                            SaveTypeFile($"{symbols.GetAbstractClassProxyName(classType)}.cs",
+                                new AbstractClassProxyGenerator(assembly.Name, classType, symbols).CreateSyntaxTree());
+                        }
 
-                        SaveTypeFile($"{symbols.GetName(interfaceType)}.cs", new InterfaceGenerator(assembly.Name, interfaceType, symbols).CreateSyntaxTree());
-                        SaveTypeFile($"{symbols.GetInterfaceProxyName(interfaceType)}.cs", new InterfaceProxyGenerator(assembly.Name, interfaceType, symbols).CreateSyntaxTree());
+                        SaveTypeFile($"{symbols.GetName(type)}.cs",
+                            new ClassGenerator(assembly.Name, classType, symbols).CreateSyntaxTree());
+                        return;
+                    }
+                    case TypeKind.Enum:
+                    {
+                        SaveTypeFile($"{symbols.GetName(type)}.cs",
+                            new EnumGenerator(assembly.Name, (EnumType) type, symbols).CreateSyntaxTree());
+                        return;
+                    }
+                    case TypeKind.Interface:
+                    {
+                        InterfaceType interfaceType = (InterfaceType) type;
+
+                        SaveTypeFile($"{symbols.GetName(interfaceType)}.cs",
+                            new InterfaceGenerator(assembly.Name, interfaceType, symbols).CreateSyntaxTree());
+                        SaveTypeFile($"{symbols.GetInterfaceProxyName(interfaceType)}.cs",
+                            new InterfaceProxyGenerator(assembly.Name, interfaceType, symbols).CreateSyntaxTree());
 
                         if (interfaceType.IsDataType == true)
                         {
-                            SaveTypeFile($"{symbols.GetInterfaceDefaultName(interfaceType)}.cs", new InterfaceDefaultGenerator(assembly.Name, interfaceType, symbols).CreateSyntaxTree());
+                            SaveTypeFile($"{symbols.GetInterfaceDefaultName(interfaceType)}.cs",
+                                new InterfaceDefaultGenerator(assembly.Name, interfaceType, symbols)
+                                    .CreateSyntaxTree());
                         }
 
                         return;
+                    }
                     default:
+                    {
                         throw new ArgumentException($"Unkown type kind: {type.Kind}", nameof(type));
+                    }
                 }
 
                 void SaveTypeFile(string filename, SyntaxTree syntaxTree)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyGenerator.cs
@@ -94,7 +94,12 @@ namespace Amazon.JSII.Generator.Class
                 return methods;
             }
 
-            // Only get the first declaration encountered, and keep it if it is abstract.
+            /*
+              Only get the first declaration encountered, and keep it if it is abstract. The list contains ALL
+              methods and properties encountered, in the order encountered. An abstract class can have concrete
+              implementations. Therefore, we only generate methods/properties if the first member encountered
+              is unimplemented. 
+            */
             return GetAllMethodsRecurse(type, Enumerable.Empty<Method>())
                 .GroupBy(m => (m.Name,
                     string.Join("",
@@ -154,7 +159,12 @@ namespace Amazon.JSII.Generator.Class
                 return properties;
             }
 
-            // Only get the first declaration encountered, and keep it if it is abstract.
+            /*
+              Only get the first declaration encountered, and keep it if it is abstract. The list contains ALL
+              methods and properties encountered, in the order encountered. An abstract class can have concrete
+              implementations. Therefore, we only generate methods/properties if the first member encountered
+              is unimplemented. 
+            */
             return GetAllPropertiesRecurse(type, Enumerable.Empty<Property>())
                 .GroupBy(p => p.Name)
                 .Select(g => g.First())

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyGenerator.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Type = Amazon.JSII.JsonModel.Spec.Type;
+
+namespace Amazon.JSII.Generator.Class
+{
+    public class AbstractClassProxyGenerator : TypeProxyGeneratorBase<ClassType>
+    {
+        public AbstractClassProxyGenerator(string package, ClassType type, ISymbolMap symbols,
+            INamespaceSet namespaces = null)
+            : base(package, type, symbols, namespaces)
+        {
+            if (!type.IsAbstract)
+            {
+                throw new ArgumentException("Class type must be abstract.", nameof(type));
+            }
+        }
+
+        protected override SyntaxToken GetProxyTypeNameSyntax()
+        {
+            return SF.Identifier(Symbols.GetAbstractClassProxyName(Type));
+        }
+
+        protected override IEnumerable<PropertyDeclarationSyntax> CreateProperties()
+        {
+            foreach (Property property in GetAllProperties(Type))
+            {
+                var generator = new AbstractClassProxyPropertyGenerator(Type, property, Symbols, Namespaces);
+                yield return generator.CreateProperty();
+            }
+        }
+
+        protected override IEnumerable<MemberDeclarationSyntax> CreateMethods()
+        {
+            foreach (Method method in GetAllMethods(Type))
+            {
+                var generator = new AbstractClassProxyMethodGenerator(Type, method, Symbols, Namespaces);
+                yield return generator.CreateMethod();
+            }
+        }
+
+        private IEnumerable<Method> GetAllMethods(Type type)
+        {
+            IEnumerable<Method> GetAllMethodsRecurse(Type currentType, IEnumerable<Method> methods)
+            {
+                if (currentType is InterfaceType interfaceType)
+                {
+                    // Get all properties from the interface.
+                    methods = methods.Concat(interfaceType.Methods ?? Enumerable.Empty<Method>());
+
+                    // Interfaces can have superinterfaces. Run through them too.
+                    if (interfaceType.Interfaces != null)
+                    {
+                        var superinterfaceMethods = interfaceType.Interfaces.Select(r =>
+                                Symbols.GetTypeFromFullyQualifiedName(r.FullyQualifiedName) as
+                                    InterfaceType)
+                            .SelectMany(i => GetAllMethodsRecurse(i, methods))
+                            .ToList();
+
+                        methods = methods.Concat(superinterfaceMethods);
+                    }
+                }
+                else if (currentType is ClassType classType)
+                {
+                    // Get all methods from the interface
+                    methods = methods.Concat(classType.Methods ?? Enumerable.Empty<Method>());
+
+                    if (classType.Interfaces != null)
+                    {
+                        // Run through all the interfaces.
+                        var superinterfaceMethods = classType.Interfaces.Select(r =>
+                                Symbols.GetTypeFromFullyQualifiedName(r.FullyQualifiedName) as
+                                    InterfaceType)
+                            .SelectMany(i => GetAllMethodsRecurse(i, methods))
+                            .ToList();
+
+                        methods = methods.Concat(superinterfaceMethods);
+                    }
+
+                    // Run through the superclass.
+                    if (classType.Base != null)
+                    {
+                        methods = methods.Concat(GetAllMethodsRecurse(
+                            Symbols.GetTypeFromFullyQualifiedName(classType.Base.FullyQualifiedName) as ClassType,
+                            methods));
+                    }
+                }
+
+                return methods;
+            }
+
+            // Only get the first declaration encountered, and keep it if it is abstract.
+            return GetAllMethodsRecurse(type, Enumerable.Empty<Method>())
+                .GroupBy(m => (m.Name,
+                    string.Join("",
+                        m.Parameters?.Select(p => p.Name + p.Type.FullyQualifiedName) ?? Enumerable.Empty<string>())))
+                .Select(g => g.First())
+                .Where(m => m.IsAbstract ?? false);
+        }
+
+        private IEnumerable<Property> GetAllProperties(Type type)
+        {
+            IEnumerable<Property> GetAllPropertiesRecurse(Type currentType, IEnumerable<Property> properties)
+            {
+                if (currentType is InterfaceType interfaceType)
+                {
+                    // Get all properties from the interface.
+                    properties = properties.Concat(interfaceType.Properties ?? Enumerable.Empty<Property>());
+
+                    // Interfaces can have superinterfaces. Run through them too.
+                    if (interfaceType.Interfaces != null)
+                    {
+                        var superinterfaceMethods = interfaceType.Interfaces.Select(r =>
+                                Symbols.GetTypeFromFullyQualifiedName(r.FullyQualifiedName) as
+                                    InterfaceType)
+                            .SelectMany(i => GetAllPropertiesRecurse(i, properties))
+                            .ToList();
+
+                        properties = properties.Concat(superinterfaceMethods);
+                    }
+                }
+                else if (currentType is ClassType classType)
+                {
+                    // Add the properties from the class.
+                    properties =
+                        properties.Concat(classType.Properties ?? Enumerable.Empty<Property>());
+
+                    // Run through all the interfaces.
+                    if (classType.Interfaces != null)
+                    {
+                        var superinterfaceMethods = classType.Interfaces.Select(r =>
+                                Symbols.GetTypeFromFullyQualifiedName(r.FullyQualifiedName) as
+                                    InterfaceType)
+                            .SelectMany(i => GetAllPropertiesRecurse(i, properties))
+                            .ToList();
+
+                        properties = properties.Concat(superinterfaceMethods);
+                    }
+
+                    // Run through the superclass.
+                    if (classType.Base != null)
+                    {
+                        properties = properties.Concat(GetAllPropertiesRecurse(
+                            Symbols.GetTypeFromFullyQualifiedName(classType.Base.FullyQualifiedName) as ClassType,
+                            properties));
+                    }
+                }
+
+                return properties;
+            }
+
+            // Only get the first declaration encountered, and keep it if it is abstract.
+            return GetAllPropertiesRecurse(type, Enumerable.Empty<Property>())
+                .GroupBy(p => p.Name)
+                .Select(g => g.First())
+                .Where(p => p.IsAbstract ?? false);
+        }
+    }
+}

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyMethodGenerator.cs
@@ -23,10 +23,6 @@ namespace Amazon.JSII.Generator.Class
             {
                 yield return SyntaxKind.OverrideKeyword;
             }
-            else
-            {
-                yield return SyntaxKind.VirtualKeyword;
-            }
         }
 
         protected override BlockSyntax GetBody()

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyMethodGenerator.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Amazon.JSII.Generator.Class
+{
+    public class AbstractClassProxyMethodGenerator : ClassMethodGenerator
+    {
+        public AbstractClassProxyMethodGenerator(ClassType type, Method method, ISymbolMap symbols,
+            INamespaceSet namespaces) : base(type, method, symbols, namespaces)
+        {
+        }
+
+        protected override IEnumerable<SyntaxKind> GetModifierKeywords()
+        {
+            yield return Method.IsProtected ? SyntaxKind.ProtectedKeyword : SyntaxKind.PublicKeyword;
+            
+            // Type is the abstract class, so we need to check it as well as ancestors.
+            if (IsDefinedOnAncestor || Type.Methods.Any(m => m.Name == Method.Name))
+            {
+                yield return SyntaxKind.OverrideKeyword;
+            }
+            else
+            {
+                yield return SyntaxKind.VirtualKeyword;
+            }
+        }
+
+        protected override BlockSyntax GetBody()
+        {
+            if (Method.Returns == null)
+            {
+                return SF.Block(SF.ExpressionStatement(CreateInvocationExpression()));
+            }
+
+            return SF.Block(SF.ReturnStatement(CreateInvocationExpression()));
+        }
+
+        protected override bool HasSemicolon => false;
+    }
+}

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyPropertyGenerator.cs
@@ -21,10 +21,6 @@ namespace Amazon.JSII.Generator.Class
             {
                 yield return SyntaxKind.OverrideKeyword;
             }
-            else
-            {
-                yield return SyntaxKind.VirtualKeyword;
-            }
         }
     }
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/AbstractClassProxyPropertyGenerator.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Amazon.JSII.Generator.Class
+{
+    public class AbstractClassProxyPropertyGenerator : ClassPropertyGenerator
+    {
+        public AbstractClassProxyPropertyGenerator(ClassType type, Property property, ISymbolMap symbols,
+            INamespaceSet namespaces) : base(type, property, symbols, namespaces)
+        {
+        }
+
+        protected override IEnumerable<SyntaxKind> GetModifierKeywords()
+        {
+            yield return Property.IsProtected == true ? SyntaxKind.ProtectedKeyword : SyntaxKind.PublicKeyword;
+
+            // Type is the abstract class, so we need to check it as well as ancestors.
+            if (IsDefinedOnAncestor || Type.Properties.Any(p => p.Name == Property.Name))
+            {
+                yield return SyntaxKind.OverrideKeyword;
+            }
+            else
+            {
+                yield return SyntaxKind.VirtualKeyword;
+            }
+        }
+    }
+}

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassMethodGenerator.cs
@@ -1,10 +1,8 @@
-﻿using Amazon.JSII.JsonModel.Spec;
-using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Amazon.JSII.Generator.Class
@@ -16,15 +14,15 @@ namespace Amazon.JSII.Generator.Class
         {
         }
 
-        bool IsDefinedOnAncestor
+        protected bool IsDefinedOnAncestor
         {
             get
             {
-                string[] objectMethods = new[]
+                string[] objectMethods =
                 {
                     "ToString",
                     "GetHashCode",
-                    "Equals",
+                    "Equals"
                 };
 
                 if (objectMethods.Contains(NameUtils.ConvertMethodName(Method.Name)))

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassPropertyGenerator.cs
@@ -1,10 +1,9 @@
-﻿using Amazon.JSII.JsonModel.Spec;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Amazon.JSII.Generator.Class
@@ -16,7 +15,7 @@ namespace Amazon.JSII.Generator.Class
         {
         }
 
-        bool IsDefinedOnAncestor => Type.AnyAncestor(Symbols, t => t.Properties?.Any(p => p.Name == Property.Name) == true);
+        protected bool IsDefinedOnAncestor => Type.AnyAncestor(Symbols, t => t.Properties?.Any(p => p.Name == Property.Name) == true);
 
         protected override IEnumerable<SyntaxKind> GetModifierKeywords()
         {

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/ISymbolMap.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/ISymbolMap.cs
@@ -15,6 +15,8 @@ namespace Amazon.JSII.Generator
         string GetName(Type type, bool disambiguate = false);
 
         string GetName(string fullyQualifiedName, bool disambiguate = false);
+        
+        string GetAbstractClassProxyName(ClassType type, bool disambiguate = false);
 
         string GetInterfaceProxyName(InterfaceType type, bool disambiguate = false);
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyGenerator.cs
@@ -1,98 +1,24 @@
-﻿using Amazon.JSII.JsonModel.Spec;
+﻿using System.Collections.Generic;
+using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Amazon.JSII.Generator.Interface
 {
-    public class InterfaceProxyGenerator : TypeGeneratorBase<InterfaceType>
+    public class InterfaceProxyGenerator : TypeProxyGeneratorBase<InterfaceType>
     {
         public InterfaceProxyGenerator(string package, InterfaceType type, ISymbolMap symbols, INamespaceSet namespaces = null)
             : base(package, type, symbols, namespaces)
         {
         }
-
-        protected override MemberDeclarationSyntax CreateType()
-        {
-            return SF.ClassDeclaration
-            (
-                CreateAttributes(),
-                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword)),
-                GetProxyTypeNameSyntax(),
-                null,
-                CreateBaseList(),
-                SF.List<TypeParameterConstraintClauseSyntax>(),
-                SF.List(CreateMembers())
-            );
-
-            SyntaxList<AttributeListSyntax> CreateAttributes()
-            {
-                TypeOfExpressionSyntax typeOfExpression = SF.TypeOfExpression(Symbols.GetNameSyntax(Type));
-                SyntaxToken fullyQualifiedNameLiteral = SF.Literal(Type.FullyQualifiedName);
-
-                return SF.List(new[] {
-                    SF.AttributeList(SF.SeparatedList(new[] {
-                        SF.Attribute(
-                            SF.ParseName("JsiiInterfaceProxy"),
-                            SF.ParseAttributeArgumentList($"({typeOfExpression}, {fullyQualifiedNameLiteral})")
-                        )
-                    }))
-                });
-            }
-
-            BaseListSyntax CreateBaseList()
-            {
-                return SF.BaseList(SF.SeparatedList(GetBaseTypes()));
-
-                IEnumerable<BaseTypeSyntax> GetBaseTypes()
-                {
-                    yield return SF.SimpleBaseType(SF.ParseTypeName("DeputyBase"));
-
-                    Namespaces.Add(Type);
-                    yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, disambiguate: true));
-                }
-            }
-
-            IEnumerable<MemberDeclarationSyntax> CreateMembers()
-            {
-                return CreateConstructors()
-                    .Concat(CreateProperties())
-                    .Concat(CreateMethods());
-            }
-        }
-
-        SyntaxToken GetProxyTypeNameSyntax()
+        
+        protected override SyntaxToken GetProxyTypeNameSyntax()
         {
             return SF.Identifier(Symbols.GetInterfaceProxyName(Type));
         }
 
-        IEnumerable<MemberDeclarationSyntax> CreateConstructors()
-        {
-            yield return SF.ConstructorDeclaration
-            (
-                SF.List<AttributeListSyntax>(),
-
-                // Only Amazon.JSII.Runtime should create interface proxies,
-                // so we make the constructor private.
-                SF.TokenList(SF.Token(SyntaxKind.PrivateKeyword)),
-
-                GetProxyTypeNameSyntax(),
-                SF.ParseParameterList("(ByRefValue reference)"),
-                SF.ConstructorInitializer
-                (
-                    SyntaxKind.BaseConstructorInitializer,
-                    SF.ParseArgumentList("(reference)")
-                ),
-                SF.Block(),
-                null
-            );
-        }
-
-        IEnumerable<PropertyDeclarationSyntax> CreateProperties()
+        protected override IEnumerable<PropertyDeclarationSyntax> CreateProperties()
         {
             foreach (Property property in Type.GetAllProperties(Symbols))
             {
@@ -101,7 +27,7 @@ namespace Amazon.JSII.Generator.Interface
             }
         }
 
-        IEnumerable<MemberDeclarationSyntax> CreateMethods()
+        protected override IEnumerable<MemberDeclarationSyntax> CreateMethods()
         {
             foreach (Method method in Type.GetAllMethods(Symbols))
             {

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyMethodGenerator.cs
@@ -1,8 +1,8 @@
-﻿using Amazon.JSII.JsonModel.Spec;
+﻿using System;
+using System.Collections.Generic;
+using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Amazon.JSII.Generator.Interface
@@ -34,7 +34,6 @@ namespace Amazon.JSII.Generator.Interface
         protected override IEnumerable<SyntaxKind> GetModifierKeywords()
         {
             yield return SyntaxKind.PublicKeyword;
-            yield return SyntaxKind.VirtualKeyword;
         }
 
         protected override BlockSyntax GetBody()

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceProxyPropertyGenerator.cs
@@ -1,9 +1,9 @@
-﻿using Amazon.JSII.JsonModel.Spec;
+﻿using System;
+using System.Collections.Generic;
+using Amazon.JSII.JsonModel.Spec;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Amazon.JSII.Generator.Interface
@@ -35,8 +35,6 @@ namespace Amazon.JSII.Generator.Interface
         protected override IEnumerable<SyntaxKind> GetModifierKeywords()
         {
             yield return SyntaxKind.PublicKeyword;
-
-            yield return SyntaxKind.VirtualKeyword;
         }
 
         protected override SyntaxToken GetIdentifier()

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
@@ -54,16 +54,26 @@ namespace Amazon.JSII.Generator
                 switch (type.Kind)
                 {
                     case JsonModel.Spec.TypeKind.Class:
+                    {
+                        var classType = (ClassType) type;
+                        if (classType.IsAbstract)
+                        {
+                            return new AbstractClassTypeMetadata(classType, assembly);
+                        }
                         return new ClassTypeMetadata((ClassType)type, assembly);
-
+                    }
                     case JsonModel.Spec.TypeKind.Enum:
-                        return new EnumTypeMetadata((EnumType)type, assembly);
-
+                    {
+                        return new EnumTypeMetadata((EnumType)type, assembly);   
+                    }
                     case JsonModel.Spec.TypeKind.Interface:
-                        return new InterfaceTypeMetadata((InterfaceType)type, assembly);
-
+                    {
+                        return new InterfaceTypeMetadata((InterfaceType)type, assembly);   
+                    }
                     default:
-                        throw new ArgumentException($"Type {type.Name} has unrecognized kind {type.Kind}", nameof(type));
+                    {
+                        throw new ArgumentException($"Type {type.Name} has unrecognized kind {type.Kind}", nameof(type));   
+                    }
                 }
             }
         }
@@ -101,6 +111,18 @@ namespace Amazon.JSII.Generator
             return GetName(GetTypeFromFullyQualifiedName(fullyQualifiedName), disambiguate);
         }
 
+        public string GetAbstractClassProxyName(ClassType type, bool disambiguate = false)
+        {
+            type = type ?? throw new ArgumentNullException(nameof(type));
+            
+            if (_types[type.FullyQualifiedName] is AbstractClassTypeMetadata metadata)
+            {
+                return metadata.ProxyName;
+            }
+
+            throw new ArgumentException($"Cannot get proxy name for '{type.FullyQualifiedName}' because it is not an abstract class.");
+        }
+
         public string GetInterfaceProxyName(InterfaceType type, bool disambiguate = false)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
@@ -110,7 +132,7 @@ namespace Amazon.JSII.Generator
                 return metadata.ProxyName;
             }
 
-            throw new ArgumentException($"Cannot get proxy name for '{type.FullyQualifiedName}' because it is not an interface");
+            throw new ArgumentException($"Cannot get proxy name for '{type.FullyQualifiedName}' because it is not an interface.");
         }
 
         public string GetInterfaceDefaultName(InterfaceType type, bool disambiguate = false)
@@ -122,7 +144,7 @@ namespace Amazon.JSII.Generator
                 return metadata.DefaultName;
             }
 
-            throw new ArgumentException($"Cannot get default name for '{type.FullyQualifiedName}' because it is not an interface");
+            throw new ArgumentException($"Cannot get default name for '{type.FullyQualifiedName}' because it is not an interface.");
         }
 
         public string GetName(Type type, Method method)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeMetadata.cs
@@ -67,6 +67,31 @@ namespace Amazon.JSII.Generator
         }
     }
 
+    public class AbstractClassTypeMetadata : ClassTypeMetadata
+    {
+        public string ProxyName { get; private set; }
+        
+        public string FrameworkFullyQualifiedProxyName => $"{Namespace}.{ProxyName}";
+        
+        public AbstractClassTypeMetadata(ClassType type, Assembly assembly)
+            : base(type, assembly)
+        {
+            ProxyName = $"{Name}Proxy";
+        }
+
+        public override void ResolveTypeNameConflicts(ISet<string> namespaceNames)
+        {
+            base.ResolveTypeNameConflicts(namespaceNames);
+
+            ISet<string> memberNames = new HashSet<string>(MemberNames.Values);
+
+            while (memberNames.Contains(ProxyName) || namespaceNames.Contains(FrameworkFullyQualifiedProxyName))
+            {
+                ProxyName += "_";
+            }
+        }
+    }
+
     public class EnumTypeMetadata : TypeMetadata
     {
         public EnumTypeMetadata(EnumType type, Assembly assembly)
@@ -82,7 +107,6 @@ namespace Amazon.JSII.Generator
             MemberNames = new ReadOnlyDictionary<string, string>(memberNames);
             Name = NameUtils.ConvertTypeName(type.Name);
         }
-
     }
 
     public class InterfaceTypeMetadata : TypeMetadata

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.JSII.JsonModel.Spec;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Amazon.JSII.Generator
+{
+    public abstract class TypeProxyGeneratorBase<T> : TypeGeneratorBase<T> where T : Type
+    {
+        protected TypeProxyGeneratorBase(string package, T type, ISymbolMap symbols, INamespaceSet namespaces)
+            : base(package, type, symbols, namespaces)
+        {
+        }
+
+        protected override MemberDeclarationSyntax CreateType()
+        {
+            return SF.ClassDeclaration
+            (
+                CreateAttributes(),
+                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword)),
+                GetProxyTypeNameSyntax(),
+                null,
+                CreateBaseList(),
+                SF.List<TypeParameterConstraintClauseSyntax>(),
+                SF.List(CreateMembers())
+            );
+
+            SyntaxList<AttributeListSyntax> CreateAttributes()
+            {
+                var typeOfExpression = SF.TypeOfExpression(Symbols.GetNameSyntax(Type));
+                var fullyQualifiedNameLiteral = SF.Literal(Type.FullyQualifiedName);
+
+                return SF.List(new[]
+                {
+                    SF.AttributeList(SF.SeparatedList(new[]
+                    {
+                        SF.Attribute(
+                            SF.ParseName("JsiiInterfaceProxy"),
+                            SF.ParseAttributeArgumentList($"({typeOfExpression}, {fullyQualifiedNameLiteral})")
+                        )
+                    }))
+                });
+            }
+
+            BaseListSyntax CreateBaseList()
+            {
+                return SF.BaseList(SF.SeparatedList(GetBaseTypes()));
+
+                IEnumerable<BaseTypeSyntax> GetBaseTypes()
+                {
+                    if (IsImplementingInterface)
+                    {
+                        yield return SF.SimpleBaseType(SF.ParseTypeName("DeputyBase"));
+                    }
+
+                    Namespaces.Add(Type);
+                    yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, disambiguate: true));
+                }
+            }
+
+            IEnumerable<MemberDeclarationSyntax> CreateMembers()
+            {
+                return CreateConstructors()
+                    .Concat(CreateProperties())
+                    .Concat(CreateMethods());
+            }
+        }
+
+        protected virtual IEnumerable<MemberDeclarationSyntax> CreateConstructors()
+        {
+            yield return SF.ConstructorDeclaration
+            (
+                SF.List<AttributeListSyntax>(),
+
+                // Only Amazon.JSII.Runtime should create interface proxies,
+                // so we make the constructor private.
+                SF.TokenList(SF.Token(SyntaxKind.PrivateKeyword)),
+                GetProxyTypeNameSyntax(),
+                SF.ParseParameterList("(ByRefValue reference)"),
+                SF.ConstructorInitializer
+                (
+                    SyntaxKind.BaseConstructorInitializer,
+                    SF.ParseArgumentList("(reference)")
+                ),
+                SF.Block(),
+                null
+            );
+        }
+
+        private bool IsImplementingInterface => Type is InterfaceType;
+
+        protected abstract SyntaxToken GetProxyTypeNameSyntax();
+
+        protected abstract IEnumerable<PropertyDeclarationSyntax> CreateProperties();
+
+        protected abstract IEnumerable<MemberDeclarationSyntax> CreateMethods();
+    }
+}

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
@@ -20,7 +20,9 @@ namespace Amazon.JSII.Generator
             return SF.ClassDeclaration
             (
                 CreateAttributes(),
-                SF.TokenList(SF.Token(SyntaxKind.InternalKeyword)),
+                SF.TokenList(
+                    SF.Token(SyntaxKind.InternalKeyword),
+                    SF.Token(SyntaxKind.SealedKeyword)),
                 GetProxyTypeNameSyntax(),
                 null,
                 CreateBaseList(),
@@ -38,7 +40,7 @@ namespace Amazon.JSII.Generator
                     SF.AttributeList(SF.SeparatedList(new[]
                     {
                         SF.Attribute(
-                            SF.ParseName("JsiiInterfaceProxy"),
+                            SF.ParseName("JsiiTypeProxy"),
                             SF.ParseAttributeArgumentList($"({typeOfExpression}, {fullyQualifiedNameLiteral})")
                         )
                     }))
@@ -51,7 +53,7 @@ namespace Amazon.JSII.Generator
 
                 IEnumerable<BaseTypeSyntax> GetBaseTypes()
                 {
-                    if (IsImplementingInterface)
+                    if (Type is InterfaceType)
                     {
                         yield return SF.SimpleBaseType(SF.ParseTypeName("DeputyBase"));
                     }
@@ -89,8 +91,6 @@ namespace Amazon.JSII.Generator
                 null
             );
         }
-
-        private bool IsImplementingInterface => Type is InterfaceType;
 
         protected abstract SyntaxToken GetProxyTypeNameSyntax();
 

--- a/packages/jsii-dotnet-generator/src/NuGet.config
+++ b/packages/jsii-dotnet-generator/src/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -1,13 +1,10 @@
+using System;
+using System.Collections.Generic;
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Runtime.Services;
 using Amazon.JSII.Tests.CalculatorNamespace;
-using Amazon.JSII.Tests.CalculatorNamespace.composition;
 using Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation;
 using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -784,13 +781,30 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         }
 
         [Fact(DisplayName = Prefix + nameof(NodeStandardLibrary))]
-        public void NodeStandardLibrary() {
+        public void NodeStandardLibrary() 
+        {
             NodeStandardLibrary obj = new NodeStandardLibrary();
             Assert.Equal("Hello, resource!", obj.FsReadFile());
             Assert.Equal("Hello, resource! SYNC!", obj.FsReadFileSync());
             Assert.True(obj.OsPlatform.Length > 0);
             Assert.Equal("6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50",
                 obj.CryptoSha256());
+        }
+        
+        [Fact(DisplayName = Prefix + nameof(ReturnAbstract))]
+        public void ReturnAbstract()
+        {
+            var obj = new AbstractClassReturner();
+            var obj2 = obj.GiveMeAbstract();
+
+            Assert.Equal("Hello, John!!", obj2.AbstractMethod("John"));
+            Assert.Equal("propFromInterfaceValue", obj2.PropFromInterface);
+            Assert.Equal(42, obj2.NonAbstractMethod());
+
+            var iface = obj.GiveMeInterface();
+            Assert.Equal("propFromInterfaceValue", iface.PropFromInterface);
+
+            Assert.Equal("hello-abstract-property", obj.ReturnAbstractFromProperty.AbstractProperty);
         }
 
 

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.sln
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.sln
@@ -14,8 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.JSII.Runtime.UnitTests", "Amazon.JSII.Runtime.UnitTests\Amazon.JSII.Runtime.UnitTests.csproj", "{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Runtime.IntegrationTests", "..\..\jsii-dotnet-runtime-test\test\Amazon.JSII.Runtime.IntegrationTests\Amazon.JSII.Runtime.IntegrationTests.csproj", "{4BD49478-03E5-45DD-97D8-A1281E9DC32C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,10 +28,6 @@ Global
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.sln
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.JSII.Runtime.UnitTests", "Amazon.JSII.Runtime.UnitTests\Amazon.JSII.Runtime.UnitTests.csproj", "{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Runtime.IntegrationTests", "..\..\jsii-dotnet-runtime-test\test\Amazon.JSII.Runtime.IntegrationTests\Amazon.JSII.Runtime.IntegrationTests.csproj", "{4BD49478-03E5-45DD-97D8-A1281E9DC32C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96CC0C0B-1D90-448F-9BFC-07CE93D2CE29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BD49478-03E5-45DD-97D8-A1281E9DC32C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/JsiiTypeProxyAttribute.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/JsiiTypeProxyAttribute.cs
@@ -3,9 +3,9 @@
 namespace Amazon.JSII.Runtime.Deputy
 {
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public class JsiiInterfaceProxyAttribute : JsiiTypeAttributeBase
+    public class JsiiTypeProxyAttribute : JsiiTypeAttributeBase
     {
-        public JsiiInterfaceProxyAttribute(Type nativeType, string fullyQualifiedName)
+        public JsiiTypeProxyAttribute(Type nativeType, string fullyQualifiedName)
             : base(nativeType, fullyQualifiedName)
         {
         }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -35,7 +35,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
 
             System.Type type = value.GetType();
 
-            if (type.GetCustomAttribute<JsiiInterfaceProxyAttribute>() != null)
+            if (type.GetCustomAttribute<JsiiTypeProxyAttribute>() != null)
             {
                 throw new ArgumentException
                 (

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/ValueConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/ValueConverter.cs
@@ -115,7 +115,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return
                     _types.GetClassType(fullyQualifiedName) != null ||
                     _types.GetInterfaceType(fullyQualifiedName) != null ||
-                    _types.GetInterfaceProxyType(fullyQualifiedName) != null;
+                    _types.GetProxyType(fullyQualifiedName) != null;
             }
         }
 

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ITypeCache.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ITypeCache.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.Runtime.Services
 
         Type GetInterfaceType(string fullyQualifiedName);
 
-        Type GetInterfaceProxyType(string fullyQualifiedName);
+        Type GetProxyType(string fullyQualifiedName);
 
         Type GetFrameworkType(JsonModel.Spec.TypeReference reference);
     }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ReferenceMap.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ReferenceMap.cs
@@ -1,8 +1,8 @@
-﻿using Amazon.JSII.JsonModel.Api;
-using Amazon.JSII.Runtime.Deputy;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Amazon.JSII.JsonModel.Api;
+using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Runtime.Services
 {
@@ -20,7 +20,9 @@ namespace Amazon.JSII.Runtime.Services
         {
             if (_references.ContainsKey(reference.Value))
             {
-                throw new ArgumentException($"Cannot add reference for {reference.Value}: A reference with this name already exists", nameof(reference));
+                throw new ArgumentException(
+                    $"Cannot add reference for {reference.Value}: A reference with this name already exists",
+                    nameof(reference));
             }
 
             _references[reference.Value] = nativeReference;
@@ -36,7 +38,7 @@ namespace Amazon.JSII.Runtime.Services
             if (!_references.ContainsKey(byRefValue.Value))
             {
                 ConstructorInfo constructorInfo = GetByRefConstructor();
-                _references[byRefValue.Value] = (DeputyBase)constructorInfo.Invoke(new object[] { byRefValue });
+                _references[byRefValue.Value] = (DeputyBase) constructorInfo.Invoke(new object[] {byRefValue});
             }
 
             return _references[byRefValue.Value];
@@ -46,8 +48,9 @@ namespace Amazon.JSII.Runtime.Services
                 Type type = _types.GetClassType(byRefValue.FullyQualifiedName);
                 if (type == null)
                 {
-                    type = _types.GetInterfaceProxyType(byRefValue.FullyQualifiedName);
+                    type = _types.GetProxyType(byRefValue.FullyQualifiedName);
                 }
+
                 if (type == null)
                 {
                     throw new ArgumentException(
@@ -58,7 +61,13 @@ namespace Amazon.JSII.Runtime.Services
 
                 BindingFlags constructorFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
-                return type.GetConstructor(constructorFlags, null, new[] { typeof(ByRefValue) }, null);
+                // Get proxy class implementation for abstract types.
+                if (type.IsClass && type.IsAbstract)
+                {
+                    type = _types.GetProxyType(byRefValue.FullyQualifiedName);
+                }
+
+                return type.GetConstructor(constructorFlags, null, new[] {typeof(ByRefValue)}, null);
             }
         }
     }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ReferenceMap.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ReferenceMap.cs
@@ -46,7 +46,9 @@ namespace Amazon.JSII.Runtime.Services
             ConstructorInfo GetByRefConstructor()
             {
                 Type type = _types.GetClassType(byRefValue.FullyQualifiedName);
-                if (type == null)
+
+                // If type is an interface or abstract class
+                if (type == null || type.IsAbstract)
                 {
                     type = _types.GetProxyType(byRefValue.FullyQualifiedName);
                 }
@@ -60,12 +62,6 @@ namespace Amazon.JSII.Runtime.Services
                 }
 
                 BindingFlags constructorFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-
-                // Get proxy class implementation for abstract types.
-                if (type.IsClass && type.IsAbstract)
-                {
-                    type = _types.GetProxyType(byRefValue.FullyQualifiedName);
-                }
 
                 return type.GetConstructor(constructorFlags, null, new[] {typeof(ByRefValue)}, null);
             }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
@@ -1,11 +1,13 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using PrimitiveType = Amazon.JSII.JsonModel.Spec.PrimitiveType;
-using CollectionKind = Amazon.JSII.JsonModel.Spec.CollectionKind;
+using Amazon.JSII.JsonModel.Spec;
 using Amazon.JSII.Runtime.Deputy;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Assembly = System.Reflection.Assembly;
+using Type = System.Type;
 
 namespace Amazon.JSII.Runtime.Services
 {
@@ -42,12 +44,12 @@ namespace Amazon.JSII.Runtime.Services
             return GetType<JsiiInterfaceAttribute>(fullyQualifiedName);
         }
 
-        public Type GetInterfaceProxyType(string fullyQualifiedName)
+        public Type GetProxyType(string fullyQualifiedName)
         {
             return GetType<JsiiInterfaceProxyAttribute>(fullyQualifiedName + ProxySuffix);
         }
 
-        public Type GetFrameworkType(JsonModel.Spec.TypeReference reference)
+        public Type GetFrameworkType(TypeReference reference)
         {
             bool isOptional = reference.IsOptional == true;
 
@@ -79,7 +81,7 @@ namespace Amazon.JSII.Runtime.Services
                     case PrimitiveType.Date:
                         return MakeNullableIfOptional(typeof(DateTime));
                     case PrimitiveType.Json:
-                        return typeof(Newtonsoft.Json.Linq.JObject);
+                        return typeof(JObject);
                     case PrimitiveType.Number:
                         return MakeNullableIfOptional(typeof(double));
                     case PrimitiveType.String:

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
@@ -46,7 +46,7 @@ namespace Amazon.JSII.Runtime.Services
 
         public Type GetProxyType(string fullyQualifiedName)
         {
-            return GetType<JsiiInterfaceProxyAttribute>(fullyQualifiedName + ProxySuffix);
+            return GetType<JsiiTypeProxyAttribute>(fullyQualifiedName + ProxySuffix);
         }
 
         public Type GetFrameworkType(TypeReference reference)
@@ -160,7 +160,7 @@ namespace Amazon.JSII.Runtime.Services
                 if (attribute != null)
                 {
                     string fullyQualifiedName = attribute.FullyQualifiedName;
-                    if (attribute is JsiiInterfaceProxyAttribute)
+                    if (attribute is JsiiTypeProxyAttribute)
                     {
                         fullyQualifiedName += ProxySuffix;
                     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BasePropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BasePropsProxy.cs
@@ -3,22 +3,22 @@ using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
-    [JsiiInterfaceProxy(typeof(IBaseProps), "@scope/jsii-calc-base.BaseProps")]
-    internal class BasePropsProxy : DeputyBase, IBaseProps
+    [JsiiTypeProxy(typeof(IBaseProps), "@scope/jsii-calc-base.BaseProps")]
+    internal sealed class BasePropsProxy : DeputyBase, IBaseProps
     {
         private BasePropsProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("bar", "{\"primitive\":\"string\"}")]
-        public virtual string Bar
+        public string Bar
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("foo", "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}")]
-        public virtual Very Foo
+        public Very Foo
         {
             get => GetInstanceProperty<Very>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
@@ -1,0 +1,13 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
+{
+    /// <summary>A base class.</summary>
+    [JsiiInterfaceProxy(typeof(Base), "@scope/jsii-calc-base.Base")]
+    internal class BaseProxy : Base
+    {
+        private BaseProxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     /// <summary>A base class.</summary>
-    [JsiiInterfaceProxy(typeof(Base), "@scope/jsii-calc-base.Base")]
-    internal class BaseProxy : Base
+    [JsiiTypeProxy(typeof(Base), "@scope/jsii-calc-base.Base")]
+    internal sealed class BaseProxy : Base
     {
         private BaseProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
@@ -6,8 +6,8 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// Applies to classes that are considered friendly. These classes can be greeted with
     /// a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
     /// </summary>
-    [JsiiInterfaceProxy(typeof(IIFriendly), "@scope/jsii-calc-lib.IFriendly")]
-    internal class IFriendlyProxy : DeputyBase, IIFriendly
+    [JsiiTypeProxy(typeof(IIFriendly), "@scope/jsii-calc-lib.IFriendly")]
+    internal sealed class IFriendlyProxy : DeputyBase, IIFriendly
     {
         private IFriendlyProxy(ByRefValue reference): base(reference)
         {
@@ -15,7 +15,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 
         /// <summary>Say hello!</summary>
         [JsiiMethod("hello", "{\"primitive\":\"string\"}", "[]")]
-        public virtual string Hello()
+        public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is the first struct we have created in jsii</summary>
-    [JsiiInterfaceProxy(typeof(IMyFirstStruct), "@scope/jsii-calc-lib.MyFirstStruct")]
-    internal class MyFirstStructProxy : DeputyBase, IMyFirstStruct
+    [JsiiTypeProxy(typeof(IMyFirstStruct), "@scope/jsii-calc-lib.MyFirstStruct")]
+    internal sealed class MyFirstStructProxy : DeputyBase, IMyFirstStruct
     {
         private MyFirstStructProxy(ByRefValue reference): base(reference)
         {
@@ -12,7 +12,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 
         /// <summary>An awesome number value</summary>
         [JsiiProperty("anumber", "{\"primitive\":\"number\"}")]
-        public virtual double Anumber
+        public double Anumber
         {
             get => GetInstanceProperty<double>();
             set => SetInstanceProperty(value);
@@ -20,14 +20,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 
         /// <summary>A string value</summary>
         [JsiiProperty("astring", "{\"primitive\":\"string\"}")]
-        public virtual string Astring
+        public string Astring
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("firstOptional", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}")]
-        public virtual string[] FirstOptional
+        public string[] FirstOptional
         {
             get => GetInstanceProperty<string[]>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
+{
+    /// <summary>Represents an operation on values.</summary>
+    [JsiiInterfaceProxy(typeof(Operation), "@scope/jsii-calc-lib.Operation")]
+    internal class OperationProxy : Operation
+    {
+        private OperationProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>The value.</summary>
+        [JsiiProperty("value", "{\"primitive\":\"number\"}")]
+        public override double Value
+        {
+            get => GetInstanceProperty<double>();
+        }
+
+        /// <summary>String representation of the value.</summary>
+        [JsiiMethod("toString", "{\"primitive\":\"string\"}", "[]")]
+        public override string ToString()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Represents an operation on values.</summary>
-    [JsiiInterfaceProxy(typeof(Operation), "@scope/jsii-calc-lib.Operation")]
-    internal class OperationProxy : Operation
+    [JsiiTypeProxy(typeof(Operation), "@scope/jsii-calc-lib.Operation")]
+    internal sealed class OperationProxy : Operation
     {
         private OperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is a struct with only optional properties.</summary>
-    [JsiiInterfaceProxy(typeof(IStructWithOnlyOptionals), "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
-    internal class StructWithOnlyOptionalsProxy : DeputyBase, IStructWithOnlyOptionals
+    [JsiiTypeProxy(typeof(IStructWithOnlyOptionals), "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
+    internal sealed class StructWithOnlyOptionalsProxy : DeputyBase, IStructWithOnlyOptionals
     {
         private StructWithOnlyOptionalsProxy(ByRefValue reference): base(reference)
         {
@@ -12,21 +12,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 
         /// <summary>The first optional!</summary>
         [JsiiProperty("optional1", "{\"primitive\":\"string\",\"optional\":true}")]
-        public virtual string Optional1
+        public string Optional1
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("optional2", "{\"primitive\":\"number\",\"optional\":true}")]
-        public virtual double? Optional2
+        public double? Optional2
         {
             get => GetInstanceProperty<double? >();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("optional3", "{\"primitive\":\"boolean\",\"optional\":true}")]
-        public virtual bool? Optional3
+        public bool? Optional3
         {
             get => GetInstanceProperty<bool? >();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
+{
+    /// <summary>Abstract class which represents a numeric value.</summary>
+    [JsiiInterfaceProxy(typeof(Value_), "@scope/jsii-calc-lib.Value")]
+    internal class ValueProxy : Value_
+    {
+        private ValueProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>The value.</summary>
+        [JsiiProperty("value", "{\"primitive\":\"number\"}")]
+        public override double Value
+        {
+            get => GetInstanceProperty<double>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Abstract class which represents a numeric value.</summary>
-    [JsiiInterfaceProxy(typeof(Value_), "@scope/jsii-calc-lib.Value")]
-    internal class ValueProxy : Value_
+    [JsiiTypeProxy(typeof(Value_), "@scope/jsii-calc-lib.Value")]
+    internal sealed class ValueProxy : Value_
     {
         private ValueProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
@@ -1,0 +1,18 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterfaceProxy(typeof(AbstractClassBase), "jsii-calc.AbstractClassBase")]
+    internal class AbstractClassBaseProxy : AbstractClassBase
+    {
+        private AbstractClassBaseProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("abstractProperty", "{\"primitive\":\"string\"}")]
+        public override string AbstractProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
@@ -2,8 +2,8 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(AbstractClassBase), "jsii-calc.AbstractClassBase")]
-    internal class AbstractClassBaseProxy : AbstractClassBase
+    [JsiiTypeProxy(typeof(AbstractClassBase), "jsii-calc.AbstractClassBase")]
+    internal sealed class AbstractClassBaseProxy : AbstractClassBase
     {
         private AbstractClassBaseProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
@@ -1,0 +1,24 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterfaceProxy(typeof(AbstractClass), "jsii-calc.AbstractClass")]
+    internal class AbstractClassProxy : AbstractClass
+    {
+        private AbstractClassProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("abstractProperty", "{\"primitive\":\"string\"}")]
+        public override string AbstractProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiMethod("abstractMethod", "{\"primitive\":\"string\"}", "[{\"name\":\"name\",\"type\":{\"primitive\":\"string\"}}]")]
+        public override string AbstractMethod(string name)
+        {
+            return InvokeInstanceMethod<string>(new object[]{name});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
@@ -2,8 +2,8 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(AbstractClass), "jsii-calc.AbstractClass")]
-    internal class AbstractClassProxy : AbstractClass
+    [JsiiTypeProxy(typeof(AbstractClass), "jsii-calc.AbstractClass")]
+    internal sealed class AbstractClassProxy : AbstractClass
     {
         private AbstractClassProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Represents an operation with two operands.</summary>
+    [JsiiInterfaceProxy(typeof(BinaryOperation), "jsii-calc.BinaryOperation")]
+    internal class BinaryOperationProxy : BinaryOperation
+    {
+        private BinaryOperationProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>The value.</summary>
+        [JsiiProperty("value", "{\"primitive\":\"number\"}")]
+        public override double Value
+        {
+            get => GetInstanceProperty<double>();
+        }
+
+        /// <summary>String representation of the value.</summary>
+        [JsiiMethod("toString", "{\"primitive\":\"string\"}", "[]")]
+        public override string ToString()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Represents an operation with two operands.</summary>
-    [JsiiInterfaceProxy(typeof(BinaryOperation), "jsii-calc.BinaryOperation")]
-    internal class BinaryOperationProxy : BinaryOperation
+    [JsiiTypeProxy(typeof(BinaryOperation), "jsii-calc.BinaryOperation")]
+    internal sealed class BinaryOperationProxy : BinaryOperation
     {
         private BinaryOperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
@@ -3,22 +3,22 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Properties for Calculator.</summary>
-    [JsiiInterfaceProxy(typeof(ICalculatorProps), "jsii-calc.CalculatorProps")]
-    internal class CalculatorPropsProxy : DeputyBase, ICalculatorProps
+    [JsiiTypeProxy(typeof(ICalculatorProps), "jsii-calc.CalculatorProps")]
+    internal sealed class CalculatorPropsProxy : DeputyBase, ICalculatorProps
     {
         private CalculatorPropsProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("initialValue", "{\"primitive\":\"number\",\"optional\":true}")]
-        public virtual double? InitialValue
+        public double? InitialValue
         {
             get => GetInstanceProperty<double? >();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("maximumValue", "{\"primitive\":\"number\",\"optional\":true}")]
-        public virtual double? MaximumValue
+        public double? MaximumValue
         {
             get => GetInstanceProperty<double? >();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
@@ -6,22 +6,22 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A struct which derives from another struct.</summary>
-    [JsiiInterfaceProxy(typeof(IDerivedStruct), "jsii-calc.DerivedStruct")]
-    internal class DerivedStructProxy : DeputyBase, IDerivedStruct
+    [JsiiTypeProxy(typeof(IDerivedStruct), "jsii-calc.DerivedStruct")]
+    internal sealed class DerivedStructProxy : DeputyBase, IDerivedStruct
     {
         private DerivedStructProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("anotherRequired", "{\"primitive\":\"date\"}")]
-        public virtual DateTime AnotherRequired
+        public DateTime AnotherRequired
         {
             get => GetInstanceProperty<DateTime>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("bool", "{\"primitive\":\"boolean\"}")]
-        public virtual bool Bool
+        public bool Bool
         {
             get => GetInstanceProperty<bool>();
             set => SetInstanceProperty(value);
@@ -29,7 +29,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>An example of a non primitive property.</summary>
         [JsiiProperty("nonPrimitive", "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
-        public virtual DoubleTrouble NonPrimitive
+        public DoubleTrouble NonPrimitive
         {
             get => GetInstanceProperty<DoubleTrouble>();
             set => SetInstanceProperty(value);
@@ -37,21 +37,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>This is optional.</summary>
         [JsiiProperty("anotherOptional", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},\"optional\":true}")]
-        public virtual IDictionary<string, Value_> AnotherOptional
+        public IDictionary<string, Value_> AnotherOptional
         {
             get => GetInstanceProperty<IDictionary<string, Value_>>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("optionalAny", "{\"primitive\":\"any\",\"optional\":true}")]
-        public virtual object OptionalAny
+        public object OptionalAny
         {
             get => GetInstanceProperty<object>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("optionalArray", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}")]
-        public virtual string[] OptionalArray
+        public string[] OptionalArray
         {
             get => GetInstanceProperty<string[]>();
             set => SetInstanceProperty(value);
@@ -59,7 +59,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>An awesome number value</summary>
         [JsiiProperty("anumber", "{\"primitive\":\"number\"}")]
-        public virtual double Anumber
+        public double Anumber
         {
             get => GetInstanceProperty<double>();
             set => SetInstanceProperty(value);
@@ -67,14 +67,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>A string value</summary>
         [JsiiProperty("astring", "{\"primitive\":\"string\"}")]
-        public virtual string Astring
+        public string Astring
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("firstOptional", "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}},\"optional\":true}")]
-        public virtual string[] FirstOptional
+        public string[] FirstOptional
         {
             get => GetInstanceProperty<string[]>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even friendlier classes can implement this interface.</summary>
-    [JsiiInterfaceProxy(typeof(IIFriendlier), "jsii-calc.IFriendlier")]
-    internal class IFriendlierProxy : DeputyBase, IIFriendlier
+    [JsiiTypeProxy(typeof(IIFriendlier), "jsii-calc.IFriendlier")]
+    internal sealed class IFriendlierProxy : DeputyBase, IIFriendlier
     {
         private IFriendlierProxy(ByRefValue reference): base(reference)
         {
@@ -12,7 +12,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Say farewell.</summary>
         [JsiiMethod("farewell", "{\"primitive\":\"string\"}", "[]")]
-        public virtual string Farewell()
+        public string Farewell()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
@@ -20,14 +20,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Say goodbye.</summary>
         /// <returns>A goodbye blessing.</returns>
         [JsiiMethod("goodbye", "{\"primitive\":\"string\"}", "[]")]
-        public virtual string Goodbye()
+        public string Goodbye()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
         /// <summary>Say hello!</summary>
         [JsiiMethod("hello", "{\"primitive\":\"string\"}", "[]")]
-        public virtual string Hello()
+        public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
@@ -2,8 +2,8 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IIFriendlyRandomGenerator), "jsii-calc.IFriendlyRandomGenerator")]
-    internal class IFriendlyRandomGeneratorProxy : DeputyBase, IIFriendlyRandomGenerator
+    [JsiiTypeProxy(typeof(IIFriendlyRandomGenerator), "jsii-calc.IFriendlyRandomGenerator")]
+    internal sealed class IFriendlyRandomGeneratorProxy : DeputyBase, IIFriendlyRandomGenerator
     {
         private IFriendlyRandomGeneratorProxy(ByRefValue reference): base(reference)
         {
@@ -12,14 +12,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Returns another random number.</summary>
         /// <returns>A random number.</returns>
         [JsiiMethod("next", "{\"primitive\":\"number\"}", "[]")]
-        public virtual double Next()
+        public double Next()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
         /// <summary>Say hello!</summary>
         [JsiiMethod("hello", "{\"primitive\":\"string\"}", "[]")]
-        public virtual string Hello()
+        public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
@@ -2,28 +2,28 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IIInterfaceWithPropertiesExtension), "jsii-calc.IInterfaceWithPropertiesExtension")]
-    internal class IInterfaceWithPropertiesExtensionProxy : DeputyBase, IIInterfaceWithPropertiesExtension
+    [JsiiTypeProxy(typeof(IIInterfaceWithPropertiesExtension), "jsii-calc.IInterfaceWithPropertiesExtension")]
+    internal sealed class IInterfaceWithPropertiesExtensionProxy : DeputyBase, IIInterfaceWithPropertiesExtension
     {
         private IInterfaceWithPropertiesExtensionProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("foo", "{\"primitive\":\"number\"}")]
-        public virtual double Foo
+        public double Foo
         {
             get => GetInstanceProperty<double>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("readOnlyString", "{\"primitive\":\"string\"}")]
-        public virtual string ReadOnlyString
+        public string ReadOnlyString
         {
             get => GetInstanceProperty<string>();
         }
 
         [JsiiProperty("readWriteString", "{\"primitive\":\"string\"}")]
-        public virtual string ReadWriteString
+        public string ReadWriteString
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
@@ -2,21 +2,21 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IIInterfaceWithProperties), "jsii-calc.IInterfaceWithProperties")]
-    internal class IInterfaceWithPropertiesProxy : DeputyBase, IIInterfaceWithProperties
+    [JsiiTypeProxy(typeof(IIInterfaceWithProperties), "jsii-calc.IInterfaceWithProperties")]
+    internal sealed class IInterfaceWithPropertiesProxy : DeputyBase, IIInterfaceWithProperties
     {
         private IInterfaceWithPropertiesProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("readOnlyString", "{\"primitive\":\"string\"}")]
-        public virtual string ReadOnlyString
+        public string ReadOnlyString
         {
             get => GetInstanceProperty<string>();
         }
 
         [JsiiProperty("readWriteString", "{\"primitive\":\"string\"}")]
-        public virtual string ReadWriteString
+        public string ReadWriteString
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Generates random numbers.</summary>
-    [JsiiInterfaceProxy(typeof(IIRandomNumberGenerator), "jsii-calc.IRandomNumberGenerator")]
-    internal class IRandomNumberGeneratorProxy : DeputyBase, IIRandomNumberGenerator
+    [JsiiTypeProxy(typeof(IIRandomNumberGenerator), "jsii-calc.IRandomNumberGenerator")]
+    internal sealed class IRandomNumberGeneratorProxy : DeputyBase, IIRandomNumberGenerator
     {
         private IRandomNumberGeneratorProxy(ByRefValue reference): base(reference)
         {
@@ -13,7 +13,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Returns another random number.</summary>
         /// <returns>A random number.</returns>
         [JsiiMethod("next", "{\"primitive\":\"number\"}", "[]")]
-        public virtual double Next()
+        public double Next()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
@@ -4,29 +4,29 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IImplictBaseOfBase), "jsii-calc.ImplictBaseOfBase")]
-    internal class ImplictBaseOfBaseProxy : DeputyBase, IImplictBaseOfBase
+    [JsiiTypeProxy(typeof(IImplictBaseOfBase), "jsii-calc.ImplictBaseOfBase")]
+    internal sealed class ImplictBaseOfBaseProxy : DeputyBase, IImplictBaseOfBase
     {
         private ImplictBaseOfBaseProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("goo", "{\"primitive\":\"date\"}")]
-        public virtual DateTime Goo
+        public DateTime Goo
         {
             get => GetInstanceProperty<DateTime>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("bar", "{\"primitive\":\"string\"}")]
-        public virtual string Bar
+        public string Bar
         {
             get => GetInstanceProperty<string>();
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty("foo", "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}")]
-        public virtual Very Foo
+        public Very Foo
         {
             get => GetInstanceProperty<Very>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceImplementedByAbstractClassProxy.cs
@@ -6,15 +6,15 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// awslabs/jsii#220
     /// Abstract return type
     /// </summary>
-    [JsiiInterfaceProxy(typeof(IInterfaceImplementedByAbstractClass), "jsii-calc.InterfaceImplementedByAbstractClass")]
-    internal class InterfaceImplementedByAbstractClassProxy : DeputyBase, IInterfaceImplementedByAbstractClass
+    [JsiiTypeProxy(typeof(IInterfaceImplementedByAbstractClass), "jsii-calc.InterfaceImplementedByAbstractClass")]
+    internal sealed class InterfaceImplementedByAbstractClassProxy : DeputyBase, IInterfaceImplementedByAbstractClass
     {
         private InterfaceImplementedByAbstractClassProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("propFromInterface", "{\"primitive\":\"string\"}")]
-        public virtual string PropFromInterface
+        public string PropFromInterface
         {
             get => GetInstanceProperty<string>();
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/HelloProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/HelloProxy.cs
@@ -2,15 +2,15 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses
 {
-    [JsiiInterfaceProxy(typeof(IHello), "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello")]
-    internal class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.IHello
+    [JsiiTypeProxy(typeof(IHello), "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello")]
+    internal sealed class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.IHello
     {
         private HelloProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("foo", "{\"primitive\":\"number\"}")]
-        public virtual double Foo
+        public double Foo
         {
             get => GetInstanceProperty<double>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/HelloProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/HelloProxy.cs
@@ -2,15 +2,15 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface
 {
-    [JsiiInterfaceProxy(typeof(IHello), "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello")]
-    internal class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface.IHello
+    [JsiiTypeProxy(typeof(IHello), "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello")]
+    internal sealed class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface.IHello
     {
         private HelloProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("foo", "{\"primitive\":\"number\"}")]
-        public virtual double Foo
+        public double Foo
         {
             get => GetInstanceProperty<double>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceWithOptionalMethodArgumentsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceWithOptionalMethodArgumentsProxy.cs
@@ -6,15 +6,15 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// awslabs/jsii#175
     /// Interface proxies (and builders) do not respect optional arguments in methods
     /// </summary>
-    [JsiiInterfaceProxy(typeof(IInterfaceWithOptionalMethodArguments), "jsii-calc.InterfaceWithOptionalMethodArguments")]
-    internal class InterfaceWithOptionalMethodArgumentsProxy : DeputyBase, IInterfaceWithOptionalMethodArguments
+    [JsiiTypeProxy(typeof(IInterfaceWithOptionalMethodArguments), "jsii-calc.InterfaceWithOptionalMethodArguments")]
+    internal sealed class InterfaceWithOptionalMethodArgumentsProxy : DeputyBase, IInterfaceWithOptionalMethodArguments
     {
         private InterfaceWithOptionalMethodArgumentsProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiMethod("hello", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\",\"optional\":true}}]")]
-        public virtual void Hello(string arg1, double? arg2)
+        public void Hello(string arg1, double? arg2)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsNumberProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsNumberProxy.cs
@@ -2,21 +2,21 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IReturnsNumber), "jsii-calc.ReturnsNumber")]
-    internal class ReturnsNumberProxy : DeputyBase, IReturnsNumber
+    [JsiiTypeProxy(typeof(IReturnsNumber), "jsii-calc.ReturnsNumber")]
+    internal sealed class ReturnsNumberProxy : DeputyBase, IReturnsNumber
     {
         private ReturnsNumberProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("numberProp", "{\"primitive\":\"number\"}")]
-        public virtual double NumberProp
+        public double NumberProp
         {
             get => GetInstanceProperty<double>();
         }
 
         [JsiiMethod("obtainNumber", "{\"primitive\":\"number\"}", "[]")]
-        public virtual double ObtainNumber()
+        public double ObtainNumber()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>An operation on a single operand.</summary>
+    [JsiiInterfaceProxy(typeof(UnaryOperation), "jsii-calc.UnaryOperation")]
+    internal class UnaryOperationProxy : UnaryOperation
+    {
+        private UnaryOperationProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>The value.</summary>
+        [JsiiProperty("value", "{\"primitive\":\"number\"}")]
+        public override double Value
+        {
+            get => GetInstanceProperty<double>();
+        }
+
+        /// <summary>String representation of the value.</summary>
+        [JsiiMethod("toString", "{\"primitive\":\"string\"}", "[]")]
+        public override string ToString()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
@@ -3,8 +3,8 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation on a single operand.</summary>
-    [JsiiInterfaceProxy(typeof(UnaryOperation), "jsii-calc.UnaryOperation")]
-    internal class UnaryOperationProxy : UnaryOperation
+    [JsiiTypeProxy(typeof(UnaryOperation), "jsii-calc.UnaryOperation")]
+    internal sealed class UnaryOperationProxy : UnaryOperation
     {
         private UnaryOperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
@@ -2,21 +2,21 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiInterfaceProxy(typeof(IUnionProperties), "jsii-calc.UnionProperties")]
-    internal class UnionPropertiesProxy : DeputyBase, IUnionProperties
+    [JsiiTypeProxy(typeof(IUnionProperties), "jsii-calc.UnionProperties")]
+    internal sealed class UnionPropertiesProxy : DeputyBase, IUnionProperties
     {
         private UnionPropertiesProxy(ByRefValue reference): base(reference)
         {
         }
 
         [JsiiProperty("bar", "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.AllTypes\"}]}}")]
-        public virtual object Bar
+        public object Bar
         {
             get => GetInstanceProperty<object>();
         }
 
         [JsiiProperty("foo", "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"}]},\"optional\":true}")]
-        public virtual object Foo
+        public object Foo
         {
             get => GetInstanceProperty<object>();
             set => SetInstanceProperty(value);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
@@ -1,0 +1,24 @@
+using Amazon.JSII.Runtime.Deputy;
+using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.composition
+{
+    /// <summary>Abstract operation composed from an expression of other operations.</summary>
+    [JsiiInterfaceProxy(typeof(CompositeOperation_), "jsii-calc.composition.CompositeOperation")]
+    internal class CompositeOperationProxy : CompositeOperation_
+    {
+        private CompositeOperationProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>
+        /// The expression that this operation consists of.
+        /// Must be implemented by derived classes.
+        /// </summary>
+        [JsiiProperty("expression", "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
+        public override Value_ Expression
+        {
+            get => GetInstanceProperty<Value_>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
@@ -4,8 +4,8 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition
 {
     /// <summary>Abstract operation composed from an expression of other operations.</summary>
-    [JsiiInterfaceProxy(typeof(CompositeOperation_), "jsii-calc.composition.CompositeOperation")]
-    internal class CompositeOperationProxy : CompositeOperation_
+    [JsiiTypeProxy(typeof(CompositeOperation_), "jsii-calc.composition.CompositeOperation")]
+    internal sealed class CompositeOperationProxy : CompositeOperation_
     {
         private CompositeOperationProxy(ByRefValue reference): base(reference)
         {


### PR DESCRIPTION
Abstract classes have can implementations that are not shared through jsii. When trying to instantiate one for these types as a return value, the runtime crashes. This change creates proxy class types for abstract classes. These types can be instantiated, and have implementations for any methods/properties marked as abstract.

Fixes #223

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
