### PR TITLE
fix(jsii): use base interfaces for 'datatype' property

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -922,3 +922,16 @@ export class ClassWithPrivateConstructorAndAutomaticProperties implements IInter
     private constructor(public readonly readOnlyString: string, public readWriteString: string) {
     }
 }
+
+export interface IInterfaceWithMethods {
+    readonly value: string;
+    doThings(): void;
+}
+
+/**
+ * Even though this interface has only properties, it is disqualified from being a datatype
+ * because it inherits from an interface that is not a datatype.
+ */
+export interface IInterfaceThatShouldNotBeADataType extends IInterfaceWithMethods {
+    readonly otherValue: string;
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1429,6 +1429,52 @@
       "kind": "interface",
       "name": "IFriendlyRandomGenerator"
     },
+    "jsii-calc.IInterfaceThatShouldNotBeADataType": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "comment": "Even though this interface has only properties, it is disqualified from being a datatype\nbecause it inherits from an interface that is not a datatype."
+      },
+      "fqn": "jsii-calc.IInterfaceThatShouldNotBeADataType",
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.IInterfaceWithMethods"
+        }
+      ],
+      "kind": "interface",
+      "name": "IInterfaceThatShouldNotBeADataType",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "otherValue",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.IInterfaceWithMethods": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IInterfaceWithMethods",
+      "kind": "interface",
+      "methods": [
+        {
+          "abstract": true,
+          "name": "doThings"
+        }
+      ],
+      "name": "IInterfaceWithMethods",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "value",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -3332,5 +3378,5 @@
     }
   },
   "version": "0.7.7",
-  "fingerprint": "SMX3FQtN8x0lUjxLt3hL50eC+4BhUchNcGPOAxkO9Xw="
+  "fingerprint": "bxhDOTLZBrkP11/RKcB3NDECWyzz3uPDRFgQXpHtrc0="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1429,6 +1429,52 @@
       "kind": "interface",
       "name": "IFriendlyRandomGenerator"
     },
+    "jsii-calc.IInterfaceThatShouldNotBeADataType": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "comment": "Even though this interface has only properties, it is disqualified from being a datatype\nbecause it inherits from an interface that is not a datatype."
+      },
+      "fqn": "jsii-calc.IInterfaceThatShouldNotBeADataType",
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.IInterfaceWithMethods"
+        }
+      ],
+      "kind": "interface",
+      "name": "IInterfaceThatShouldNotBeADataType",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "otherValue",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.IInterfaceWithMethods": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IInterfaceWithMethods",
+      "kind": "interface",
+      "methods": [
+        {
+          "abstract": true,
+          "name": "doThings"
+        }
+      ],
+      "name": "IInterfaceWithMethods",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "value",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -3332,5 +3378,5 @@
     }
   },
   "version": "0.7.7",
