### PR TITLE
fix(docs): improve docs rendering

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -241,7 +241,7 @@ export class RuntimeTypeChecking {
         arg1; arg2; arg3;
     }
 
-    public methodWithDefaultedArguments(arg1: number = 2, arg2: string, arg3: Date = new Date()) {
+    public methodWithDefaultedArguments(arg1: number = 2, arg2?: string, arg3: Date = new Date()) {
         arg1; arg2; arg3;
     }
 
@@ -258,7 +258,7 @@ export class OptionalConstructorArgument {
 
 export class DefaultedConstructorArgument {
     public constructor(public readonly arg1: number = 2,
-                       public readonly arg2: string,
+                       public readonly arg2?: string,
                        public readonly arg3: Date = new Date()) {}
 }
 
@@ -994,3 +994,65 @@ export interface NullShouldBeTreatedAsUndefinedData {
     arrayWithThreeElementsAndUndefinedAsSecondArgument: any[];
 }
 
+/**
+ * jsii#298: show default values in sphinx documentation, and respect newlines.
+ **/
+export interface LoadBalancedFargateServiceProps {
+    /**
+     * The number of cpu units used by the task.
+     * Valid values, which determines your range of valid values for the memory parameter:
+     * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+     * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+     * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+     * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+     * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+     *
+     * This default is set in the underlying FargateTaskDefinition construct.
+     *
+     * @default 256
+     */
+    cpu?: string;
+  
+    /**
+     * The amount (in MiB) of memory used by the task.
+     *
+     * This field is required and you must use one of the following values, which determines your range of valid values
+     * for the cpu parameter:
+     *
+     * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+     *
+     * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+     *
+     * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+     *
+     * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+     *
+     * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+     *
+     * This default is set in the underlying FargateTaskDefinition construct.
+     *
+     * @default 512
+     */
+    memoryMiB?: string;
+  
+    /**
+     * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+     *
+     * @default 80
+     */
+    containerPort?: number;
+  
+    /**
+     * Determines whether the Application Load Balancer will be internet-facing
+     *
+     * @default true
+     */
+    publicLoadBalancer?: boolean;
+  
+    /**
+     * Determines whether your Fargate Service will be assigned a public IP address.
+     *
+     * @default false
+     */
+    publicTasks?: boolean;
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1114,6 +1114,7 @@
           {
             "name": "arg2",
             "type": {
+              "optional": true,
               "primitive": "string"
             }
           },
@@ -1138,16 +1139,17 @@
         },
         {
           "immutable": true,
-          "name": "arg2",
+          "name": "arg3",
           "type": {
-            "primitive": "string"
+            "primitive": "date"
           }
         },
         {
           "immutable": true,
-          "name": "arg3",
+          "name": "arg2",
           "type": {
-            "primitive": "date"
+            "optional": true,
+            "primitive": "string"
           }
         }
       ]
@@ -1996,6 +1998,78 @@
         }
       ]
     },
