### PR TITLE
Add support for public properties defined in a private constructor

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -914,3 +914,11 @@ export class DoNotOverridePrivates {
         this.privateProperty = newValue;
     }
 }
+
+/**
+ * Class that implements interface properties automatically, but using a private constructor
+ */
+export class ClassWithPrivateConstructorAndAutomaticProperties implements IInterfaceWithProperties {
+    private constructor(public readonly readOnlyString: string, public readWriteString: string) {
+    }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1035,6 +1035,41 @@
         }
       ]
     },
+    "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "comment": "Class that implements interface properties automatically, but using a private constructor"
+      },
+      "fqn": "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.IInterfaceWithProperties"
+        }
+      ],
+      "kind": "class",
+      "name": "ClassWithPrivateConstructorAndAutomaticProperties",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "readOnlyString",
+          "overrides": {
+            "fqn": "jsii-calc.IInterfaceWithProperties"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "readWriteString",
+          "overrides": {
+            "fqn": "jsii-calc.IInterfaceWithProperties"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DefaultedConstructorArgument",
@@ -3297,5 +3332,5 @@
     }
   },
   "version": "0.7.6",
-  "fingerprint": "IrPnQp841TiCOiG/Z2z18s0K8pxTwuMglW1UJ2t1zsM="
+  "fingerprint": "eFasWxN7YC37iWdz+dDbEFTSQCzyangrqP5Nu02rzpw="
 }

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -4695,11 +4695,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4712,15 +4714,18 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4823,7 +4828,8 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4833,6 +4839,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4845,17 +4852,20 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4872,6 +4882,7 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4944,7 +4955,8 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4954,6 +4966,7 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -5059,6 +5072,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
This change is incomplete; the .NET generator doesn't know how to
deal with a private ("missing") constructor, so it throws a
NullReferenceException.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
