### PR TITLE
fix(runtime/dotnet): Correct a number of type mappings

### DIFF
--- a/packages/jsii-calc-lib/lib/index.ts
+++ b/packages/jsii-calc-lib/lib/index.ts
@@ -7,20 +7,27 @@ export abstract class Value extends base.Base {
     /**
      * The value.
      */
-    abstract readonly value: number
+    public abstract readonly value: number;
 
     /**
      * String representation of the value.
      */
-    toString() {
+    public toString() {
         return this.value.toString();
     }
 }
 
 /**
+ * The general contract for a concrete number.
+ */
+export interface IDoublable {
+    readonly doubleValue: number;
+}
+
+/**
  * Represents a concrete number.
  */
-export class Number extends Value {
+export class Number extends Value implements IDoublable {
     /**
      * Creates a Number object.
      * @param value The number.
@@ -41,7 +48,7 @@ export class Number extends Value {
  * Represents an operation on values.
  */
 export abstract class Operation extends Value {
-    abstract toString(): string
+    public abstract toString(): string;
 }
 
 /**

--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -92,6 +92,25 @@
       ],
       "name": "EnumFromScopedModule"
     },
+    "@scope/jsii-calc-lib.IDoublable": {
+      "assembly": "@scope/jsii-calc-lib",
+      "docs": {
+        "comment": "The general contract for a concrete number."
+      },
+      "fqn": "@scope/jsii-calc-lib.IDoublable",
+      "kind": "interface",
+      "name": "IDoublable",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "doubleValue",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
     "@scope/jsii-calc-lib.IFriendly": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
@@ -184,6 +203,11 @@
           }
         ]
       },
+      "interfaces": [
+        {
+          "fqn": "@scope/jsii-calc-lib.IDoublable"
+        }
+      ],
       "kind": "class",
       "name": "Number",
       "properties": [
@@ -193,6 +217,9 @@
           },
           "immutable": true,
           "name": "doubleValue",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IDoublable"
+          },
           "type": {
             "primitive": "number"
           }
@@ -324,5 +351,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "16sTfW7oHGAWfPOj50gWvXsI1REjbNbpk7VUpG1JVVI="
+  "fingerprint": "HzcyHys0b9gFmP4dogeIJmGE6GVtrSo/P0S54Vd/X8U="
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1,5 +1,5 @@
 // tslint:disable
-import { Value, Number, IFriendly, MyFirstStruct, StructWithOnlyOptionals, EnumFromScopedModule } from '@scope/jsii-calc-lib';
+import { Value, Number, IFriendly, IDoublable, MyFirstStruct, StructWithOnlyOptionals, EnumFromScopedModule } from '@scope/jsii-calc-lib';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -574,7 +574,7 @@ export class AllowedMethodNames {
 }
 
 export interface IReturnsNumber {
-    obtainNumber(): Number;
+    obtainNumber(): IDoublable;
     readonly numberProp: Number;
 }
 

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -436,7 +436,7 @@
           "type": {
             "collection": {
               "elementtype": {
-                "primitive": "number"
+                "fqn": "@scope/jsii-calc-lib.Number"
               },
               "kind": "map"
             }
@@ -486,6 +486,9 @@
                     },
                     {
                       "primitive": "number"
+                    },
+                    {
+                      "fqn": "@scope/jsii-calc-lib.Number"
                     }
                   ]
                 }
@@ -507,6 +510,9 @@
                 },
                 {
                   "fqn": "jsii-calc.Multiply"
+                },
+                {
+                  "fqn": "@scope/jsii-calc-lib.Number"
                 }
               ]
             }
@@ -1559,7 +1565,7 @@
           "abstract": true,
           "name": "obtainNumber",
           "returns": {
-            "primitive": "number"
+            "fqn": "@scope/jsii-calc-lib.IDoublable"
           }
         }
       ],
@@ -1570,7 +1576,7 @@
           "immutable": true,
           "name": "numberProp",
           "type": {
-            "primitive": "number"
+            "fqn": "@scope/jsii-calc-lib.Number"
           }
         }
       ]
@@ -3401,5 +3407,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "fhzPkiQLwsWAnEdA5+YEotaWom2Av1au0q2FzpexXaQ="
+  "fingerprint": "jHSXTzCSZbwYMvLKpeZB6SE8hNgYgt9/2JF1ihM41SI="
 }

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -83,10 +83,10 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             Assert.Equal("World", types.ArrayProperty[1]);
 
             // map
-            IDictionary<string, double> map = new Dictionary<string, double>();
-            map["Foo"] = 123;
+            IDictionary<string, Number> map = new Dictionary<string, Number>();
+            map["Foo"] = new Number(123);
             types.MapProperty = map;
-            Assert.Equal((double) 123, types.MapProperty["Foo"]);
+            Assert.Equal((double) 123, types.MapProperty["Foo"].Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(DynamicTypes))]
@@ -816,6 +816,43 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             obj.ReadWriteString = "Hello";
 
             Assert.Equal("Hello", obj.ReadOnlyString);
+        }
+
+        [Fact(DisplayName = Prefix + nameof(TestReturnInterfaceFromOverride))]
+        public void TestReturnInterfaceFromOverride()
+        {
+            var n = 1337;
+            var obj = new OverrideReturnsObject();
+            var arg = new NumberReturner(n);
+            Assert.Equal(4 * n, obj.Test(arg));
+        }
+
+        class NumberReturner : DeputyBase, IIReturnsNumber
+        {
+            public NumberReturner(double number)
+            {
+                NumberProp = new Number(number);
+            }
+
+            [JsiiProperty("numberProp", "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}", true)]
+            public Number NumberProp { get; }
+
+            [JsiiMethod("obtainNumber", "{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}", "[]",true)]
+            public IIDoublable ObtainNumber()
+            {
+                return new Doublable(this.NumberProp);
+            }
+
+            class Doublable : DeputyBase, IIDoublable
+            {
+                public Doublable(Number number)
+                {
+                    this.DoubleValue = number.DoubleValue;
+                }
+
+                [JsiiProperty("doubleValue","{\"primitive\":\"number\"}",true)]
+                public Double DoubleValue { get; }
+            }
         }
 
         class MulTen : Multiply

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
@@ -18,9 +18,9 @@ namespace Amazon.JSII.Runtime
                 CallbackResult frameworkResult = callback.InvokeCallbackCore(referenceMap);
 
                 converter.TryConvert(
-                    frameworkResult.Type,
+                    frameworkResult?.Type ?? new TypeReference(primitive: PrimitiveType.Any),
                     referenceMap,
-                    frameworkResult.Value,
+                    frameworkResult?.Value,
                     out object result
                 );
 
@@ -125,7 +125,7 @@ namespace Amazon.JSII.Runtime
     {
         public CallbackResult(TypeReference type, object value)
         {
-            Type = type ?? new TypeReference(primitive: PrimitiveType.Any);
+            Type = type;
             Value = value;
         }
 

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -251,6 +251,10 @@ namespace Amazon.JSII.Runtime.Services.Converters
                     return false;
                 }
 
+                if (convertedElement != null && !(convertedElement is String) && !convertedElement.GetType().IsPrimitive)
+                {
+                    convertedElement = JObject.FromObject(convertedElement);
+                }
                 resultObject.Add(new JProperty(key, convertedElement));
             }
 

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -109,8 +109,8 @@ public class ComplianceTest {
         assertEquals("World", types.getArrayProperty().get(1));
 
         // map
-        Map<String, java.lang.Number> map = new HashMap<>();
-        map.put("Foo", 123);
+        Map<String, Number> map = new HashMap<>();
+        map.put("Foo", new Number(123));
         types.setMapProperty(map);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -92,6 +92,25 @@
       ],
       "name": "EnumFromScopedModule"
     },
+    "@scope/jsii-calc-lib.IDoublable": {
+      "assembly": "@scope/jsii-calc-lib",
+      "docs": {
+        "comment": "The general contract for a concrete number."
+      },
+      "fqn": "@scope/jsii-calc-lib.IDoublable",
+      "kind": "interface",
+      "name": "IDoublable",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "doubleValue",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
     "@scope/jsii-calc-lib.IFriendly": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
@@ -184,6 +203,11 @@
           }
         ]
       },
+      "interfaces": [
+        {
+          "fqn": "@scope/jsii-calc-lib.IDoublable"
+        }
+      ],
       "kind": "class",
       "name": "Number",
       "properties": [
@@ -193,6 +217,9 @@
           },
           "immutable": true,
           "name": "doubleValue",
+          "overrides": {
+            "fqn": "@scope/jsii-calc-lib.IDoublable"
+          },
           "type": {
             "primitive": "number"
           }
@@ -324,5 +351,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "16sTfW7oHGAWfPOj50gWvXsI1REjbNbpk7VUpG1JVVI="
+  "fingerprint": "HzcyHys0b9gFmP4dogeIJmGE6GVtrSo/P0S54Vd/X8U="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
@@ -1,0 +1,19 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
+{
+    /// <summary>The general contract for a concrete number.</summary>
+    [JsiiTypeProxy(typeof(IIDoublable), "@scope/jsii-calc-lib.IDoublable")]
+    internal sealed class IDoublableProxy : DeputyBase, IIDoublable
+    {
+        private IDoublableProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("doubleValue", "{\"primitive\":\"number\"}")]
+        public double DoubleValue
+        {
+            get => GetInstanceProperty<double>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIDoublable.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIDoublable.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
+{
+    /// <summary>The general contract for a concrete number.</summary>
+    [JsiiInterface(typeof(IIDoublable), "@scope/jsii-calc-lib.IDoublable")]
+    public interface IIDoublable
+    {
+        [JsiiProperty("doubleValue", "{\"primitive\":\"number\"}")]
+        double DoubleValue
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Represents a concrete number.</summary>
     [JsiiClass(typeof(Number), "@scope/jsii-calc-lib.Number", "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
-    public class Number : Value_
+    public class Number : Value_, IIDoublable
     {
         public Number(double value): base(new DeputyProps(new object[]{value}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
@@ -19,6 +19,7 @@ public final class $Module extends JsiiModule {
     protected Class<?> resolveClass(final String fqn) throws ClassNotFoundException {
         switch (fqn) {
             case "@scope/jsii-calc-lib.EnumFromScopedModule": return software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class;
+            case "@scope/jsii-calc-lib.IDoublable": return software.amazon.jsii.tests.calculator.lib.IDoublable.class;
             case "@scope/jsii-calc-lib.IFriendly": return software.amazon.jsii.tests.calculator.lib.IFriendly.class;
             case "@scope/jsii-calc-lib.MyFirstStruct": return software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class;
             case "@scope/jsii-calc-lib.Number": return software.amazon.jsii.tests.calculator.lib.Number.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -1,0 +1,23 @@
+package software.amazon.jsii.tests.calculator.lib;
+
+/**
+ * The general contract for a concrete number.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
+    java.lang.Number getDoubleValue();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IDoublable {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.Number getDoubleValue() {
+            return this.jsiiGet("doubleValue", java.lang.Number.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -5,7 +5,7 @@ package software.amazon.jsii.tests.calculator.lib;
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Number")
-public class Number extends software.amazon.jsii.tests.calculator.lib.Value {
+public class Number extends software.amazon.jsii.tests.calculator.lib.Value implements software.amazon.jsii.tests.calculator.lib.IDoublable {
     protected Number(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
@@ -21,6 +21,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value {
     /**
      * The number multiplied by 2.
      */
+    @Override
     public java.lang.Number getDoubleValue() {
         return this.jsiiGet("doubleValue", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -158,6 +158,43 @@ EnumFromScopedModule (enum)
    .. py:data:: Value2
 
 
+IDoublable (interface)
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IDoublable
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.lib.IDoublable;
+
+      .. code-tab:: javascript
+
+         // IDoublable is an interface
+
+      .. code-tab:: typescript
+
+         import { IDoublable } from '@scope/jsii-calc-lib';
+
+
+
+   The general contract for a concrete number.
+
+
+
+
+   .. py:attribute:: doubleValue
+
+      :type: number *(readonly)* *(abstract)*
+
+
 IFriendly (interface)
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -283,10 +320,13 @@ Number
 
 
    :extends: :py:class:`~@scope/jsii-calc-lib.Value`\ 
+   :implements: :py:class:`~@scope/jsii-calc-lib.IDoublable`\ 
    :param value: The number.
    :type value: number
 
    .. py:attribute:: doubleValue
+
+      *Implements* :py:meth:`@scope/jsii-calc-lib.IDoublable.doubleValue`
 
       The number multiplied by 2.
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -436,7 +436,7 @@
           "type": {
             "collection": {
               "elementtype": {
-                "primitive": "number"
+                "fqn": "@scope/jsii-calc-lib.Number"
               },
               "kind": "map"
             }
@@ -486,6 +486,9 @@
                     },
                     {
                       "primitive": "number"
+                    },
+                    {
+                      "fqn": "@scope/jsii-calc-lib.Number"
                     }
                   ]
                 }
@@ -507,6 +510,9 @@
                 },
                 {
                   "fqn": "jsii-calc.Multiply"
+                },
+                {
+                  "fqn": "@scope/jsii-calc-lib.Number"
                 }
               ]
             }