+    "jsii-calc.LoadBalancedFargateServiceProps": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "comment": "jsii#298: show default values in sphinx documentation, and respect newlines."
+      },
+      "fqn": "jsii-calc.LoadBalancedFargateServiceProps",
+      "kind": "interface",
+      "name": "LoadBalancedFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.",
+            "default": "80"
+          },
+          "name": "containerPort",
+          "type": {
+            "optional": true,
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The number of cpu units used by the task.\nValid values, which determines your range of valid values for the memory parameter:\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "default": "256"
+          },
+          "name": "cpu",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The amount (in MiB) of memory used by the task.\n\nThis field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)\n\n1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)\n\n2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)\n\nBetween 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)\n\nBetween 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "default": "512"
+          },
+          "name": "memoryMiB",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "Determines whether the Application Load Balancer will be internet-facing",
+            "default": "true"
+          },
+          "name": "publicLoadBalancer",
+          "type": {
+            "optional": true,
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "Determines whether your Fargate Service will be assigned a public IP address.",
+            "default": "false"
+          },
+          "name": "publicTasks",
+          "type": {
+            "optional": true,
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
     "jsii-calc.Multiply": {
       "assembly": "jsii-calc",
       "base": {
@@ -2713,6 +2787,7 @@
             {
               "name": "arg2",
               "type": {
+                "optional": true,
                 "primitive": "string"
               }
             },
@@ -3537,5 +3612,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "FZk0ePQ2XUte84CmnOjU3PPCl6QUA88ke6wHIJKhyzo="
+  "fingerprint": "3UAOWGBZzphiNp40hKAbXcsM27uWdwmXnbiPU74ZroU="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/sphinx/_scope_jsii-calc-base.rst
@@ -153,6 +153,7 @@ Base
    A base class.
 
 
+
    :abstract: Yes
 
    .. py:method:: typeName() -> any
@@ -193,13 +194,13 @@ BaseProps (interface)
 
    .. py:attribute:: bar
 
-      :type: string *(abstract)*
+      :type: string
 
 
    .. py:attribute:: foo
 
       *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps <@scope/jsii-calc-base-of-base.VeryBaseProps.foo>`
 
-      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
+      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\ 
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/sphinx/_scope_jsii-calc-lib.rst
@@ -150,7 +150,10 @@ EnumFromScopedModule (enum)
 
 
 
-   Check that enums from @scoped packages can be references. See awslabs/jsii#138
+   Check that enums from @scoped packages can be references.
+
+   See awslabs/jsii#138
+
 
 
    .. py:data:: Value1
@@ -190,9 +193,10 @@ IDoublable (interface)
 
 
 
+
    .. py:attribute:: doubleValue
 
-      :type: number *(readonly)* *(abstract)*
+      :type: number *(readonly)*
 
 
 IFriendly (interface)
@@ -222,7 +226,10 @@ IFriendly (interface)
 
 
 
-   Applies to classes that are considered friendly. These classes can be greeted with a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+   Applies to classes that are considered friendly. These classes can be greeted with
+
+   a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+
 
 
 
@@ -230,6 +237,7 @@ IFriendly (interface)
    .. py:method:: hello() -> string
 
       Say hello!
+
 
 
       :rtype: string
@@ -268,12 +276,14 @@ MyFirstStruct (interface)
 
 
 
+
    .. py:attribute:: anumber
 
       An awesome number value
 
 
-      :type: number *(abstract)*
+
+      :type: number
 
 
    .. py:attribute:: astring
@@ -281,12 +291,13 @@ MyFirstStruct (interface)
       A string value
 
 
-      :type: string *(abstract)*
+
+      :type: string
 
 
    .. py:attribute:: firstOptional
 
-      :type: string[] or ``undefined`` *(abstract)*
+      :type: string[] *(optional)*
 
 
 Number
@@ -319,6 +330,7 @@ Number
    Represents a concrete number.
 
 
+
    :extends: :py:class:`~@scope/jsii-calc-lib.Value`\ 
    :implements: :py:class:`~@scope/jsii-calc-lib.IDoublable`\ 
    :param value: The number.
@@ -331,6 +343,7 @@ Number
       The number multiplied by 2.
 
 
+
       :type: number *(readonly)*
 
 
@@ -339,6 +352,7 @@ Number
       *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
 
       The number.
+
 
 
       :type: number *(readonly)*
@@ -357,6 +371,7 @@ Number
       *Inherited from* :py:meth:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.toString>`
 
       String representation of the value.
+
 
 
       :rtype: string
@@ -392,6 +407,7 @@ Operation
    Represents an operation on values.
 
 
+
    :extends: :py:class:`~@scope/jsii-calc-lib.Value`\ 
    :abstract: Yes
 
@@ -400,6 +416,7 @@ Operation
       *Overrides* :py:meth:`@scope/jsii-calc-lib.Value.toString`
 
       String representation of the value.
+
 
 
       :rtype: string
@@ -419,6 +436,7 @@ Operation
       *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
+
 
 
       :type: number *(readonly)* *(abstract)*
@@ -456,22 +474,24 @@ StructWithOnlyOptionals (interface)
 
 
 
+
    .. py:attribute:: optional1
 
       The first optional!
 
 
-      :type: string or ``undefined`` *(abstract)*
+
+      :type: string *(optional)*
 
 
    .. py:attribute:: optional2
 
-      :type: number or ``undefined`` *(abstract)*
+      :type: number *(optional)*
 
 
    .. py:attribute:: optional3
 
-      :type: boolean or ``undefined`` *(abstract)*
+      :type: boolean *(optional)*
 
 
 Value
@@ -504,6 +524,7 @@ Value
    Abstract class which represents a numeric value.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-base.Base`\ 
    :abstract: Yes
 
@@ -512,12 +533,14 @@ Value
       String representation of the value.
 
 
+
       :rtype: string
 
 
    .. py:attribute:: value
 
       The value.
+
 
 
       :type: number *(readonly)* *(abstract)*

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1114,6 +1114,7 @@
           {
             "name": "arg2",
             "type": {
+              "optional": true,
               "primitive": "string"
             }
           },
@@ -1138,16 +1139,17 @@
         },
         {
           "immutable": true,
-          "name": "arg2",
+          "name": "arg3",
           "type": {
-            "primitive": "string"
+            "primitive": "date"
           }
         },
         {
           "immutable": true,
-          "name": "arg3",
+          "name": "arg2",
           "type": {
-            "primitive": "date"
+            "optional": true,
+            "primitive": "string"
           }
         }
       ]
@@ -1996,6 +1998,78 @@
         }
       ]
     },
+    "jsii-calc.LoadBalancedFargateServiceProps": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "comment": "jsii#298: show default values in sphinx documentation, and respect newlines."
+      },
+      "fqn": "jsii-calc.LoadBalancedFargateServiceProps",
+      "kind": "interface",
+      "name": "LoadBalancedFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.",
+            "default": "80"
+          },
+          "name": "containerPort",
+          "type": {
+            "optional": true,
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The number of cpu units used by the task.\nValid values, which determines your range of valid values for the memory parameter:\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "default": "256"
+          },
+          "name": "cpu",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "The amount (in MiB) of memory used by the task.\n\nThis field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)\n\n1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)\n\n2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)\n\nBetween 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)\n\nBetween 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "default": "512"
+          },
+          "name": "memoryMiB",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "Determines whether the Application Load Balancer will be internet-facing",
+            "default": "true"
+          },
+          "name": "publicLoadBalancer",
+          "type": {
+            "optional": true,
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "comment": "Determines whether your Fargate Service will be assigned a public IP address.",
+            "default": "false"
+          },
+          "name": "publicTasks",
+          "type": {
+            "optional": true,
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
     "jsii-calc.Multiply": {
       "assembly": "jsii-calc",
       "base": {
@@ -2713,6 +2787,7 @@
             {
               "name": "arg2",
               "type": {
+                "optional": true,
                 "primitive": "string"
               }
             },
@@ -3537,5 +3612,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "FZk0ePQ2XUte84CmnOjU3PPCl6QUA88ke6wHIJKhyzo="
+  "fingerprint": "3UAOWGBZzphiNp40hKAbXcsM27uWdwmXnbiPU74ZroU="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiClass(typeof(DefaultedConstructorArgument), "jsii-calc.DefaultedConstructorArgument", "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
+    [JsiiClass(typeof(DefaultedConstructorArgument), "jsii-calc.DefaultedConstructorArgument", "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\",\"optional\":true}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
     public class DefaultedConstructorArgument : DeputyBase
     {
         public DefaultedConstructorArgument(double? arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))
@@ -24,16 +24,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             get => GetInstanceProperty<double>();
         }
 
-        [JsiiProperty("arg2", "{\"primitive\":\"string\"}")]
-        public virtual string Arg2
-        {
-            get => GetInstanceProperty<string>();
-        }
-
         [JsiiProperty("arg3", "{\"primitive\":\"date\"}")]
         public virtual DateTime Arg3
         {
             get => GetInstanceProperty<DateTime>();
+        }
+
+        [JsiiProperty("arg2", "{\"primitive\":\"string\",\"optional\":true}")]
+        public virtual string Arg2
+        {
+            get => GetInstanceProperty<string>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ILoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ILoadBalancedFargateServiceProps.cs
@@ -1,0 +1,81 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    [JsiiInterface(typeof(ILoadBalancedFargateServiceProps), "jsii-calc.LoadBalancedFargateServiceProps")]
+    public interface ILoadBalancedFargateServiceProps
+    {
+        /// <summary>The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.</summary>
+        /// <remarks>default: 80</remarks>
+        [JsiiProperty("containerPort", "{\"primitive\":\"number\",\"optional\":true}")]
+        double? ContainerPort
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The number of cpu units used by the task.
+        /// Valid values, which determines your range of valid values for the memory parameter:
+        /// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+        /// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+        /// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+        /// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+        /// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 256</remarks>
+        [JsiiProperty("cpu", "{\"primitive\":\"string\",\"optional\":true}")]
+        string Cpu
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The amount (in MiB) of memory used by the task.
+        /// 
+        /// This field is required and you must use one of the following values, which determines your range of valid values
+        /// for the cpu parameter:
+        /// 
+        /// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+        /// 
+        /// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+        /// 
+        /// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+        /// 
+        /// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+        /// 
+        /// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 512</remarks>
+        [JsiiProperty("memoryMiB", "{\"primitive\":\"string\",\"optional\":true}")]
+        string MemoryMiB
+        {
+            get;
+            set;
+        }
+
+        /// <summary>Determines whether the Application Load Balancer will be internet-facing</summary>
+        /// <remarks>default: true</remarks>
+        [JsiiProperty("publicLoadBalancer", "{\"primitive\":\"boolean\",\"optional\":true}")]
+        bool? PublicLoadBalancer
+        {
+            get;
+            set;
+        }
+
+        /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
+        /// <remarks>default: false</remarks>
+        [JsiiProperty("publicTasks", "{\"primitive\":\"boolean\",\"optional\":true}")]
+        bool? PublicTasks
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
@@ -1,0 +1,80 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    public class LoadBalancedFargateServiceProps : DeputyBase, ILoadBalancedFargateServiceProps
+    {
+        /// <summary>The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.</summary>
+        /// <remarks>default: 80</remarks>
+        [JsiiProperty("containerPort", "{\"primitive\":\"number\",\"optional\":true}", true)]
+        public double? ContainerPort
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The number of cpu units used by the task.
+        /// Valid values, which determines your range of valid values for the memory parameter:
+        /// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+        /// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+        /// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+        /// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+        /// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 256</remarks>
+        [JsiiProperty("cpu", "{\"primitive\":\"string\",\"optional\":true}", true)]
+        public string Cpu
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The amount (in MiB) of memory used by the task.
+        /// 
+        /// This field is required and you must use one of the following values, which determines your range of valid values
+        /// for the cpu parameter:
+        /// 
+        /// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+        /// 
+        /// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+        /// 
+        /// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+        /// 
+        /// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+        /// 
+        /// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 512</remarks>
+        [JsiiProperty("memoryMiB", "{\"primitive\":\"string\",\"optional\":true}", true)]
+        public string MemoryMiB
+        {
+            get;
+            set;
+        }
+
+        /// <summary>Determines whether the Application Load Balancer will be internet-facing</summary>
+        /// <remarks>default: true</remarks>
+        [JsiiProperty("publicLoadBalancer", "{\"primitive\":\"boolean\",\"optional\":true}", true)]
+        public bool? PublicLoadBalancer
+        {
+            get;
+            set;
+        }
+
+        /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
+        /// <remarks>default: false</remarks>
+        [JsiiProperty("publicTasks", "{\"primitive\":\"boolean\",\"optional\":true}", true)]
+        public bool? PublicTasks
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
@@ -1,0 +1,85 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    [JsiiTypeProxy(typeof(ILoadBalancedFargateServiceProps), "jsii-calc.LoadBalancedFargateServiceProps")]
+    internal sealed class LoadBalancedFargateServicePropsProxy : DeputyBase, ILoadBalancedFargateServiceProps
+    {
+        private LoadBalancedFargateServicePropsProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.</summary>
+        /// <remarks>default: 80</remarks>
+        [JsiiProperty("containerPort", "{\"primitive\":\"number\",\"optional\":true}")]
+        public double? ContainerPort
+        {
+            get => GetInstanceProperty<double? >();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <summary>
+        /// The number of cpu units used by the task.
+        /// Valid values, which determines your range of valid values for the memory parameter:
+        /// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+        /// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+        /// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+        /// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+        /// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 256</remarks>
+        [JsiiProperty("cpu", "{\"primitive\":\"string\",\"optional\":true}")]
+        public string Cpu
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <summary>
+        /// The amount (in MiB) of memory used by the task.
+        /// 
+        /// This field is required and you must use one of the following values, which determines your range of valid values
+        /// for the cpu parameter:
+        /// 
+        /// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+        /// 
+        /// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+        /// 
+        /// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+        /// 
+        /// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+        /// 
+        /// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+        /// 
+        /// This default is set in the underlying FargateTaskDefinition construct.
+        /// </summary>
+        /// <remarks>default: 512</remarks>
+        [JsiiProperty("memoryMiB", "{\"primitive\":\"string\",\"optional\":true}")]
+        public string MemoryMiB
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <summary>Determines whether the Application Load Balancer will be internet-facing</summary>
+        /// <remarks>default: true</remarks>
+        [JsiiProperty("publicLoadBalancer", "{\"primitive\":\"boolean\",\"optional\":true}")]
+        public bool? PublicLoadBalancer
+        {
+            get => GetInstanceProperty<bool? >();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
+        /// <remarks>default: false</remarks>
+        [JsiiProperty("publicTasks", "{\"primitive\":\"boolean\",\"optional\":true}")]
+        public bool? PublicTasks
+        {
+            get => GetInstanceProperty<bool? >();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
@@ -18,7 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod("methodWithDefaultedArguments", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
+        [JsiiMethod("methodWithDefaultedArguments", null, "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\",\"optional\":true}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\",\"optional\":true}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\",\"optional\":true}}]")]
         public virtual void MethodWithDefaultedArguments(double? arg1, string arg2, DateTime? arg3)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -57,6 +57,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.JSObjectLiteralToNative": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNative.class;
             case "jsii-calc.JSObjectLiteralToNativeClass": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class;
             case "jsii-calc.JavaReservedWords": return software.amazon.jsii.tests.calculator.JavaReservedWords.class;
+            case "jsii-calc.LoadBalancedFargateServiceProps": return software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps.class;
             case "jsii-calc.Multiply": return software.amazon.jsii.tests.calculator.Multiply.class;
             case "jsii-calc.MutableObjectLiteral": return software.amazon.jsii.tests.calculator.MutableObjectLiteral.class;
             case "jsii-calc.Negate": return software.amazon.jsii.tests.calculator.Negate.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -6,24 +6,33 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
     protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
-    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)), java.util.stream.Stream.of(arg3)).toArray());
     }
-    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2) {
+    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)).toArray());
+    }
+    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(arg1).toArray());
+    }
+    public DefaultedConstructorArgument() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
     public java.lang.Number getArg1() {
         return this.jsiiGet("arg1", java.lang.Number.class);
     }
 
-    public java.lang.String getArg2() {
-        return this.jsiiGet("arg2", java.lang.String.class);
-    }
-
     public java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);
+    }
+
+    @javax.annotation.Nullable
+    public java.lang.String getArg2() {
+        return this.jsiiGet("arg2", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -1,0 +1,417 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * jsii#298: show default values in sphinx documentation, and respect newlines.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+     * @default 80
+     */
+    java.lang.Number getContainerPort();
+    /**
+     * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+     * @default 80
+     */
+    void setContainerPort(final java.lang.Number value);
+    /**
+     * The number of cpu units used by the task.
+     * Valid values, which determines your range of valid values for the memory parameter:
+     * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+     * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+     * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+     * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+     * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+     * 
+     * This default is set in the underlying FargateTaskDefinition construct.
+     * @default 256
+     */
+    java.lang.String getCpu();
+    /**
+     * The number of cpu units used by the task.
+     * Valid values, which determines your range of valid values for the memory parameter:
+     * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+     * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+     * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+     * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+     * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+     * 
+     * This default is set in the underlying FargateTaskDefinition construct.
+     * @default 256
+     */
+    void setCpu(final java.lang.String value);
+    /**
+     * The amount (in MiB) of memory used by the task.
+     * 
+     * This field is required and you must use one of the following values, which determines your range of valid values
+     * for the cpu parameter:
+     * 
+     * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+     * 
+     * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+     * 
+     * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+     * 
+     * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+     * 
+     * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+     * 
+     * This default is set in the underlying FargateTaskDefinition construct.
+     * @default 512
+     */
+    java.lang.String getMemoryMiB();
+    /**
+     * The amount (in MiB) of memory used by the task.
+     * 
+     * This field is required and you must use one of the following values, which determines your range of valid values
+     * for the cpu parameter:
+     * 
+     * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+     * 
+     * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+     * 
+     * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+     * 
+     * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+     * 
+     * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+     * 
+     * This default is set in the underlying FargateTaskDefinition construct.
+     * @default 512
+     */
+    void setMemoryMiB(final java.lang.String value);
+    /**
+     * Determines whether the Application Load Balancer will be internet-facing
+     * @default true
+     */
+    java.lang.Boolean getPublicLoadBalancer();
+    /**
+     * Determines whether the Application Load Balancer will be internet-facing
+     * @default true
+     */
+    void setPublicLoadBalancer(final java.lang.Boolean value);
+    /**
+     * Determines whether your Fargate Service will be assigned a public IP address.
+     * @default false
+     */
+    java.lang.Boolean getPublicTasks();
+    /**
+     * Determines whether your Fargate Service will be assigned a public IP address.
+     * @default false
+     */
+    void setPublicTasks(final java.lang.Boolean value);
+
+    /**
+     * @return a {@link Builder} of {@link LoadBalancedFargateServiceProps}
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link LoadBalancedFargateServiceProps}
+     */
+    final class Builder {
+        @javax.annotation.Nullable
+        private java.lang.Number _containerPort;
+        @javax.annotation.Nullable
+        private java.lang.String _cpu;
+        @javax.annotation.Nullable
+        private java.lang.String _memoryMiB;
+        @javax.annotation.Nullable
+        private java.lang.Boolean _publicLoadBalancer;
+        @javax.annotation.Nullable
+        private java.lang.Boolean _publicTasks;
+
+        /**
+         * Sets the value of ContainerPort
+         * @param value The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+         * @return {@code this}
+         */
+        public Builder withContainerPort(@javax.annotation.Nullable final java.lang.Number value) {
+            this._containerPort = value;
+            return this;
+        }
+        /**
+         * Sets the value of Cpu
+         * @param value The number of cpu units used by the task.
+Valid values, which determines your range of valid values for the memory parameter:
+256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+
+This default is set in the underlying FargateTaskDefinition construct.
+         * @return {@code this}
+         */
+        public Builder withCpu(@javax.annotation.Nullable final java.lang.String value) {
+            this._cpu = value;
+            return this;
+        }
+        /**
+         * Sets the value of MemoryMiB
+         * @param value The amount (in MiB) of memory used by the task.
+
+This field is required and you must use one of the following values, which determines your range of valid values
+for the cpu parameter:
+
+0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+
+1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+
+2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+
+Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+
+Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+
+This default is set in the underlying FargateTaskDefinition construct.
+         * @return {@code this}
+         */
+        public Builder withMemoryMiB(@javax.annotation.Nullable final java.lang.String value) {
+            this._memoryMiB = value;
+            return this;
+        }
+        /**
+         * Sets the value of PublicLoadBalancer
+         * @param value Determines whether the Application Load Balancer will be internet-facing
+         * @return {@code this}
+         */
+        public Builder withPublicLoadBalancer(@javax.annotation.Nullable final java.lang.Boolean value) {
+            this._publicLoadBalancer = value;
+            return this;
+        }
+        /**
+         * Sets the value of PublicTasks
+         * @param value Determines whether your Fargate Service will be assigned a public IP address.
+         * @return {@code this}
+         */
+        public Builder withPublicTasks(@javax.annotation.Nullable final java.lang.Boolean value) {
+            this._publicTasks = value;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link LoadBalancedFargateServiceProps}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        public LoadBalancedFargateServiceProps build() {
+            return new LoadBalancedFargateServiceProps() {
+                @javax.annotation.Nullable
+                private java.lang.Number $containerPort = _containerPort;
+                @javax.annotation.Nullable
+                private java.lang.String $cpu = _cpu;
+                @javax.annotation.Nullable
+                private java.lang.String $memoryMiB = _memoryMiB;
+                @javax.annotation.Nullable
+                private java.lang.Boolean $publicLoadBalancer = _publicLoadBalancer;
+                @javax.annotation.Nullable
+                private java.lang.Boolean $publicTasks = _publicTasks;
+
+                @Override
+                public java.lang.Number getContainerPort() {
+                    return this.$containerPort;
+                }
+
+                @Override
+                public void setContainerPort(@javax.annotation.Nullable final java.lang.Number value) {
+                    this.$containerPort = value;
+                }
+
+                @Override
+                public java.lang.String getCpu() {
+                    return this.$cpu;
+                }
+
+                @Override
+                public void setCpu(@javax.annotation.Nullable final java.lang.String value) {
+                    this.$cpu = value;
+                }
+
+                @Override
+                public java.lang.String getMemoryMiB() {
+                    return this.$memoryMiB;
+                }
+
+                @Override
+                public void setMemoryMiB(@javax.annotation.Nullable final java.lang.String value) {
+                    this.$memoryMiB = value;
+                }
+
+                @Override
+                public java.lang.Boolean getPublicLoadBalancer() {
+                    return this.$publicLoadBalancer;
+                }
+
+                @Override
+                public void setPublicLoadBalancer(@javax.annotation.Nullable final java.lang.Boolean value) {
+                    this.$publicLoadBalancer = value;
+                }
+
+                @Override
+                public java.lang.Boolean getPublicTasks() {
+                    return this.$publicTasks;
+                }
+
+                @Override
+                public void setPublicTasks(@javax.annotation.Nullable final java.lang.Boolean value) {
+                    this.$publicTasks = value;
+                }
+
+            };
+        }
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        /**
+         * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+         * @default 80
+         */
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.Number getContainerPort() {
+            return this.jsiiGet("containerPort", java.lang.Number.class);
+        }
+
+        /**
+         * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+         * @default 80
+         */
+        @Override
+        public void setContainerPort(@javax.annotation.Nullable final java.lang.Number value) {
+            this.jsiiSet("containerPort", value);
+        }
+
+        /**
+         * The number of cpu units used by the task.
+         * Valid values, which determines your range of valid values for the memory parameter:
+         * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+         * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+         * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+         * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+         * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+         * 
+         * This default is set in the underlying FargateTaskDefinition construct.
+         * @default 256
+         */
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.String getCpu() {
+            return this.jsiiGet("cpu", java.lang.String.class);
+        }
+
+        /**
+         * The number of cpu units used by the task.
+         * Valid values, which determines your range of valid values for the memory parameter:
+         * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+         * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+         * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+         * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+         * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+         * 
+         * This default is set in the underlying FargateTaskDefinition construct.
+         * @default 256
+         */
+        @Override
+        public void setCpu(@javax.annotation.Nullable final java.lang.String value) {
+            this.jsiiSet("cpu", value);
+        }
+
+        /**
+         * The amount (in MiB) of memory used by the task.
+         * 
+         * This field is required and you must use one of the following values, which determines your range of valid values
+         * for the cpu parameter:
+         * 
+         * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+         * 
+         * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+         * 
+         * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+         * 
+         * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+         * 
+         * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+         * 
+         * This default is set in the underlying FargateTaskDefinition construct.
+         * @default 512
+         */
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.String getMemoryMiB() {
+            return this.jsiiGet("memoryMiB", java.lang.String.class);
+        }
+
+        /**
+         * The amount (in MiB) of memory used by the task.
+         * 
+         * This field is required and you must use one of the following values, which determines your range of valid values
+         * for the cpu parameter:
+         * 
+         * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+         * 
+         * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+         * 
+         * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+         * 
+         * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+         * 
+         * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+         * 
+         * This default is set in the underlying FargateTaskDefinition construct.
+         * @default 512
+         */
+        @Override
+        public void setMemoryMiB(@javax.annotation.Nullable final java.lang.String value) {
+            this.jsiiSet("memoryMiB", value);
+        }
+
+        /**
+         * Determines whether the Application Load Balancer will be internet-facing
+         * @default true
+         */
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.Boolean getPublicLoadBalancer() {
+            return this.jsiiGet("publicLoadBalancer", java.lang.Boolean.class);
+        }
+
+        /**
+         * Determines whether the Application Load Balancer will be internet-facing
+         * @default true
+         */
+        @Override
+        public void setPublicLoadBalancer(@javax.annotation.Nullable final java.lang.Boolean value) {
+            this.jsiiSet("publicLoadBalancer", value);
+        }
+
+        /**
+         * Determines whether your Fargate Service will be assigned a public IP address.
+         * @default false
+         */
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.Boolean getPublicTasks() {
+            return this.jsiiGet("publicTasks", java.lang.Boolean.class);
+        }
+
+        /**
+         * Determines whether your Fargate Service will be assigned a public IP address.
+         * @default false
+         */
+        @Override
+        public void setPublicTasks(@javax.annotation.Nullable final java.lang.Boolean value) {
+            this.jsiiSet("publicTasks", value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -11,12 +11,20 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
-    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
-        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)), java.util.stream.Stream.of(arg3)).toArray());
     }
 
-    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, final java.lang.String arg2) {
-        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)).toArray());
+    }
+
+    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1) {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.of(arg1).toArray());
+    }
+
+    public void methodWithDefaultedArguments() {
+        this.jsiiCall("methodWithDefaultedArguments", Void.class);
     }
 
     public void methodWithOptionalAnyArgument(@javax.annotation.Nullable final java.lang.Object arg) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -290,6 +290,7 @@ Add
    The "+" binary operation.
 
 
+
    :extends: :py:class:`~jsii-calc.BinaryOperation`\ 
    :param lhs: Left-hand side operand
    :type lhs: :py:class:`@scope/jsii-calc-lib.Value`\ 
@@ -303,6 +304,7 @@ Add
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -311,6 +313,7 @@ Add
       *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -331,6 +334,7 @@ Add
       Say hello!
 
 
+
       :rtype: string
 
 
@@ -341,6 +345,7 @@ Add
       Left-hand side operand
 
 
+
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
@@ -349,6 +354,7 @@ Add
       *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.rhs>`
 
       Right-hand side operand
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -381,7 +387,10 @@ AllTypes
 
 
 
-   This class includes property for all types supported by jsii. The setters will validate that the value set is of the expected type and throw otherwise.
+   This class includes property for all types supported by jsii. The setters will validate
+
+   that the value set is of the expected type and throw otherwise.
+
 
 
 
@@ -484,7 +493,7 @@ AllTypes
 
    .. py:attribute:: optionalEnumValue
 
-      :type: :py:class:`~jsii-calc.StringEnum`\  or ``undefined``
+      :type: :py:class:`~jsii-calc.StringEnum`\  *(optional)*
 
 
 AllTypesEnum (enum)
@@ -562,6 +571,7 @@ AllowedMethodNames
       getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
 
 
+
       :param withParam: 
       :type withParam: string
       :rtype: string
@@ -580,6 +590,7 @@ AllowedMethodNames
    .. py:method:: setFoo(_x, _y)
 
       setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
+
 
 
       :param _x: 
@@ -626,12 +637,20 @@ AsyncVirtualMethods
       Just calls "overrideMeToo"
 
 
+
       :rtype: number
 
 
    .. py:method:: callMeDoublePromise() -> number
 
-      This method calls the "callMe" async method indirectly, which will then invoke a virtual method. This is a "double promise" situation, which means that callbacks are not going to be available immediate, but only after an "immediates" cycle.
+      This method calls the "callMe" async method indirectly, which will then
+
+      invoke a virtual method. This is a "double promise" situation, which
+
+      means that callbacks are not going to be available immediate, but only
+
+      after an "immediates" cycle.
+
 
 
       :rtype: number
@@ -684,6 +703,7 @@ BinaryOperation
    Represents an operation with two operands.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-lib.Operation`\ 
    :implements: :py:class:`@scope/jsii-calc-lib.IFriendly`\ 
    :abstract: Yes
@@ -699,6 +719,7 @@ BinaryOperation
       Say hello!
 
 
+
       :rtype: string
 
 
@@ -707,12 +728,14 @@ BinaryOperation
       Left-hand side operand
 
 
+
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
    .. py:attribute:: rhs
 
       Right-hand side operand
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -733,6 +756,7 @@ BinaryOperation
       String representation of the value.
 
 
+
       :rtype: string
       :abstract: Yes
 
@@ -742,6 +766,7 @@ BinaryOperation
       *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
+
 
 
       :type: number *(readonly)* *(abstract)*
@@ -777,13 +802,15 @@ Calculator
    A calculator which maintains a current value and allows adding operations.
 
 
+
    :extends: :py:class:`~jsii-calc.composition.CompositeOperation`\ 
    :param props: Initialization properties.
-   :type props: :py:class:`~jsii-calc.CalculatorProps`\  or ``undefined``
+   :type props: :py:class:`~jsii-calc.CalculatorProps`\  *(optional)*
 
    .. py:method:: add(value)
 
       Adds a number to the current value.
+
 
 
       :param value: 
@@ -793,6 +820,7 @@ Calculator
    .. py:method:: mul(value)
 
       Multiplies the current value by a number.
+
 
 
       :param value: 
@@ -806,9 +834,11 @@ Calculator
 
 
 
+
    .. py:method:: pow(value)
 
       Raises the current value by a power.
+
 
 
       :param value: 
@@ -818,6 +848,7 @@ Calculator
    .. py:method:: readUnionValue() -> number
 
       Returns teh value of the union property (if defined).
+
 
 
       :rtype: number
@@ -830,12 +861,14 @@ Calculator
       Returns the expression.
 
 
+
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
    .. py:attribute:: operationsLog
 
       A log of all operations.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\ [] *(readonly)*
@@ -846,12 +879,14 @@ Calculator
       A map of per operation name of all operations performed.
 
 
+
       :type: string => :py:class:`@scope/jsii-calc-lib.Value`\ [] *(readonly)*
 
 
    .. py:attribute:: curr
 
       The current value.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\ 
@@ -862,7 +897,8 @@ Calculator
       The maximum value allows in this calculator.
 
 
-      :type: number or ``undefined``
+
+      :type: number *(optional)*
 
 
    .. py:attribute:: unionProperty
@@ -870,7 +906,8 @@ Calculator
       Example of a property that accepts a union of types.
 
 
-      :type: :py:class:`~jsii-calc.Add`\  or :py:class:`~jsii-calc.Multiply`\  or :py:class:`~jsii-calc.Power`\  or ``undefined``
+
+      :type: :py:class:`~jsii-calc.Add`\  or :py:class:`~jsii-calc.Multiply`\  or :py:class:`~jsii-calc.Power`\  *(optional)*
 
 
    .. py:method:: typeName() -> any
@@ -888,6 +925,7 @@ Calculator
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -896,6 +934,7 @@ Calculator
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -908,6 +947,7 @@ Calculator
       A set of postfixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -918,6 +958,7 @@ Calculator
       A set of prefixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -926,6 +967,7 @@ Calculator
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
+
 
 
       :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
@@ -963,14 +1005,15 @@ CalculatorProps (interface)
 
 
 
+
    .. py:attribute:: initialValue
 
-      :type: number or ``undefined`` *(abstract)*
+      :type: number *(optional)*
 
 
    .. py:attribute:: maximumValue
 
-      :type: number or ``undefined`` *(abstract)*
+      :type: number *(optional)*
 
 
 ClassWithMutableObjectLiteralProperty
@@ -1036,6 +1079,7 @@ ClassWithPrivateConstructorAndAutomaticProperties
    Class that implements interface properties automatically, but using a private constructor
 
 
+
    :implements: :py:class:`~jsii-calc.InterfaceWithProperties`\ 
 
    .. py:staticmethod:: create(readOnlyString, readWriteString) -> jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties
@@ -1064,7 +1108,7 @@ ClassWithPrivateConstructorAndAutomaticProperties
 DefaultedConstructorArgument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:class:: DefaultedConstructorArgument(arg1, arg2, [arg3])
+.. py:class:: DefaultedConstructorArgument([arg1, [arg2, [arg3]]])
 
    **Language-specific names:**
 
@@ -1089,25 +1133,25 @@ DefaultedConstructorArgument
 
 
    :param arg1: 
-   :type arg1: number or ``undefined``
+   :type arg1: number *(optional)*
    :param arg2: 
-   :type arg2: string
+   :type arg2: string *(optional)*
    :param arg3: 
-   :type arg3: date or ``undefined``
+   :type arg3: date *(optional)*
 
    .. py:attribute:: arg1
 
       :type: number *(readonly)*
 
 
-   .. py:attribute:: arg2
-
-      :type: string *(readonly)*
-
-
    .. py:attribute:: arg3
 
       :type: date *(readonly)*
+
+
+   .. py:attribute:: arg2
+
+      :type: string *(optional)* *(readonly)*
 
 
 
@@ -1217,17 +1261,18 @@ DerivedStruct (interface)
    A struct which derives from another struct.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-lib.MyFirstStruct`\ 
 
 
    .. py:attribute:: anotherRequired
 
-      :type: date *(abstract)*
+      :type: date
 
 
    .. py:attribute:: bool
 
-      :type: boolean *(abstract)*
+      :type: boolean
 
 
    .. py:attribute:: nonPrimitive
@@ -1235,7 +1280,8 @@ DerivedStruct (interface)
       An example of a non primitive property.
 
 
-      :type: :py:class:`~jsii-calc.DoubleTrouble`\  *(abstract)*
+
+      :type: :py:class:`~jsii-calc.DoubleTrouble`\ 
 
 
    .. py:attribute:: anotherOptional
@@ -1243,17 +1289,18 @@ DerivedStruct (interface)
       This is optional.
 
 
-      :type: string => :py:class:`@scope/jsii-calc-lib.Value`\  or ``undefined`` *(abstract)*
+
+      :type: string => :py:class:`@scope/jsii-calc-lib.Value`\  *(optional)*
 
 
    .. py:attribute:: optionalAny
 
-      :type: any or ``undefined`` *(abstract)*
+      :type: any *(optional)*
 
 
    .. py:attribute:: optionalArray
 
-      :type: string[] or ``undefined`` *(abstract)*
+      :type: string[] *(optional)*
 
 
    .. py:attribute:: anumber
@@ -1263,7 +1310,8 @@ DerivedStruct (interface)
       An awesome number value
 
 
-      :type: number *(abstract)*
+
+      :type: number
 
 
    .. py:attribute:: astring
@@ -1273,14 +1321,15 @@ DerivedStruct (interface)
       A string value
 
 
-      :type: string *(abstract)*
+
+      :type: string
 
 
    .. py:attribute:: firstOptional
 
       *Inherited from* :py:attr:`@scope/jsii-calc-lib.MyFirstStruct <@scope/jsii-calc-lib.MyFirstStruct.firstOptional>`
 
-      :type: string[] or ``undefined`` *(abstract)*
+      :type: string[] *(optional)*
 
 
 DoNotOverridePrivates
@@ -1358,14 +1407,15 @@ DoNotRecognizeAnyAsOptional
 
 
 
+
    .. py:method:: method(_requiredAny, [_optionalAny, [_optionalString]])
 
       :param _requiredAny: 
       :type _requiredAny: any
       :param _optionalAny: 
-      :type _optionalAny: any or ``undefined``
+      :type _optionalAny: any *(optional)*
       :param _optionalString: 
-      :type _optionalString: string or ``undefined``
+      :type _optionalString: string *(optional)*
 
 
 DoubleTrouble
@@ -1404,6 +1454,7 @@ DoubleTrouble
       Say hello!
 
 
+
       :rtype: string
 
 
@@ -1412,6 +1463,7 @@ DoubleTrouble
       *Implements* :py:meth:`jsii-calc.IRandomNumberGenerator.next`
 
       Returns another random number.
+
 
 
       :rtype: number
@@ -1450,6 +1502,7 @@ GiveMeStructs
       Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
 
 
+
       :param derived: 
       :type derived: :py:class:`~jsii-calc.DerivedStruct`\ 
       :rtype: :py:class:`@scope/jsii-calc-lib.MyFirstStruct`\ 
@@ -1460,6 +1513,7 @@ GiveMeStructs
       Returns the boolean from a DerivedStruct struct.
 
 
+
       :param derived: 
       :type derived: :py:class:`~jsii-calc.DerivedStruct`\ 
       :rtype: :py:class:`~jsii-calc.DoubleTrouble`\ 
@@ -1468,6 +1522,7 @@ GiveMeStructs
    .. py:method:: readFirstNumber(first) -> number
 
       Returns the "anumber" from a MyFirstStruct struct;
+
 
 
       :param first: 
@@ -1510,12 +1565,14 @@ IFriendlier (interface)
    Even friendlier classes can implement this interface.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-lib.IFriendly`\ 
 
 
    .. py:method:: farewell() -> string
 
       Say farewell.
+
 
 
       :rtype: string
@@ -1525,6 +1582,7 @@ IFriendlier (interface)
    .. py:method:: goodbye() -> string
 
       Say goodbye.
+
 
 
       :return: A goodbye blessing.
@@ -1537,6 +1595,7 @@ IFriendlier (interface)
       *Inherited from* :py:meth:`@scope/jsii-calc-lib.IFriendly <@scope/jsii-calc-lib.IFriendly.hello>`
 
       Say hello!
+
 
 
       :rtype: string
@@ -1581,6 +1640,7 @@ IFriendlyRandomGenerator (interface)
       Say hello!
 
 
+
       :rtype: string
       :abstract: Yes
 
@@ -1590,6 +1650,7 @@ IFriendlyRandomGenerator (interface)
       *Inherited from* :py:meth:`jsii-calc.IRandomNumberGenerator <jsii-calc.IRandomNumberGenerator.next>`
 
       Returns another random number.
+
 
 
       :return: A random number.
@@ -1624,7 +1685,10 @@ IInterfaceThatShouldNotBeADataType (interface)
 
 
 
-   Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+   Even though this interface has only properties, it is disqualified from being a datatype
+
+   because it inherits from an interface that is not a datatype.
+
 
 
    :extends: :py:class:`~jsii-calc.IInterfaceWithMethods`\ 
@@ -1632,7 +1696,7 @@ IInterfaceThatShouldNotBeADataType (interface)
 
    .. py:attribute:: otherValue
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
    .. py:method:: doThings()
@@ -1646,7 +1710,7 @@ IInterfaceThatShouldNotBeADataType (interface)
 
       *Inherited from* :py:attr:`jsii-calc.IInterfaceWithMethods <jsii-calc.IInterfaceWithMethods.value>`
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
 IInterfaceWithMethods (interface)
@@ -1680,7 +1744,7 @@ IInterfaceWithMethods (interface)
 
    .. py:attribute:: value
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
    .. py:method:: doThings()
@@ -1715,7 +1779,10 @@ IInterfaceWithOptionalMethodArguments (interface)
 
 
 
-   awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods
+   awslabs/jsii#175
+
+   Interface proxies (and builders) do not respect optional arguments in methods
+
 
 
 
@@ -1725,7 +1792,7 @@ IInterfaceWithOptionalMethodArguments (interface)
       :param arg1: 
       :type arg1: string
       :param arg2: 
-      :type arg2: number or ``undefined``
+      :type arg2: number *(optional)*
       :abstract: Yes
 
 
@@ -1761,9 +1828,11 @@ IRandomNumberGenerator (interface)
 
 
 
+
    .. py:method:: next() -> number
 
       Returns another random number.
+
 
 
       :return: A random number.
@@ -1802,7 +1871,7 @@ IReturnsNumber (interface)
 
    .. py:attribute:: numberProp
 
-      :type: :py:class:`@scope/jsii-calc-lib.Number`\  *(readonly)* *(abstract)*
+      :type: :py:class:`@scope/jsii-calc-lib.Number`\  *(readonly)*
 
 
    .. py:method:: obtainNumber() -> @scope/jsii-calc-lib.IDoublable
@@ -1843,21 +1912,21 @@ ImplictBaseOfBase (interface)
 
    .. py:attribute:: goo
 
-      :type: date *(abstract)*
+      :type: date
 
 
    .. py:attribute:: foo
 
       *Inherited from* :py:attr:`@scope/jsii-calc-base-of-base.VeryBaseProps <@scope/jsii-calc-base-of-base.VeryBaseProps.foo>`
 
-      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\  *(abstract)*
+      :type: :py:class:`@scope/jsii-calc-base-of-base.Very`\ 
 
 
    .. py:attribute:: bar
 
       *Inherited from* :py:attr:`@scope/jsii-calc-base.BaseProps <@scope/jsii-calc-base.BaseProps.bar>`
 
-      :type: string *(abstract)*
+      :type: string
 
 
 InterfaceImplementedByAbstractClass (interface)
@@ -1887,14 +1956,17 @@ InterfaceImplementedByAbstractClass (interface)
 
 
 
-   awslabs/jsii#220 Abstract return type
+   awslabs/jsii#220
+
+   Abstract return type
+
 
 
 
 
    .. py:attribute:: propFromInterface
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
 
@@ -1932,7 +2004,7 @@ Foo
 
    .. py:attribute:: bar
 
-      :type: string or ``undefined``
+      :type: string *(optional)*
 
 
 Hello (interface)
@@ -1966,7 +2038,7 @@ Hello (interface)
 
    .. py:attribute:: foo
 
-      :type: number *(abstract)*
+      :type: number
 
 
 
@@ -2008,7 +2080,7 @@ Hello (interface)
 
    .. py:attribute:: foo
 
-      :type: number *(abstract)*
+      :type: number
 
 
 
@@ -2045,12 +2117,12 @@ InterfaceWithProperties (interface)
 
    .. py:attribute:: readOnlyString
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
    .. py:attribute:: readWriteString
 
-      :type: string *(abstract)*
+      :type: string
 
 
 InterfaceWithPropertiesExtension (interface)
@@ -2085,21 +2157,21 @@ InterfaceWithPropertiesExtension (interface)
 
    .. py:attribute:: foo
 
-      :type: number *(abstract)*
+      :type: number
 
 
    .. py:attribute:: readOnlyString
 
       *Inherited from* :py:attr:`jsii-calc.InterfaceWithProperties <jsii-calc.InterfaceWithProperties.readOnlyString>`
 
-      :type: string *(readonly)* *(abstract)*
+      :type: string *(readonly)*
 
 
    .. py:attribute:: readWriteString
 
       *Inherited from* :py:attr:`jsii-calc.InterfaceWithProperties <jsii-calc.InterfaceWithProperties.readWriteString>`
 
-      :type: string *(abstract)*
+      :type: string
 
 
 JSObjectLiteralForInterface
@@ -2452,6 +2524,135 @@ JavaReservedWords
       :type: string
 
 
+LoadBalancedFargateServiceProps (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: LoadBalancedFargateServiceProps
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps;
+
+      .. code-tab:: javascript
+
+         // LoadBalancedFargateServiceProps is an interface
+
+      .. code-tab:: typescript
+
+         import { LoadBalancedFargateServiceProps } from 'jsii-calc';
+
+
+
+   jsii#298: show default values in sphinx documentation, and respect newlines.
+
+
+
+
+
+   .. py:attribute:: containerPort
+
+      The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
+
+
+
+      :type: number *(optional)*
+      :default: 80
+
+
+   .. py:attribute:: cpu
+
+      The number of cpu units used by the task.
+
+      Valid values, which determines your range of valid values for the memory parameter:
+
+      256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+
+      512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+
+      1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+
+      2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+
+      4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+
+      
+
+      This default is set in the underlying FargateTaskDefinition construct.
+
+
+
+      :type: string *(optional)*
+      :default: 256
+
+
+   .. py:attribute:: memoryMiB
+
+      The amount (in MiB) of memory used by the task.
+
+      
+
+      This field is required and you must use one of the following values, which determines your range of valid values
+
+      for the cpu parameter:
+
+      
+
+      0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+
+      
+
+      1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+
+      
+
+      2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+
+      
+
+      Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+
+      
+
+      Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+
+      
+
+      This default is set in the underlying FargateTaskDefinition construct.
+
+
+
+      :type: string *(optional)*
+      :default: 512
+
+
+   .. py:attribute:: publicLoadBalancer
+
+      Determines whether the Application Load Balancer will be internet-facing
+
+
+
+      :type: boolean *(optional)*
+      :default: true
+
+
+   .. py:attribute:: publicTasks
+
+      Determines whether your Fargate Service will be assigned a public IP address.
+
+
+
+      :type: boolean *(optional)*
+      :default: false
+
+
 Multiply
 ^^^^^^^^
 
@@ -2482,6 +2683,7 @@ Multiply
    The "*" binary operation.
 
 
+
    :extends: :py:class:`~jsii-calc.BinaryOperation`\ 
    :implements: :py:class:`~jsii-calc.IFriendlier`\ 
    :implements: :py:class:`~jsii-calc.IRandomNumberGenerator`\ 
@@ -2497,6 +2699,7 @@ Multiply
       Say farewell.
 
 
+
       :rtype: string
 
 
@@ -2505,6 +2708,7 @@ Multiply
       *Implements* :py:meth:`jsii-calc.IFriendlier.goodbye`
 
       Say goodbye.
+
 
 
       :rtype: string
@@ -2517,6 +2721,7 @@ Multiply
       Returns another random number.
 
 
+
       :rtype: number
 
 
@@ -2527,6 +2732,7 @@ Multiply
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -2535,6 +2741,7 @@ Multiply
       *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -2555,6 +2762,7 @@ Multiply
       Say hello!
 
 
+
       :rtype: string
 
 
@@ -2565,6 +2773,7 @@ Multiply
       Left-hand side operand
 
 
+
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
@@ -2573,6 +2782,7 @@ Multiply
       *Inherited from* :py:attr:`jsii-calc.BinaryOperation <jsii-calc.BinaryOperation.rhs>`
 
       Right-hand side operand
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -2609,7 +2819,7 @@ MutableObjectLiteral (interface)
 
    .. py:attribute:: value
 
-      :type: string *(abstract)*
+      :type: string
 
 
 Negate
@@ -2642,6 +2852,7 @@ Negate
    The negation operation ("-value")
 
 
+
    :extends: :py:class:`~jsii-calc.UnaryOperation`\ 
    :implements: :py:class:`~jsii-calc.IFriendlier`\ 
    :param operand: 
@@ -2654,6 +2865,7 @@ Negate
       Say farewell.
 
 
+
       :rtype: string
 
 
@@ -2662,6 +2874,7 @@ Negate
       *Implements* :py:meth:`jsii-calc.IFriendlier.goodbye`
 
       Say goodbye.
+
 
 
       :rtype: string
@@ -2674,6 +2887,7 @@ Negate
       Say hello!
 
 
+
       :rtype: string
 
 
@@ -2684,6 +2898,7 @@ Negate
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -2692,6 +2907,7 @@ Negate
       *Implements* :py:meth:`@scope/jsii-calc-lib.Value.value`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -2743,9 +2959,11 @@ NodeStandardLibrary
 
 
 
+
    .. py:method:: cryptoSha256() -> string
 
       Uses node.js "crypto" module to calculate sha256 of a string.
+
 
 
       :return: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
@@ -2757,6 +2975,7 @@ NodeStandardLibrary
       Reads a local resource file (resource.txt) asynchronously.
 
 
+
       :return: "Hello, resource!"
       :rtype: string
 
@@ -2766,6 +2985,7 @@ NodeStandardLibrary
       Sync version of fsReadFile.
 
 
+
       :return: "Hello, resource! SYNC!"
       :rtype: string
 
@@ -2773,6 +2993,7 @@ NodeStandardLibrary
    .. py:attribute:: osPlatform
 
       Returns the current os.platform() from the "os" node module.
+
 
 
       :type: string *(readonly)*
@@ -2808,15 +3029,16 @@ NullShouldBeTreatedAsUndefined
    jsii#282, aws-cdk#157: null should be treated as "undefined"
 
 
+
    :param _param1: 
    :type _param1: string
    :param optional: 
-   :type optional: any or ``undefined``
+   :type optional: any *(optional)*
 
    .. py:method:: giveMeUndefined([value])
 
       :param value: 
-      :type value: any or ``undefined``
+      :type value: any *(optional)*
 
 
    .. py:method:: giveMeUndefinedInsideAnObject(input)
@@ -2831,7 +3053,7 @@ NullShouldBeTreatedAsUndefined
 
    .. py:attribute:: changeMeToUndefined
 
-      :type: string or ``undefined``
+      :type: string *(optional)*
 
 
 NullShouldBeTreatedAsUndefinedData (interface)
@@ -2865,12 +3087,12 @@ NullShouldBeTreatedAsUndefinedData (interface)
 
    .. py:attribute:: arrayWithThreeElementsAndUndefinedAsSecondArgument
 
-      :type: any[] *(abstract)*
+      :type: any[]
 
 
    .. py:attribute:: thisShouldBeUndefined
 
-      :type: any or ``undefined`` *(abstract)*
+      :type: any *(optional)*
 
 
 NumberGenerator
@@ -2900,7 +3122,10 @@ NumberGenerator
 
 
 
-   This allows us to test that a reference can be stored for objects that implement interfaces.
+   This allows us to test that a reference can be stored for objects that
+
+   implement interfaces.
+
 
 
    :param generator: 
@@ -2954,9 +3179,11 @@ ObjectRefsInCollections
 
 
 
+
    .. py:method:: sumFromArray(values) -> number
 
       Returns the sum of all values
+
 
 
       :param values: 
@@ -2967,6 +3194,7 @@ ObjectRefsInCollections
    .. py:method:: sumFromMap(values) -> number
 
       Returns the sum of all values in a map
+
 
 
       :param values: 
@@ -3006,7 +3234,7 @@ OptionalConstructorArgument
    :param arg2: 
    :type arg2: string
    :param arg3: 
-   :type arg3: date or ``undefined``
+   :type arg3: date *(optional)*
 
    .. py:attribute:: arg1
 
@@ -3020,7 +3248,7 @@ OptionalConstructorArgument
 
    .. py:attribute:: arg3
 
-      :type: date or ``undefined`` *(readonly)*
+      :type: date *(optional)* *(readonly)*
 
 
 OverrideReturnsObject
@@ -3123,6 +3351,7 @@ Power
    The power operation.
 
 
+
    :extends: :py:class:`~jsii-calc.composition.CompositeOperation`\ 
    :param base: The base of the power
    :type base: :py:class:`@scope/jsii-calc-lib.Value`\ 
@@ -3134,6 +3363,7 @@ Power
       The base of the power
 
 
+
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
 
 
@@ -3141,7 +3371,10 @@ Power
 
       *Implements* :py:meth:`jsii-calc.composition.CompositeOperation.expression`
 
-      The expression that this operation consists of. Must be implemented by derived classes.
+      The expression that this operation consists of.
+
+      Must be implemented by derived classes.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -3150,6 +3383,7 @@ Power
    .. py:attribute:: pow
 
       The number of times to multiply
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -3170,6 +3404,7 @@ Power
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -3178,6 +3413,7 @@ Power
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -3190,6 +3426,7 @@ Power
       A set of postfixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -3200,6 +3437,7 @@ Power
       A set of prefixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -3208,6 +3446,7 @@ Power
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
+
 
 
       :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
@@ -3244,9 +3483,10 @@ ReferenceEnumFromScopedPackage
 
 
 
+
    .. py:method:: loadFoo() -> @scope/jsii-calc-lib.EnumFromScopedModule
 
-      :rtype: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or ``undefined``
+      :rtype: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  *(optional)*
 
 
    .. py:method:: saveFoo(value)
@@ -3257,7 +3497,7 @@ ReferenceEnumFromScopedPackage
 
    .. py:attribute:: foo
 
-      :type: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  or ``undefined``
+      :type: :py:class:`@scope/jsii-calc-lib.EnumFromScopedModule`\  *(optional)*
 
 
 RuntimeTypeChecking
@@ -3288,20 +3528,20 @@ RuntimeTypeChecking
 
 
 
-   .. py:method:: methodWithDefaultedArguments(arg1, arg2, [arg3])
+   .. py:method:: methodWithDefaultedArguments([arg1, [arg2, [arg3]]])
 
       :param arg1: 
-      :type arg1: number or ``undefined``
+      :type arg1: number *(optional)*
       :param arg2: 
-      :type arg2: string
+      :type arg2: string *(optional)*
       :param arg3: 
-      :type arg3: date or ``undefined``
+      :type arg3: date *(optional)*
 
 
    .. py:method:: methodWithOptionalAnyArgument([arg])
 
       :param arg: 
-      :type arg: any or ``undefined``
+      :type arg: any *(optional)*
 
 
    .. py:method:: methodWithOptionalArguments(arg1, arg2, [arg3])
@@ -3309,12 +3549,13 @@ RuntimeTypeChecking
       Used to verify verification of number of method arguments.
 
 
+
       :param arg1: 
       :type arg1: number
       :param arg2: 
       :type arg2: string
       :param arg3: 
-      :type arg3: date or ``undefined``
+      :type arg3: date *(optional)*
 
 
 Statics
@@ -3352,6 +3593,7 @@ Statics
       Jsdocs for static method
 
 
+
       :param name: The name of the person to say hello to
       :type name: string
       :rtype: string
@@ -3367,6 +3609,7 @@ Statics
       Constants may also use all-caps.
 
 
+
       :type: number *(readonly)* *(static)*
 
 
@@ -3380,6 +3623,7 @@ Statics
       Jsdocs for static property.
 
 
+
       :type: string *(readonly)* *(static)*
 
 
@@ -3388,12 +3632,16 @@ Statics
       Constants can also use camelCase.
 
 
+
       :type: string => string *(readonly)* *(static)*
 
 
    .. py:attribute:: instance
 
-      Jsdocs for static getter. Jsdocs for static setter.
+      Jsdocs for static getter.
+
+      Jsdocs for static setter.
+
 
 
       :type: :py:class:`~jsii-calc.Statics`\  *(static)*
@@ -3473,13 +3721,17 @@ Sum
    An operation that sums multiple values.
 
 
+
    :extends: :py:class:`~jsii-calc.composition.CompositeOperation`\ 
 
    .. py:attribute:: expression
 
       *Implements* :py:meth:`jsii-calc.composition.CompositeOperation.expression`
 
-      The expression that this operation consists of. Must be implemented by derived classes.
+      The expression that this operation consists of.
+
+      Must be implemented by derived classes.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)*
@@ -3488,6 +3740,7 @@ Sum
    .. py:attribute:: parts
 
       The parts to sum.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\ []
@@ -3508,6 +3761,7 @@ Sum
       String representation of the value.
 
 
+
       :rtype: string
 
 
@@ -3516,6 +3770,7 @@ Sum
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.value>`
 
       The value.
+
 
 
       :type: number *(readonly)*
@@ -3528,6 +3783,7 @@ Sum
       A set of postfixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -3538,6 +3794,7 @@ Sum
       A set of prefixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
@@ -3546,6 +3803,7 @@ Sum
       *Inherited from* :py:attr:`jsii-calc.composition.CompositeOperation <jsii-calc.composition.CompositeOperation.stringStyle>`
 
       The .toString() style.
+
 
 
       :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
@@ -3726,6 +3984,7 @@ UnaryOperation
    An operation on a single operand.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-lib.Operation`\ 
    :abstract: Yes
    :param operand: 
@@ -3751,6 +4010,7 @@ UnaryOperation
       String representation of the value.
 
 
+
       :rtype: string
       :abstract: Yes
 
@@ -3760,6 +4020,7 @@ UnaryOperation
       *Inherited from* :py:attr:`@scope/jsii-calc-lib.Value <@scope/jsii-calc-lib.Value.value>`
 
       The value.
+
 
 
       :type: number *(readonly)* *(abstract)*
@@ -3796,12 +4057,12 @@ UnionProperties (interface)
 
    .. py:attribute:: bar
 
-      :type: string or number or :py:class:`~jsii-calc.AllTypes`\  *(readonly)* *(abstract)*
+      :type: string or number or :py:class:`~jsii-calc.AllTypes`\  *(readonly)*
 
 
    .. py:attribute:: foo
 
-      :type: string or number or ``undefined`` *(abstract)*
+      :type: string or number *(optional)*
 
 
 UseBundledDependency
@@ -3865,6 +4126,7 @@ UseCalcBase
 
 
    Depend on a type from jsii-calc-base as a test for awslabs/jsii#128
+
 
 
 
@@ -4064,6 +4326,7 @@ CompositeOperation
    Abstract operation composed from an expression of other operations.
 
 
+
    :extends: :py:class:`@scope/jsii-calc-lib.Operation`\ 
    :abstract: Yes
 
@@ -4074,12 +4337,16 @@ CompositeOperation
       String representation of the value.
 
 
+
       :rtype: string
 
 
    .. py:attribute:: expression
 
-      The expression that this operation consists of. Must be implemented by derived classes.
+      The expression that this operation consists of.
+
+      Must be implemented by derived classes.
+
 
 
       :type: :py:class:`@scope/jsii-calc-lib.Value`\  *(readonly)* *(abstract)*
@@ -4092,12 +4359,14 @@ CompositeOperation
       The value.
 
 
+
       :type: number *(readonly)*
 
 
    .. py:attribute:: decorationPostfixes
 
       A set of postfixes to include in a decorated .toString().
+
 
 
       :type: string[]
@@ -4108,12 +4377,14 @@ CompositeOperation
       A set of prefixes to include in a decorated .toString().
 
 
+
       :type: string[]
 
 
    .. py:attribute:: stringStyle
 
       The .toString() style.
+
 
 
       :type: :py:class:`~jsii-calc.composition.CompositeOperation.CompositionStringStyle`\ 
@@ -4145,14 +4416,17 @@ CompositeOperation
       Style of .toString() output for CompositeOperation.
 
 
+
       .. py:data:: Normal
 
       Normal string expression
 
 
+
       .. py:data:: Decorated
 
       Decorated string expression
+
 
 
 

--- a/packages/jsii/test/negatives/neg.non-optional-after-optional-ctor.ts
+++ b/packages/jsii/test/negatives/neg.non-optional-after-optional-ctor.ts
@@ -1,0 +1,7 @@
+///!MATCH_ERROR: Parameter _arg3 must be optional since it comes after an optional parameter
+
+export class NonOptionalAfterOptional {
+    constructor(_arg1: string, _arg2 = 'hello', _arg3: string) {
+        return;
+    }
+}

--- a/packages/jsii/test/negatives/neg.non-optional-after-optional-method.ts
+++ b/packages/jsii/test/negatives/neg.non-optional-after-optional-method.ts
@@ -1,0 +1,7 @@
+///!MATCH_ERROR: Parameter _argX must be optional since it comes after an optional parameter
+
+export class NonOptionalAfterOptional {
+    public foo(_arg1: string, _arg2 = 'hello', _argX: string, _arg4?: boolean) {
+        return;
+    }
+}


### PR DESCRIPTION
Fixes #301: reject non-optional arguments after optional arguments
Fixes #298: show default values for optional properties
Fixes #302: omit "abstract" from interface properties (they are by definition abstract)
Fixes #300: indicate optionals with "optional" instead of "or undefined"
Fixes #299: render multiple jsdoc lines as multiple lines in sphinx

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
