### PR TITLE
fix(dotnet/runtime): Incorrect callback response format

### DIFF
--- a/fetch-dotnet-snk.sh
+++ b/fetch-dotnet-snk.sh
@@ -11,7 +11,7 @@ function echo_usage() {
     echo -e "\tDOTNET_STRONG_NAME_SECRET_ID=<The name (i.e. production/my/key) or ARN of the secret containing the .snk file.>"
 }
 
-if [ -z ${DOTNET_STRONG_NAME_ENABLED:-} ]; then
+if [ -z "${DOTNET_STRONG_NAME_ENABLED:-}" ]; then
     echo "Environment variable DOTNET_STRONG_NAME_ENABLED is not set. Skipping strong-name signing."
     exit 0
 fi
@@ -21,19 +21,19 @@ echo "Retrieving SNK..."
 apt update -y
 apt install jq -y
 
-if [ -z ${DOTNET_STRONG_NAME_ROLE_ARN:-} ]; then
+if [ -z "${DOTNET_STRONG_NAME_ROLE_ARN:-}" ]; then
     echo "Strong name signing is enabled, but DOTNET_STRONG_NAME_ROLE_ARN is not set."
     echo_usage
     exit 1
 fi
 
-if [ -z ${DOTNET_STRONG_NAME_SECRET_REGION:-}]; then
+if [ -z "${DOTNET_STRONG_NAME_SECRET_REGION:-}" ]; then
     echo "Strong name signing is enabled, but DOTNET_STRONG_NAME_SECRET_REGION is not set."
     echo_usage
     exit 1
 fi
 
-if [ -z ${DOTNET_STRONG_NAME_SECRET_ID:-} ]; then
+if [ -z "${DOTNET_STRONG_NAME_SECRET_ID:-}" ]; then
     echo "Strong name signing is enabled, but DOTNET_STRONG_NAME_SECRET_ID is not set."
     echo_usage
     exit 1

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Request/CompleteRequest.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Request/CompleteRequest.cs
@@ -19,7 +19,7 @@ namespace Amazon.JSII.JsonModel.Api.Request
         [JsonProperty("cbid")]
         public string CallbackId { get; }
 
-        [JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("err", NullValueHandling = NullValueHandling.Ignore)]
         public string Error { get; }
 
         [JsonProperty("result", NullValueHandling = NullValueHandling.Ignore)]

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -462,8 +462,8 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         {
             AsyncVirtualMethodsChild obj = new AsyncVirtualMethodsChild();
 
-            RuntimeException exception = Assert.Throws<RuntimeException>(() => obj.CallMe());
-            Assert.Equal("Thrown by native code", exception.Message);
+            JsiiException exception = Assert.Throws<JsiiException>(() => obj.CallMe());
+            Assert.Contains("Thrown by native code", exception.Message);
         }
 
         class SyncVirtualMethodsChild_Set_CallsSuper : SyncVirtualMethods
@@ -531,8 +531,8 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         {
             SyncVirtualMethodsChild_Throws so = new SyncVirtualMethodsChild_Throws();
 
-            RuntimeException exception = Assert.Throws<RuntimeException>(() => so.RetrieveValueOfTheProperty());
-            Assert.Equal("Oh no, this is bad", exception.Message);
+            JsiiException exception = Assert.Throws<JsiiException>(() => so.RetrieveValueOfTheProperty());
+            Assert.Contains("Oh no, this is bad", exception.Message);
         }
 
         [Fact(DisplayName = Prefix + nameof(PropertyOverrides_Set_CallsSuper))]
@@ -549,8 +549,8 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         {
             SyncVirtualMethodsChild_Throws so = new SyncVirtualMethodsChild_Throws();
 
-            RuntimeException exception = Assert.Throws<RuntimeException>(() => so.ModifyValueOfTheProperty("Hii"));
-            Assert.Equal("Exception from overloaded setter", exception.Message);
+            JsiiException exception = Assert.Throws<JsiiException>(() => so.ModifyValueOfTheProperty("Hii"));
+            Assert.Contains("Exception from overloaded setter", exception.Message);
         }
 
         [Fact(DisplayName = Prefix + nameof(PropertyOverrides_Interfaces))]

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
@@ -29,14 +29,13 @@ namespace Amazon.JSII.Runtime
             }
             catch (TargetInvocationException e)
             {
-                throw e.InnerException;
-            }
-            catch (TargetParameterCountException)
-            {
-                throw;
+                // An exception was thrown by the method being invoked
+                error = e.InnerException.ToString();
+                return null;
             }
             catch (Exception e)
             {
+                // An exception was thrown while preparing the request or processing the result
                 error = e.ToString();
                 return null;
             }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
@@ -251,7 +251,7 @@ namespace Amazon.JSII.Runtime.Deputy
         )
         {
             IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IClient client = serviceProvider.GetRequiredService<IClient>(); ;
+            IClient client = serviceProvider.GetRequiredService<IClient>();
             IJsiiToFrameworkConverter converter = serviceProvider.GetRequiredService<IJsiiToFrameworkConverter>();
             IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
 


### PR DESCRIPTION
The response for a callback completion that resulted in an error should use the `err` field
name and not the `error` field name as was initially done. Additionally, the program flow
did not propagate all errors back to the `jsii-kernel`, causing false-pass on the compliance
test suite, as expectations were incorrectly set up to expect `RuntimeException` instead
of `JsiiException`.

Fixes #285