@@ -1559,7 +1565,7 @@
           "abstract": true,
           "name": "obtainNumber",
           "returns": {
-            "primitive": "number"
+            "fqn": "@scope/jsii-calc-lib.IDoublable"
           }
         }
       ],
@@ -1570,7 +1576,7 @@
           "immutable": true,
           "name": "numberProp",
           "type": {
-            "primitive": "number"
+            "fqn": "@scope/jsii-calc-lib.Number"
           }
         }
       ]
@@ -3401,5 +3407,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "fhzPkiQLwsWAnEdA5+YEotaWom2Av1au0q2FzpexXaQ="
+  "fingerprint": "jHSXTzCSZbwYMvLKpeZB6SE8hNgYgt9/2JF1ihM41SI="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
@@ -1,5 +1,6 @@
 using Amazon.JSII.Runtime.Deputy;
 using Amazon.JSII.Tests.CalculatorNamespace.composition;
+using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -80,10 +81,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("mapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"number\"}}}")]
-        public virtual IDictionary<string, double> MapProperty
+        [JsiiProperty("mapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Number\"}}}")]
+        public virtual IDictionary<string, Number> MapProperty
         {
-            get => GetInstanceProperty<IDictionary<string, double>>();
+            get => GetInstanceProperty<IDictionary<string, Number>>();
             set => SetInstanceProperty(value);
         }
 
