### PR TITLE
fix(jsii): use default jsx compiler options

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -16,8 +16,6 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
     experimentalDecorators: true,
     inlineSourceMap: true,
     inlineSources: true,
-    jsx: ts.JsxEmit.React,
-    jsxFactory: 'jsx.create',
     lib: ['lib.es2016.d.ts', 'lib.es2017.object.d.ts', 'lib.es2017.string.d.ts'],
     module: ts.ModuleKind.CommonJS,
     noEmitOnError: true,


### PR DESCRIPTION
Revert to use default jsx compiler options as there is no
need to be opinionated about it. This is a left over from
our desire to support JSX in the CDK, which is now being
removed (awslabs/aws-cdk#830).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
