### PR TITLE
chore: make error message about statics more descriptive

### DIFF
--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -75,7 +75,7 @@ function _defaultValidations(): ValidationFunction[] {
             if (member.static && (member as spec.Property).const) { continue; }
             if (member.name && member.name !== Case.camel(member.name)) {
                 diagnostic(ts.DiagnosticCategory.Error,
-                            `Method and non-const property names must use camelCase: ${member.name}`);
+                            `Method and non-static non-readonly property names must use camelCase: ${member.name}`);
             }
         }
     }

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -75,7 +75,7 @@ function _defaultValidations(): ValidationFunction[] {
             if (member.static && (member as spec.Property).const) { continue; }
             if (member.name && member.name !== Case.camel(member.name)) {
                 diagnostic(ts.DiagnosticCategory.Error,
-                            `Method and property names must use camelCase: ${member.name}`);
+                            `Method and non-const property names must use camelCase: ${member.name}`);
             }
         }
     }

--- a/packages/jsii/test/negatives/neg.method-name.1.ts
+++ b/packages/jsii/test/negatives/neg.method-name.1.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: METHOD
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: METHOD
 
 export class MyClass {
     public METHOD() {

--- a/packages/jsii/test/negatives/neg.method-name.2.ts
+++ b/packages/jsii/test/negatives/neg.method-name.2.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: hello_world
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: hello_world
 
 export class MyClass {
     public hello_world() {

--- a/packages/jsii/test/negatives/neg.property-name.1.ts
+++ b/packages/jsii/test/negatives/neg.property-name.1.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: PROP
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: PROP
 
 export class MyClass {
     public PROP?: number;

--- a/packages/jsii/test/negatives/neg.property-name.2.ts
+++ b/packages/jsii/test/negatives/neg.property-name.2.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: my_Prop
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: my_Prop
 
 export class MyClass {
     public my_Prop?: number;

--- a/packages/jsii/test/negatives/neg.static-method-name.1.ts
+++ b/packages/jsii/test/negatives/neg.static-method-name.1.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: MethodIsNotCamelCase
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: MethodIsNotCamelCase
 
 export class MyClass {
     MethodIsNotCamelCase() {

--- a/packages/jsii/test/negatives/neg.static-method-name.ts
+++ b/packages/jsii/test/negatives/neg.static-method-name.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: METHOD
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: METHOD
 
 export class MyClass {
     METHOD() {

--- a/packages/jsii/test/negatives/neg.static-prop-name.1.ts
+++ b/packages/jsii/test/negatives/neg.static-prop-name.1.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: Prop
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: Prop
 
 export class MyClass {
     static get Prop() {

--- a/packages/jsii/test/negatives/neg.static-prop-name.2.ts
+++ b/packages/jsii/test/negatives/neg.static-prop-name.2.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Method and property names must use camelCase: PROP
+///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: PROP
 
 export class MyClass {
     static get PROP() {


### PR DESCRIPTION
Add a 'non-const' qualifier to indicate that you probably forgot
to add 'const' on your 'public static' properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
