### PR TITLE
fix(kernel): Return object literals as references

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -887,3 +887,11 @@ export class AbstractClassReturner {
         }
     }
 }
+
+export interface MutableObjectLiteral {
+    value: string;
+}
+
+export class ClassWithMutableObjectLiteralProperty {
+    public mutableObject: MutableObjectLiteral = { value: 'default' };
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1018,6 +1018,23 @@
         }
       ]
     },
+    "jsii-calc.ClassWithMutableObjectLiteralProperty": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "ClassWithMutableObjectLiteralProperty",
+      "properties": [
+        {
+          "name": "mutableObject",
+          "type": {
+            "fqn": "jsii-calc.MutableObjectLiteral"
+          }
+        }
+      ]
+    },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DefaultedConstructorArgument",
@@ -1879,6 +1896,22 @@
           },
           "type": {
             "primitive": "number"
+          }
+        }
+      ]
+    },
+    "jsii-calc.MutableObjectLiteral": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "fqn": "jsii-calc.MutableObjectLiteral",
+      "kind": "interface",
+      "name": "MutableObjectLiteral",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "value",
+          "type": {
+            "primitive": "string"
           }
         }
       ]
@@ -3230,5 +3263,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "ecDtx3DHVZi7UjyCDhGncg4jbSRaD536bUyh6YzAxlY="
+  "fingerprint": "DFShLmIJQmPjTv5Dmz4JoBKqoCtAyifD1RpCuHo+sEc="
 }

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -886,6 +886,8 @@ defineTest('object literals are returned by reference', async (test, sandbox) =>
                    objref: sandbox.get({ objref, property: 'mutableObject' }).value,
                    property: 'value'
                }).value);
+
+    sandbox.del({ objref: property });
 });
 
 const testNames: { [name: string]: boolean } = { };

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -873,6 +873,21 @@ defineTest('node.js standard library', async (test, sandbox) => {
         { result: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50" });
 });
 
+// @see awslabs/jsii#248
+defineTest('object literals are returned by reference', async (test, sandbox) => {
+    const objref = sandbox.create({ fqn: 'jsii-calc.ClassWithMutableObjectLiteralProperty' });
+    const property = sandbox.get({ objref, property: 'mutableObject' }).value;
+
+    const newValue = 'Bazinga!1!';
+    sandbox.set({ objref: property, property: 'value', value: newValue });
+
+    test.equal(newValue,
+               sandbox.get({
+                   objref: sandbox.get({ objref, property: 'mutableObject' }).value,
+                   property: 'value'
+               }).value);
+});
+
 const testNames: { [name: string]: boolean } = { };
 
 async function createCalculatorSandbox(name: string) {

--- a/packages/jsii-kernel/tsconfig.json
+++ b/packages/jsii-kernel/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
+    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1018,6 +1018,23 @@
         }
       ]
     },
+    "jsii-calc.ClassWithMutableObjectLiteralProperty": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "ClassWithMutableObjectLiteralProperty",
+      "properties": [
+        {
+          "name": "mutableObject",
+          "type": {
+            "fqn": "jsii-calc.MutableObjectLiteral"
+          }
+        }
+      ]
+    },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DefaultedConstructorArgument",
@@ -1879,6 +1896,22 @@
           },
           "type": {
             "primitive": "number"
+          }
+        }
+      ]
+    },
+    "jsii-calc.MutableObjectLiteral": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "fqn": "jsii-calc.MutableObjectLiteral",
+      "kind": "interface",
+      "name": "MutableObjectLiteral",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "value",
+          "type": {
+            "primitive": "string"
           }
         }
       ]
