### PR TITLE
 fix(kernel + java): skip overrides of private methods/properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7570,9 +7570,9 @@
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-			"integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+			"integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
 			"dev": true
 		},
 		"unicode-length": {

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -871,7 +871,6 @@ class ConcreteClass extends AbstractClass {
     }
 }
 
-
 export class AbstractClassReturner {
     public giveMeAbstract(): AbstractClass {
         return new ConcreteClass();
@@ -885,5 +884,21 @@ export class AbstractClassReturner {
         return {
             abstractProperty: 'hello-abstract-property'
         }
+    }
+}
+
+export class DoNotOverridePrivates {
+    private privateMethod(): string {
+        return 'privateMethod';
+    }
+
+    private privateProperty = 'privateProperty';
+
+    public privateMethodValue() {
+        return this.privateMethod();
+    }
+
+    public privatePropertyValue() {
+        return this.privateProperty;
     }
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -909,4 +909,8 @@ export class DoNotOverridePrivates {
     public privatePropertyValue() {
         return this.privateProperty;
     }
+
+    public changePrivatePropertyValue(newValue: string) {
+        this.privateProperty = newValue;
+    }
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -910,5 +910,3 @@ export class DoNotOverridePrivates {
         return this.privateProperty;
     }
 }
-
-

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1181,6 +1181,29 @@
         }
       ]
     },
+    "jsii-calc.DoNotOverridePrivates": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DoNotOverridePrivates",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "privateMethodValue",
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "privatePropertyValue",
+          "returns": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "name": "DoNotOverridePrivates"
+    },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DoubleTrouble",
@@ -3230,5 +3253,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "ecDtx3DHVZi7UjyCDhGncg4jbSRaD536bUyh6YzAxlY="
+  "fingerprint": "eSNc0E/b0z3EKspPQoD/VEU1sfZLTkQJpTS8y7XqbJM="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3297,5 +3297,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "eSNc0E/b0z3EKspPQoD/VEU1sfZLTkQJpTS8y7XqbJM="
+  "fingerprint": "IrPnQp841TiCOiG/Z2z18s0K8pxTwuMglW1UJ2t1zsM="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1207,6 +1207,17 @@
       "kind": "class",
       "methods": [
         {
+          "name": "changePrivatePropertyValue",
+          "parameters": [
+            {
+              "name": "newValue",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ]
+        },
+        {
           "name": "privateMethodValue",
           "returns": {
             "primitive": "string"

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -11,6 +11,7 @@ import software.amazon.jsii.tests.calculator.AsyncVirtualMethods;
 import software.amazon.jsii.tests.calculator.Calculator;
 import software.amazon.jsii.tests.calculator.CalculatorProps;
 import software.amazon.jsii.tests.calculator.DerivedStruct;
+import software.amazon.jsii.tests.calculator.DoNotOverridePrivates;
 import software.amazon.jsii.tests.calculator.DoubleTrouble;
 import software.amazon.jsii.tests.calculator.GiveMeStructs;
 import software.amazon.jsii.tests.calculator.IFriendlier;
@@ -836,6 +837,73 @@ public class ComplianceTest {
 
         assertEquals("hello-abstract-property", obj.getReturnAbstractFromProperty().getAbstractProperty());
     }
+
+    @Test
+    public void doNotOverridePrivates_method_public() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            public String privateMethod() {
+                return "privateMethod-Override";
+            }
+        };
+
+        assertEquals("privateMethod", obj.privateMethodValue());
+    }
+
+    @Test
+    public void doNotOverridePrivates_method_private() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            private String privateMethod() {
+                return "privateMethod-Override";
+            }
+        };
+
+        assertEquals("privateMethod", obj.privateMethodValue());
+    }
+
+    @Test
+    public void doNotOverridePrivates_property_by_name_private() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            private String privateProperty() {
+                return "privateProperty-Override";
+            }
+        };
+
+        assertEquals("privateProperty", obj.privatePropertyValue());
+    }
+
+    @Test
+    public void doNotOverridePrivates_property_by_name_public() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            public String privateProperty() {
+                return "privateProperty-Override";
+            }
+        };
+
+        assertEquals("privateProperty", obj.privatePropertyValue());
+    }
+
+    @Test
+    public void doNotOverridePrivates_property_getter_public() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            public String getPrivateProperty() {
+                return "privateProperty-Override";
+            }
+        };
+
+        assertEquals("privateProperty", obj.privatePropertyValue());
+    }
+
+    @Test
+    public void doNotOverridePrivates_property_getter_private() {
+        DoNotOverridePrivates obj = new DoNotOverridePrivates() {
+            private String getPrivateProperty() {
+                return "privateProperty-Override";
+            }
+        };
+
+        assertEquals("privateProperty", obj.privatePropertyValue());
+    }
+
 
     static class MulTen extends Multiply {
         public MulTen(final int value) {

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -888,9 +888,16 @@ public class ComplianceTest {
             public String getPrivateProperty() {
                 return "privateProperty-Override";
             }
+            public void setPrivateProperty(String value) {
+                throw new RuntimeException("Boom");
+            }
         };
 
         assertEquals("privateProperty", obj.privatePropertyValue());
+
+        // verify the setter override is not invoked.
+        obj.changePrivatePropertyValue("MyNewValue");
+        assertEquals("MyNewValue", obj.privatePropertyValue());
     }
 
     @Test
@@ -899,11 +906,17 @@ public class ComplianceTest {
             private String getPrivateProperty() {
                 return "privateProperty-Override";
             }
+            public void setPrivateProperty(String value) {
+                throw new RuntimeException("Boom");
+            }
         };
 
         assertEquals("privateProperty", obj.privatePropertyValue());
-    }
 
