### PR TITLE
fix: accept variadic arguments after optional arguments

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -994,6 +994,12 @@ export interface NullShouldBeTreatedAsUndefinedData {
     arrayWithThreeElementsAndUndefinedAsSecondArgument: any[];
 }
 
+export class DontComplainAboutVariadicAfterOptional {
+    public optionalAndVariadic(optional?: string, ...things: string[]) {
+        return `${optional} and ${things.join(',')}`;
+    }
+}
+
 /**
  * jsii#298: show default values in sphinx documentation, and respect newlines.
  **/
@@ -1012,7 +1018,7 @@ export interface LoadBalancedFargateServiceProps {
      * @default 256
      */
     cpu?: string;
-  
+
     /**
      * The amount (in MiB) of memory used by the task.
      *
@@ -1034,21 +1040,21 @@ export interface LoadBalancedFargateServiceProps {
      * @default 512
      */
     memoryMiB?: string;
-  
+
     /**
      * The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping.
      *
      * @default 80
      */
     containerPort?: number;
-  
+
     /**
      * Determines whether the Application Load Balancer will be internet-facing
      *
      * @default true
      */
     publicLoadBalancer?: boolean;
-  
+
     /**
      * Determines whether your Fargate Service will be assigned a public IP address.
      *

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1336,6 +1336,40 @@
       ],
       "name": "DoNotRecognizeAnyAsOptional"
     },
+    "jsii-calc.DontComplainAboutVariadicAfterOptional": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DontComplainAboutVariadicAfterOptional",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "optionalAndVariadic",
+          "parameters": [
+            {
+              "name": "optional",
+              "type": {
+                "optional": true,
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "things",
+              "type": {
+                "primitive": "string"
+              },
+              "variadic": true
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          },
+          "variadic": true
+        }
+      ],
+      "name": "DontComplainAboutVariadicAfterOptional"
+    },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DoubleTrouble",
@@ -3612,5 +3646,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "3UAOWGBZzphiNp40hKAbXcsM27uWdwmXnbiPU74ZroU="
+  "fingerprint": "MNdOxOP9VioCZlGXuccW1Zu64GAKSSIg93bLN+YDPYE="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1336,6 +1336,40 @@
       ],
       "name": "DoNotRecognizeAnyAsOptional"
     },
+    "jsii-calc.DontComplainAboutVariadicAfterOptional": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.DontComplainAboutVariadicAfterOptional",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "optionalAndVariadic",
+          "parameters": [
+            {
+              "name": "optional",
+              "type": {
+                "optional": true,
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "things",
+              "type": {
+                "primitive": "string"
+              },
+              "variadic": true
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          },
+          "variadic": true
+        }
+      ],
+      "name": "DontComplainAboutVariadicAfterOptional"
+    },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.DoubleTrouble",
@@ -3612,5 +3646,5 @@
     }
   },
   "version": "0.7.8",
-  "fingerprint": "3UAOWGBZzphiNp40hKAbXcsM27uWdwmXnbiPU74ZroU="
+  "fingerprint": "MNdOxOP9VioCZlGXuccW1Zu64GAKSSIg93bLN+YDPYE="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
@@ -1,0 +1,26 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(DontComplainAboutVariadicAfterOptional), "jsii-calc.DontComplainAboutVariadicAfterOptional", "[]")]
+    public class DontComplainAboutVariadicAfterOptional : DeputyBase
+    {
+        public DontComplainAboutVariadicAfterOptional(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected DontComplainAboutVariadicAfterOptional(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected DontComplainAboutVariadicAfterOptional(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod("optionalAndVariadic", "{\"primitive\":\"string\"}", "[{\"name\":\"optional\",\"type\":{\"primitive\":\"string\",\"optional\":true}},{\"name\":\"things\",\"type\":{\"primitive\":\"string\"}}]")]
+        public virtual string OptionalAndVariadic(string optional, string things)
+        {
+            return InvokeInstanceMethod<string>(new object[]{optional, things});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -37,6 +37,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.DerivedStruct": return software.amazon.jsii.tests.calculator.DerivedStruct.class;
             case "jsii-calc.DoNotOverridePrivates": return software.amazon.jsii.tests.calculator.DoNotOverridePrivates.class;
             case "jsii-calc.DoNotRecognizeAnyAsOptional": return software.amazon.jsii.tests.calculator.DoNotRecognizeAnyAsOptional.class;
+            case "jsii-calc.DontComplainAboutVariadicAfterOptional": return software.amazon.jsii.tests.calculator.DontComplainAboutVariadicAfterOptional.class;
             case "jsii-calc.DoubleTrouble": return software.amazon.jsii.tests.calculator.DoubleTrouble.class;
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
             case "jsii-calc.IFriendlier": return software.amazon.jsii.tests.calculator.IFriendlier.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -1,0 +1,17 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DontComplainAboutVariadicAfterOptional")
+public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii.JsiiObject {
+    protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public DontComplainAboutVariadicAfterOptional() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public java.lang.String optionalAndVariadic(@javax.annotation.Nullable final java.lang.String optional, final java.lang.String... things) {
+        return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(optional), java.util.Arrays.stream(java.util.Objects.requireNonNull(things, "things is required"))).toArray());
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1418,6 +1418,43 @@ DoNotRecognizeAnyAsOptional
       :type _optionalString: string *(optional)*
 
 
+DontComplainAboutVariadicAfterOptional
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DontComplainAboutVariadicAfterOptional()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DontComplainAboutVariadicAfterOptional;
+
+      .. code-tab:: javascript
+
+         const { DontComplainAboutVariadicAfterOptional } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { DontComplainAboutVariadicAfterOptional } from 'jsii-calc';
+
+
+
+
+   .. py:method:: optionalAndVariadic(optional, *things) -> string
+
+      :param optional: 
+      :type optional: string *(optional)*
+      :param \*things: 
+      :type \*things: string
+      :rtype: string
+
+
 DoubleTrouble
 ^^^^^^^^^^^^^
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -951,7 +951,7 @@ export class Assembler implements Emitter {
 
         let optional = false;
         for (const p of parameters) {
-            if (optional && !p.type.optional) {
+            if (optional && !p.type.optional && !p.variadic) {
                 this._diagnostic(node, ts.DiagnosticCategory.Error,
                     `Parameter ${p.name} must be optional since it comes after an optional parameter`);
             }


### PR DESCRIPTION
The following type signature is valid:

    function(optional?: string, ...args: string[])

The function can be called with anywhere from 0-infinity arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
