### PR TITLE
fix: remove overly strict checks on peer versions

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1085,6 +1085,7 @@ function _sortMembers(type: spec.ClassType | spec.InterfaceType): spec.ClassTyp
 
 function _toDependencies(assemblies: ReadonlyArray<spec.Assembly>, peers: ReadonlyArray<spec.Assembly>): { [name: string]: spec.PackageVersion } {
     const result: { [name: string]: spec.PackageVersion } = {};
+
     for (const assembly of assemblies) {
         result[assembly.name] = {
             version: assembly.version,
@@ -1094,16 +1095,6 @@ function _toDependencies(assemblies: ReadonlyArray<spec.Assembly>, peers: Readon
     }
 
     for (const peer of peers) {
-        if (peer.name in result) {
-            // module already appears as a normal dependency. just make sure it's the same version
-            const depVersion = result[peer.name].version;
-            if (depVersion !== peer.version) {
-                throw new Error(
-                    `Module '${peer.name}' appears both as a dependency (${depVersion}) ` +
-                    `and a peer dependency (${peer.version}), with mismatching versions`);
-            }
-        }
-
         result[peer.name] = {
             version: peer.version,
             targets: peer.targets,

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -44,21 +44,13 @@ export async function loadProjectInfo(projectRoot: string): Promise<ProjectInfo>
         if (!version) {
             throw new Error(`The "package.json" has "${name}" in "bundleDependencies", but it is not declared in "dependencies"`);
         }
+
+        if (pkg.peerDependencies && name in pkg.peerDependencies) {
+            throw new Error(`The "package.json" has "${name}" in "bundleDependencies", and also in "peerDependencies"`);
+        }
+
         bundleDependencies[name] = version;
     });
-
-    // verify peer dependencies and dependencies have the same version specs
-    const deps = pkg.dependencies || { };
-    const peerDeps = pkg.peerDependencies || { };
-    for (const module of Object.keys(peerDeps)) {
-        const peerVersion = peerDeps[module];
-        const depVersion = deps[module];
-        if (depVersion && peerVersion !== depVersion) {
-            throw new Error(
-                `The module '${module}' is specified as ${peerVersion} under ` +
-                `"peerDependencieds" and as ${depVersion} under "dependencies"`);
-        }
-    }
 
     const transitiveAssemblies: { [name: string]: spec.Assembly } = {};
     const dependencies =


### PR DESCRIPTION
1) ProjectInfo was verifying that the specified version range in
   peerDependencies is exactly the same as the version range in regular
   dependencies. This is not necessary, the only requirement is that
   the actual concrete dependency version satisfies the peer dependency
   version (which is already checked in _loadDependencies).

2) Assembler was verifying that the concrete version of a library found
   in dependencies was the same as that same concrete library found in
   peerDependencies. But since there's ever only one concrete copy of
   any dependency, this check can never fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