@@ -108,14 +109,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("unionMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"}]}}}}")]
+        [JsiiProperty("unionMapProperty", "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"@scope/jsii-calc-lib.Number\"}]}}}}")]
         public virtual IDictionary<string, object> UnionMapProperty
         {
             get => GetInstanceProperty<IDictionary<string, object>>();
             set => SetInstanceProperty(value);
         }
 
-        [JsiiProperty("unionProperty", "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.Multiply\"}]}}")]
+        [JsiiProperty("unionProperty", "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.Multiply\"},{\"fqn\":\"@scope/jsii-calc-lib.Number\"}]}}")]
         public virtual object UnionProperty
         {
             get => GetInstanceProperty<object>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
@@ -1,17 +1,18 @@
 using Amazon.JSII.Runtime.Deputy;
+using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     [JsiiInterface(typeof(IIReturnsNumber), "jsii-calc.IReturnsNumber")]
     public interface IIReturnsNumber
     {
-        [JsiiProperty("numberProp", "{\"primitive\":\"number\"}")]
-        double NumberProp
+        [JsiiProperty("numberProp", "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
+        Number NumberProp
         {
             get;
         }
 
-        [JsiiMethod("obtainNumber", "{\"primitive\":\"number\"}", "[]")]
-        double ObtainNumber();
+        [JsiiMethod("obtainNumber", "{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}", "[]")]
+        IIDoublable ObtainNumber();
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
@@ -1,4 +1,5 @@
 using Amazon.JSII.Runtime.Deputy;
+using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -9,16 +10,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiProperty("numberProp", "{\"primitive\":\"number\"}")]
-        public double NumberProp
+        [JsiiProperty("numberProp", "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
+        public Number NumberProp
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<Number>();
         }
 
-        [JsiiMethod("obtainNumber", "{\"primitive\":\"number\"}", "[]")]
-        public double ObtainNumber()
+        [JsiiMethod("obtainNumber", "{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}", "[]")]
+        public IIDoublable ObtainNumber()
         {
-            return InvokeInstanceMethod<double>(new object[]{});
+            return InvokeInstanceMethod<IIDoublable>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -79,11 +79,11 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
         this.jsiiSet("jsonProperty", java.util.Objects.requireNonNull(value, "jsonProperty is required"));
     }
 
-    public java.util.Map<java.lang.String, java.lang.Number> getMapProperty() {
+    public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> getMapProperty() {
         return this.jsiiGet("mapProperty", java.util.Map.class);
     }
 
-    public void setMapProperty(final java.util.Map<java.lang.String, java.lang.Number> value) {
+    public void setMapProperty(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> value) {
         this.jsiiSet("mapProperty", java.util.Objects.requireNonNull(value, "mapProperty is required"));
     }
 
@@ -132,6 +132,10 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
     }
 
     public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
+        this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
+    }
+
+    public void setUnionProperty(final software.amazon.jsii.tests.calculator.lib.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -2,8 +2,8 @@ package software.amazon.jsii.tests.calculator;
 
 @javax.annotation.Generated(value = "jsii-pacmak")
 public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
-    java.lang.Number getNumberProp();
-    java.lang.Number obtainNumber();
+    software.amazon.jsii.tests.calculator.lib.Number getNumberProp();
+    software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -14,13 +14,13 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
         }
 
         @Override
-        public java.lang.Number getNumberProp() {
-            return this.jsiiGet("numberProp", java.lang.Number.class);
+        public software.amazon.jsii.tests.calculator.lib.Number getNumberProp() {
+            return this.jsiiGet("numberProp", software.amazon.jsii.tests.calculator.lib.Number.class);
         }
 
         @Override
-        public java.lang.Number obtainNumber() {
-            return this.jsiiCall("obtainNumber", java.lang.Number.class);
+        public software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber() {
+            return this.jsiiCall("obtainNumber", software.amazon.jsii.tests.calculator.lib.IDoublable.class);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -434,7 +434,7 @@ AllTypes
 
    .. py:attribute:: mapProperty
 
-      :type: string => number
+      :type: string => :py:class:`@scope/jsii-calc-lib.Number`\ 
 
 
    .. py:attribute:: numberProperty
@@ -454,12 +454,12 @@ AllTypes
 
    .. py:attribute:: unionMapProperty
 
-      :type: string => (string or number)
+      :type: string => (string or number or :py:class:`@scope/jsii-calc-lib.Number`\ )
 
 
    .. py:attribute:: unionProperty
 
-      :type: string or number or :py:class:`~jsii-calc.Multiply`\ 
+      :type: string or number or :py:class:`~jsii-calc.Multiply`\  or :py:class:`@scope/jsii-calc-lib.Number`\ 
 
 
    .. py:attribute:: unknownArrayProperty
@@ -1761,12 +1761,12 @@ IReturnsNumber (interface)
 
    .. py:attribute:: numberProp
 
-      :type: number *(readonly)* *(abstract)*
+      :type: :py:class:`@scope/jsii-calc-lib.Number`\  *(readonly)* *(abstract)*
 
 
-   .. py:method:: obtainNumber() -> number
+   .. py:method:: obtainNumber() -> @scope/jsii-calc-lib.IDoublable
 
-      :rtype: number
+      :rtype: :py:class:`@scope/jsii-calc-lib.IDoublable`\ 
       :abstract: Yes
 
 


### PR DESCRIPTION
The `jsii` compiler incorrectly mapped types homonym with a standard
type (`String`, `Number`, ...) to the primitive type on usage sites.
This commit corrects this behavior and adjusts the C# tests accordingly.

Additionally, when the return type of a callback was an interface, the
C# runtime was unable to determine the correct JSII type to use, despite
it has the information on the type of the callback method available. The
resolution behavior has also been fixes, as well as a couple of other
glitches that became apparent as a result of the `Number` type starting
to be correctly represented as the `@scope/jsii-calc-lib.Number` type.

Fixes #290
Fixes awslabs/aws-cdk#1027