-  "fingerprint": "SMX3FQtN8x0lUjxLt3hL50eC+4BhUchNcGPOAxkO9Xw="
+  "fingerprint": "bxhDOTLZBrkP11/RKcB3NDECWyzz3uPDRFgQXpHtrc0="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
@@ -1,0 +1,18 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>
+    /// Even though this interface has only properties, it is disqualified from being a datatype
+    /// because it inherits from an interface that is not a datatype.
+    /// </summary>
+    [JsiiInterface(typeof(IIInterfaceThatShouldNotBeADataType), "jsii-calc.IInterfaceThatShouldNotBeADataType")]
+    public interface IIInterfaceThatShouldNotBeADataType : IIInterfaceWithMethods
+    {
+        [JsiiProperty("otherValue", "{\"primitive\":\"string\"}")]
+        string OtherValue
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithMethods.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithMethods.cs
@@ -1,0 +1,17 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(typeof(IIInterfaceWithMethods), "jsii-calc.IInterfaceWithMethods")]
+    public interface IIInterfaceWithMethods
+    {
+        [JsiiProperty("value", "{\"primitive\":\"string\"}")]
+        string Value
+        {
+            get;
+        }
+
+        [JsiiMethod("doThings", null, "[]")]
+        void DoThings();
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
@@ -1,0 +1,34 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>
+    /// Even though this interface has only properties, it is disqualified from being a datatype
+    /// because it inherits from an interface that is not a datatype.
+    /// </summary>
+    [JsiiTypeProxy(typeof(IIInterfaceThatShouldNotBeADataType), "jsii-calc.IInterfaceThatShouldNotBeADataType")]
+    internal sealed class IInterfaceThatShouldNotBeADataTypeProxy : DeputyBase, IIInterfaceThatShouldNotBeADataType
+    {
+        private IInterfaceThatShouldNotBeADataTypeProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("otherValue", "{\"primitive\":\"string\"}")]
+        public string OtherValue
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiProperty("value", "{\"primitive\":\"string\"}")]
+        public string Value
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiMethod("doThings", null, "[]")]
+        public void DoThings()
+        {
+            InvokeInstanceVoidMethod(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
@@ -1,0 +1,24 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(typeof(IIInterfaceWithMethods), "jsii-calc.IInterfaceWithMethods")]
+    internal sealed class IInterfaceWithMethodsProxy : DeputyBase, IIInterfaceWithMethods
+    {
+        private IInterfaceWithMethodsProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("value", "{\"primitive\":\"string\"}")]
+        public string Value
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        [JsiiMethod("doThings", null, "[]")]
+        public void DoThings()
+        {
+            InvokeInstanceVoidMethod(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -40,6 +40,8 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
             case "jsii-calc.IFriendlier": return software.amazon.jsii.tests.calculator.IFriendlier.class;
             case "jsii-calc.IFriendlyRandomGenerator": return software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class;
+            case "jsii-calc.IInterfaceThatShouldNotBeADataType": return software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType.class;
+            case "jsii-calc.IInterfaceWithMethods": return software.amazon.jsii.tests.calculator.IInterfaceWithMethods.class;
             case "jsii-calc.IInterfaceWithProperties": return software.amazon.jsii.tests.calculator.IInterfaceWithProperties.class;
             case "jsii-calc.IInterfaceWithPropertiesExtension": return software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension.class;
             case "jsii-calc.IRandomNumberGenerator": return software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -1,0 +1,34 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Even though this interface has only properties, it is disqualified from being a datatype
+ * because it inherits from an interface that is not a datatype.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IInterfaceWithMethods {
+    java.lang.String getOtherValue();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getOtherValue() {
+            return this.jsiiGet("otherValue", java.lang.String.class);
+        }
+
+        @Override
+        public java.lang.String getValue() {
+            return this.jsiiGet("value", java.lang.String.class);
+        }
+
+        @Override
+        public void doThings() {
+            this.jsiiCall("doThings", Void.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -1,0 +1,26 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializable {
+    java.lang.String getValue();
+    void doThings();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithMethods {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getValue() {
+            return this.jsiiGet("value", java.lang.String.class);
+        }
+
+        @Override
+        public void doThings() {
+            this.jsiiCall("doThings", Void.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1547,6 +1547,97 @@ IFriendlyRandomGenerator (interface)
       :abstract: Yes
 
 
+IInterfaceThatShouldNotBeADataType (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IInterfaceThatShouldNotBeADataType
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType;
+
+      .. code-tab:: javascript
+
+         // IInterfaceThatShouldNotBeADataType is an interface
+
+      .. code-tab:: typescript
+
+         import { IInterfaceThatShouldNotBeADataType } from 'jsii-calc';
+
+
+
+   Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+
+
+   :extends: :py:class:`~jsii-calc.IInterfaceWithMethods`\ 
+
+
+   .. py:attribute:: otherValue
+
+      :type: string *(readonly)* *(abstract)*
+
+
+   .. py:method:: doThings()
+
+      *Inherited from* :py:meth:`jsii-calc.IInterfaceWithMethods <jsii-calc.IInterfaceWithMethods.doThings>`
+
+      :abstract: Yes
+
+
+   .. py:attribute:: value
+
+      *Inherited from* :py:attr:`jsii-calc.IInterfaceWithMethods <jsii-calc.IInterfaceWithMethods.value>`
+
+      :type: string *(readonly)* *(abstract)*
+
+
+IInterfaceWithMethods (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IInterfaceWithMethods
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IInterfaceWithMethods;
+
+      .. code-tab:: javascript
+
+         // IInterfaceWithMethods is an interface
+
+      .. code-tab:: typescript
+
+         import { IInterfaceWithMethods } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: value
+
+      :type: string *(readonly)* *(abstract)*
+
+
+   .. py:method:: doThings()
+
+      :abstract: Yes
+
+
 IInterfaceWithProperties (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
If an interface inherits from a non-datatype interface, it should no
longer be classified as a datatype interface itself.

Making this change requires that information about the base classes
has already been determined, so I introduced an ordering mechanism
for 'deferred's.

Fixes #264.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