+        // verify the setter override is not invoked.
+        obj.changePrivatePropertyValue("MyNewValue");
+        assertEquals("MyNewValue", obj.privatePropertyValue());
+    }
 
     static class MulTen extends Multiply {
         public MulTen(final int value) {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -468,6 +468,10 @@ public final class JsiiEngine implements JsiiCallbackHandler {
 
             // add all the methods in the current class
             for (Method method : klass.getDeclaredMethods()) {
+                if (Modifier.isPrivate(method.getModifiers())) {
+                    continue;
+                }
+
                 String methodName = method.getName();
 
                 // check if this is a property ("getXXX" or "setXXX", oh java!)

--- a/packages/jsii-kernel/lib/kernel.ts
+++ b/packages/jsii-kernel/lib/kernel.ts
@@ -619,8 +619,6 @@ export class Kernel {
                     });
                 }
             });
-        } else if (!methodInfo && Object.keys(obj).includes(methodName)) {
-            throw new Error('boom');
         } else {
             // sync method override (method info is not required)
             Object.defineProperty(obj, methodName, {

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -936,7 +936,6 @@ defineTest('overrides: skip overrides of private properties', async (test, sandb
     test.deepEqual(result.result, 'privateProperty');
 });
 
-
 // =================================================================================================
 
 const testNames: { [name: string]: boolean } = { };

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1181,6 +1181,29 @@
         }
       ]
     },