@@ -3230,5 +3263,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "ecDtx3DHVZi7UjyCDhGncg4jbSRaD536bUyh6YzAxlY="
+  "fingerprint": "DFShLmIJQmPjTv5Dmz4JoBKqoCtAyifD1RpCuHo+sEc="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(ClassWithMutableObjectLiteralProperty), "jsii-calc.ClassWithMutableObjectLiteralProperty", "[]")]
+    public class ClassWithMutableObjectLiteralProperty : DeputyBase
+    {
+        public ClassWithMutableObjectLiteralProperty(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected ClassWithMutableObjectLiteralProperty(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected ClassWithMutableObjectLiteralProperty(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("mutableObject", "{\"fqn\":\"jsii-calc.MutableObjectLiteral\"}")]
+        public virtual IMutableObjectLiteral MutableObject
+        {
+            get => GetInstanceProperty<IMutableObjectLiteral>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteral.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteral.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(typeof(IMutableObjectLiteral), "jsii-calc.MutableObjectLiteral")]
+    public interface IMutableObjectLiteral
+    {
+        [JsiiProperty("value", "{\"primitive\":\"string\"}")]
+        string Value
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/MutableObjectLiteral.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/MutableObjectLiteral.cs
@@ -1,0 +1,14 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    public class MutableObjectLiteral : DeputyBase, IMutableObjectLiteral
+    {
+        [JsiiProperty("value", "{\"primitive\":\"string\"}", true)]
+        public string Value
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/MutableObjectLiteralProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/MutableObjectLiteralProxy.cs
@@ -1,0 +1,19 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(typeof(IMutableObjectLiteral), "jsii-calc.MutableObjectLiteral")]
+    internal sealed class MutableObjectLiteralProxy : DeputyBase, IMutableObjectLiteral
+    {
+        private MutableObjectLiteralProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("value", "{\"primitive\":\"string\"}")]
+        public string Value
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -29,6 +29,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.BinaryOperation": return software.amazon.jsii.tests.calculator.BinaryOperation.class;
             case "jsii-calc.Calculator": return software.amazon.jsii.tests.calculator.Calculator.class;
             case "jsii-calc.CalculatorProps": return software.amazon.jsii.tests.calculator.CalculatorProps.class;
+            case "jsii-calc.ClassWithMutableObjectLiteralProperty": return software.amazon.jsii.tests.calculator.ClassWithMutableObjectLiteralProperty.class;
             case "jsii-calc.DefaultedConstructorArgument": return software.amazon.jsii.tests.calculator.DefaultedConstructorArgument.class;
             case "jsii-calc.DerivedClassHasNoProperties.Base": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base.class;
             case "jsii-calc.DerivedClassHasNoProperties.Derived": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived.class;
@@ -51,6 +52,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.JSObjectLiteralToNativeClass": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class;
             case "jsii-calc.JavaReservedWords": return software.amazon.jsii.tests.calculator.JavaReservedWords.class;
             case "jsii-calc.Multiply": return software.amazon.jsii.tests.calculator.Multiply.class;
+            case "jsii-calc.MutableObjectLiteral": return software.amazon.jsii.tests.calculator.MutableObjectLiteral.class;
             case "jsii-calc.Negate": return software.amazon.jsii.tests.calculator.Negate.class;
             case "jsii-calc.NodeStandardLibrary": return software.amazon.jsii.tests.calculator.NodeStandardLibrary.class;
             case "jsii-calc.NumberGenerator": return software.amazon.jsii.tests.calculator.NumberGenerator.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
@@ -1,0 +1,21 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithMutableObjectLiteralProperty")
+public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.JsiiObject {
+    protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public ClassWithMutableObjectLiteralProperty() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public software.amazon.jsii.tests.calculator.MutableObjectLiteral getMutableObject() {
+        return this.jsiiGet("mutableObject", software.amazon.jsii.tests.calculator.MutableObjectLiteral.class);
+    }
+
+    public void setMutableObject(final software.amazon.jsii.tests.calculator.MutableObjectLiteral value) {
+        this.jsiiSet("mutableObject", java.util.Objects.requireNonNull(value, "mutableObject is required"));
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/MutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/MutableObjectLiteral.java
@@ -1,0 +1,72 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface MutableObjectLiteral extends software.amazon.jsii.JsiiSerializable {
+    java.lang.String getValue();
+    void setValue(final java.lang.String value);
+
+    /**
+     * @return a {@link Builder} of {@link MutableObjectLiteral}
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link MutableObjectLiteral}
+     */
+    final class Builder {
+        private java.lang.String _value;
+
+        /**
+         * Sets the value of Value
+         * @param value the value to be set
+         * @return {@code this}
+         */
+        public Builder withValue(final java.lang.String value) {
+            this._value = java.util.Objects.requireNonNull(value, "value is required");
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link MutableObjectLiteral}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        public MutableObjectLiteral build() {
+            return new MutableObjectLiteral() {
+                private java.lang.String $value = java.util.Objects.requireNonNull(_value, "value is required");
+
+                @Override
+                public java.lang.String getValue() {
+                    return this.$value;
+                }
+
+                @Override
+                public void setValue(final java.lang.String value) {
+                    this.$value = java.util.Objects.requireNonNull(value, "value is required");
+                }
+
+            };
+        }
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.MutableObjectLiteral {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getValue() {
+            return this.jsiiGet("value", java.lang.String.class);
+        }
+
+        @Override
+        public void setValue(final java.lang.String value) {
+            this.jsiiSet("value", java.util.Objects.requireNonNull(value, "value is required"));
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -973,6 +973,39 @@ CalculatorProps (interface)
       :type: number or ``undefined`` *(abstract)*
 
 
+ClassWithMutableObjectLiteralProperty
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: ClassWithMutableObjectLiteralProperty()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.ClassWithMutableObjectLiteralProperty;
+
+      .. code-tab:: javascript
+
+         const { ClassWithMutableObjectLiteralProperty } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { ClassWithMutableObjectLiteralProperty } from 'jsii-calc';
+
+
+
+
+   .. py:attribute:: mutableObject
+
+      :type: :py:class:`~jsii-calc.MutableObjectLiteral`\ 
+
+
 DefaultedConstructorArgument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2272,6 +2305,40 @@ Multiply
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
+
+
+MutableObjectLiteral (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: MutableObjectLiteral
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.MutableObjectLiteral;
+
+      .. code-tab:: javascript
+
+         // MutableObjectLiteral is an interface
+
+      .. code-tab:: typescript
+
+         import { MutableObjectLiteral } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: value
+
+      :type: string *(abstract)*
 
 
 Negate

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -44,6 +44,14 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"requires": {
+				"lodash": "^4.17.10"
+			}
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -72,6 +80,11 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bind-obj-methods": {
 			"version": "2.0.0",
@@ -197,6 +210,11 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -397,6 +415,11 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -412,6 +435,21 @@
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
 			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"requires": {
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"log-driver": {
 			"version": "1.2.7",
@@ -2942,6 +2980,15 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+		},
+		"source-map-loader": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+			"requires": {
+				"async": "^2.5.0",
+				"loader-utils": "^1.1.0"
+			}
 		},
 		"source-map-support": {
 			"version": "0.5.9",

--- a/packages/jsii-runtime/package.json
+++ b/packages/jsii-runtime/package.json
@@ -20,6 +20,7 @@
     "jsii-build-tools": "^0.7.6",
     "jsii-calc": "^0.7.6",
     "nodeunit": "^0.11.3",
+    "source-map-loader": "^0.2.4",
     "typescript": "^3.0.1",
     "wasm-loader": "^1.3.0",
     "webpack": "^4.12.0",

--- a/packages/jsii-runtime/webpack.config.js
+++ b/packages/jsii-runtime/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
         path: __dirname + '/webpack',
         filename: 'jsii-runtime.js'
     },
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
     target: 'node',
     node: {
         console: false,

--- a/packages/jsii-runtime/webpack.config.js
+++ b/packages/jsii-runtime/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
         path: __dirname + '/webpack',
         filename: 'jsii-runtime.js'
     },
-    devtool: 'source-maps',
+    devtool: 'inline-source-map',
     target: 'node',
     node: {
         console: false,
@@ -16,5 +16,12 @@ module.exports = {
         __dirname: false,
         Buffer: false,
         setImmediate: false,
+    },
+    module: {
+        rules: [{
+            test: /\.js$/,
+            use: ['source-map-loader'],
+            enforce: 'pre'
+        }]
     }
 }


### PR DESCRIPTION
Use the javascript `Proxy` class to coalesce object literals to an
interface type, allowing them to be returned by reference instead of by
value.

Introduces a test in the `jsii-kernel` to demonstrate the feature works
as intended.

Fixes #248
Fixes awslabs/aws-cdk#774