+    "jsii-calc.DoNotOverridePrivates": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DoNotOverridePrivates",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "privateMethodValue",
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "privatePropertyValue",
+          "returns": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "name": "DoNotOverridePrivates"
+    },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DoubleTrouble",
@@ -3230,5 +3253,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "ecDtx3DHVZi7UjyCDhGncg4jbSRaD536bUyh6YzAxlY="
+  "fingerprint": "eSNc0E/b0z3EKspPQoD/VEU1sfZLTkQJpTS8y7XqbJM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3297,5 +3297,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "eSNc0E/b0z3EKspPQoD/VEU1sfZLTkQJpTS8y7XqbJM="
+  "fingerprint": "IrPnQp841TiCOiG/Z2z18s0K8pxTwuMglW1UJ2t1zsM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1207,6 +1207,17 @@
       "kind": "class",
       "methods": [
         {
+          "name": "changePrivatePropertyValue",
+          "parameters": [
+            {
+              "name": "newValue",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ]
+        },
+        {
           "name": "privateMethodValue",
           "returns": {
             "primitive": "string"

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
@@ -1,0 +1,32 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(DoNotOverridePrivates), "jsii-calc.DoNotOverridePrivates", "[]")]
+    public class DoNotOverridePrivates : DeputyBase
+    {
+        public DoNotOverridePrivates(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected DoNotOverridePrivates(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected DoNotOverridePrivates(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod("privateMethodValue", "{\"primitive\":\"string\"}", "[]")]
+        public virtual string PrivateMethodValue()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+
+        [JsiiMethod("privatePropertyValue", "{\"primitive\":\"string\"}", "[]")]
+        public virtual string PrivatePropertyValue()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
@@ -17,6 +17,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        [JsiiMethod("changePrivatePropertyValue", null, "[{\"name\":\"newValue\",\"type\":{\"primitive\":\"string\"}}]")]
+        public virtual void ChangePrivatePropertyValue(string newValue)
+        {
+            InvokeInstanceVoidMethod(new object[]{newValue});
+        }
+
         [JsiiMethod("privateMethodValue", "{\"primitive\":\"string\"}", "[]")]
         public virtual string PrivateMethodValue()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -33,6 +33,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.DerivedClassHasNoProperties.Base": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base.class;
             case "jsii-calc.DerivedClassHasNoProperties.Derived": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived.class;
             case "jsii-calc.DerivedStruct": return software.amazon.jsii.tests.calculator.DerivedStruct.class;
+            case "jsii-calc.DoNotOverridePrivates": return software.amazon.jsii.tests.calculator.DoNotOverridePrivates.class;
             case "jsii-calc.DoubleTrouble": return software.amazon.jsii.tests.calculator.DoubleTrouble.class;
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
             case "jsii-calc.IFriendlier": return software.amazon.jsii.tests.calculator.IFriendlier.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -11,6 +11,10 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    public void changePrivatePropertyValue(final java.lang.String newValue) {
+        this.jsiiCall("changePrivatePropertyValue", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(newValue, "newValue is required")).toArray());
+    }
+
     public java.lang.String privateMethodValue() {
         return this.jsiiCall("privateMethodValue", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -1,0 +1,21 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoNotOverridePrivates")
+public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
+    protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public DoNotOverridePrivates() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public java.lang.String privateMethodValue() {
+        return this.jsiiCall("privateMethodValue", java.lang.String.class);
+    }
+
+    public java.lang.String privatePropertyValue() {
+        return this.jsiiCall("privatePropertyValue", java.lang.String.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1256,6 +1256,12 @@ DoNotOverridePrivates
 
 
 
+   .. py:method:: changePrivatePropertyValue(newValue)
+
+      :param newValue: 
+      :type newValue: string
+
+
    .. py:method:: privateMethodValue() -> string
 
       :rtype: string

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1195,6 +1195,44 @@ DerivedStruct (interface)
       :type: string[] or ``undefined`` *(abstract)*
 
 
+DoNotOverridePrivates
+^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DoNotOverridePrivates()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DoNotOverridePrivates;
+
+      .. code-tab:: javascript
+
+         const { DoNotOverridePrivates } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { DoNotOverridePrivates } from 'jsii-calc';
+
+
+
+
+   .. py:method:: privateMethodValue() -> string
+
+      :rtype: string
+
+
+   .. py:method:: privatePropertyValue() -> string
+
+      :rtype: string
+
+
 DoubleTrouble
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
jsii-kernel will ignore override requests for methods/properties that
resolve on the object but are not defined in the public API of the
type.

java runtime will not request overrides for methods/properties that
use "private" accessibility.

Fixes #244

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
