### PR TITLE
fix(jsii-dotnet-runtime): Proxy parameters should not throw exception.

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1,14 +1,24 @@
 // tslint:disable
-import { Value, Number, IFriendly, IDoublable, MyFirstStruct, StructWithOnlyOptionals, EnumFromScopedModule } from '@scope/jsii-calc-lib';
+import {
+    EnumFromScopedModule,
+    IDoublable,
+    IFriendly,
+    MyFirstStruct,
+    Number,
+    StructWithOnlyOptionals,
+    Value
+} from '@scope/jsii-calc-lib';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { promisify } from 'util';
+import { composition, IFriendlyRandomGenerator, IRandomNumberGenerator, Multiply } from './calculator';
+
 const bundled = require('jsii-calc-bundled');
 import base = require('@scope/jsii-calc-base');
+
 const readFile = promisify(fs.readFile);
-import { composition, IFriendlyRandomGenerator, IRandomNumberGenerator, Multiply } from './calculator';
 
 export enum AllTypesEnum {
     MyEnumValue,
@@ -38,7 +48,7 @@ export class AllTypes {
 
     set booleanProperty(value: boolean) {
         if (typeof(value) !== 'boolean') {
-            throw new Error('not a boolean')
+            throw new Error('not a boolean');
         }
         this.boolValue = value;
     }
@@ -140,7 +150,7 @@ export class AllTypes {
 
     // non-typed (any)
 
-    anyProperty: any
+    anyProperty: any;
     anyArrayProperty: any[] = [];
     anyMapProperty: { [key: string]: any } = {};
 
@@ -197,7 +207,7 @@ export class JSObjectLiteralToNative {
         return {
             propA: 'Hello',
             propB: 102
-        }
+        };
     }
 }
 
@@ -238,11 +248,15 @@ export class RuntimeTypeChecking {
      * Used to verify verification of number of method arguments.
      */
     public methodWithOptionalArguments(arg1: number, arg2: string, arg3?: Date) {
-        arg1; arg2; arg3;
+        arg1;
+        arg2;
+        arg3;
     }
 
     public methodWithDefaultedArguments(arg1: number = 2, arg2?: string, arg3: Date = new Date()) {
-        arg1; arg2; arg3;
+        arg1;
+        arg2;
+        arg3;
     }
 
     public methodWithOptionalAnyArgument(arg?: any) {
@@ -253,13 +267,15 @@ export class RuntimeTypeChecking {
 export class OptionalConstructorArgument {
     public constructor(public readonly arg1: number,
                        public readonly arg2: string,
-                       public readonly arg3?: Date) {}
+                       public readonly arg3?: Date) {
+    }
 }
 
 export class DefaultedConstructorArgument {
     public constructor(public readonly arg1: number = 2,
                        public readonly arg2?: string,
-                       public readonly arg3: Date = new Date()) {}
+                       public readonly arg3: Date = new Date()) {
+    }
 }
 
 export namespace DerivedClassHasNoProperties {
@@ -427,8 +443,13 @@ export class VirtualMethodPlayground {
 }
 
 export class DoubleTrouble implements IFriendlyRandomGenerator {
-    next() { return 12; }
-    hello() { return 'world'; }
+    next() {
+        return 12;
+    }
+
+    hello() {
+        return 'world';
+    }
 }
 
 export class Polymorphism {
@@ -470,6 +491,12 @@ export class JSObjectLiteralForInterface {
         };
     }
 
+}
+
+export class GreetingAugmenter {
+    betterGreeting(friendly: IFriendly): string {
+        return friendly.hello() + ' Let me buy you a drink!';
+    }
 }
 
 /**
@@ -516,7 +543,7 @@ export class GiveMeStructs {
         return {
             optional1: 'optional1FromStructLiteral',
             optional3: false
-        }
+        };
     }
 }
 
@@ -575,6 +602,7 @@ export class AllowedMethodNames {
 
 export interface IReturnsNumber {
     obtainNumber(): IDoublable;
+
     readonly numberProp: Number;
 }
 
@@ -614,7 +642,8 @@ export class VariadicMethod {
 }
 
 export class Statics {
-    constructor(public readonly value: string) { }
+    constructor(public readonly value: string) {
+    }
 
     /**
      * Jsdocs for static method
@@ -643,7 +672,7 @@ export class Statics {
      */
     public static readonly zooBar: { [name: string]: string } = { hello: 'world' };
 
-    private static _instance?: Statics
+    private static _instance?: Statics;
 
     /**
      * Jsdocs for static getter.
@@ -668,58 +697,162 @@ export class Statics {
 
 // https://en.wikipedia.org/wiki/List_of_Java_keywords
 export class JavaReservedWords {
-    public abstract() { }
-    public assert() { }
-    public boolean() { }
-    public break() { }
-    public byte() { }
-    public case() { }
-    public catch() { }
-    public char() { }
-    public class() { }
-    public const() { }
-    public continue() { }
-    public default() { }
-    public double() { }
-    public do() { }
-    public else() { }
-    public enum() { }
-    public extends() { }
-    public false() { }
-    public final() { }
-    public finally() { }
-    public float() { }
-    public for() { }
-    public goto() { }
-    public if() { }
-    public implements() { }
-    public import() { }
-    public instanceof() { }
-    public int() { }
-    public interface() { }
-    public long() { }
-    public native() { }
-    public new() { }
-    public null() { }
-    public package() { }
-    public private() { }
-    public protected() { }
-    public public() { }
-    public return() { }
-    public short() { }
-    public static() { }
-    public strictfp() { }
-    public super() { }
-    public switch() { }
-    public synchronized() { }
-    public this() { }
-    public throw() { }
-    public throws() { }
-    public transient() { }
-    public true() { }
-    public try() { }
-    public void() { }
-    public volatile() { }
+    public abstract() {
+    }
+
+    public assert() {
+    }
+
+    public boolean() {
+    }
+
+    public break() {
+    }
+
+    public byte() {
+    }
+
+    public case() {
+    }
+
+    public catch() {
+    }
+
+    public char() {
+    }
+
+    public class() {
+    }
+
+    public const() {
+    }
+
+    public continue() {
+    }
+
+    public default() {
+    }
+
+    public double() {
+    }
+
+    public do() {
+    }
+
+    public else() {
+    }
+
+    public enum() {
+    }
+
+    public extends() {
+    }
+
+    public false() {
+    }
+
+    public final() {
+    }
+
+    public finally() {
+    }
+
+    public float() {
+    }
+
+    public for() {
+    }
+
+    public goto() {
+    }
+
+    public if() {
+    }
+
+    public implements() {
+    }
+
+    public import() {
+    }
+
+    public instanceof() {
+    }
+
+    public int() {
+    }
+
+    public interface() {
+    }
+
+    public long() {
+    }
+
+    public native() {
+    }
+
+    public new() {
+    }
+
+    public null() {
+    }
+
+    public package() {
+    }
+
+    public private() {
+    }
+
+    public protected() {
+    }
+
+    public public() {
+    }
+
+    public return() {
+    }
+
+    public short() {
+    }
+
+    public static() {
+    }
+
+    public strictfp() {
+    }
+
+    public super() {
+    }
+
+    public switch() {
+    }
+
+    public synchronized() {
+    }
+
+    public this() {
+    }
+
+    public throw() {
+    }
+
+    public throws() {
+    }
+
+    public transient() {
+    }
+
+    public true() {
+    }
+
+    public try() {
+    }
+
+    public void() {
+    }
+
+    public volatile() {
+    }
+
     public while = 'hello';
 }
 
@@ -780,8 +913,8 @@ export class NodeStandardLibrary {
 export class UseCalcBase {
     public hello(): base.Base {
         return {
-            typeName: () => "hello"
-        }
+            typeName: () => 'hello'
+        };
     }
 }
 
@@ -883,7 +1016,7 @@ export class AbstractClassReturner {
     public get returnAbstractFromProperty(): AbstractClassBase {
         return {
             abstractProperty: 'hello-abstract-property'
-        }
+        };
     }
 }
 
@@ -929,6 +1062,7 @@ export class ClassWithPrivateConstructorAndAutomaticProperties implements Interf
 
 export interface IInterfaceWithMethods {
     readonly value: string;
+
     doThings(): void;
 }
 
@@ -953,7 +1087,7 @@ export class DoNotRecognizeAnyAsOptional {
  * jsii#282, aws-cdk#157: null should be treated as "undefined"
  */
 export class NullShouldBeTreatedAsUndefined {
-    public changeMeToUndefined? = "hello";
+    public changeMeToUndefined? = 'hello';
 
     constructor(_param1: string, optional?: any) {
         if (optional !== undefined) {
@@ -978,7 +1112,7 @@ export class NullShouldBeTreatedAsUndefined {
         }
 
         if (array[1] !== undefined) {
-            throw new Error('Expected arrayWithThreeElementsAndUndefinedAsSecondArgument[1] to be undefined: ' + JSON.stringify(input))
+            throw new Error('Expected arrayWithThreeElementsAndUndefinedAsSecondArgument[1] to be undefined: ' + JSON.stringify(input));
         }
     }
 

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1481,6 +1481,31 @@
         }
       ]
     },
+    "jsii-calc.GreetingAugmenter": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.GreetingAugmenter",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "betterGreeting",
+          "parameters": [
+            {
+              "name": "friendly",
+              "type": {
+                "fqn": "@scope/jsii-calc-lib.IFriendly"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "name": "GreetingAugmenter"
+    },
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
@@ -3646,5 +3671,5 @@
     }
   },
   "version": "0.7.10",
-  "fingerprint": "rxx0uqvwitnI8U0/tQLwhghDWxc85lS6Gghk4xDtIx0="
+  "fingerprint": "FD4+eWzYL86xxcqBEJh/D6O533Bbjwo/LHD4si6frmg="
 }

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -708,6 +708,18 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             Assert.Equal((double) 42, gen.Next());
         }
 
+        [Fact(DisplayName = Prefix + nameof(TestInterfaceParameter))]
+        public void TestInterfaceParameter()
+        {
+            var obj = new JSObjectLiteralForInterface();
+            var friendly = obj.GiveMeFriendly();
+            Assert.Equal("I am literally friendly!", friendly.Hello());
+
+            var greetingAugmenter = new GreetingAugmenter();
+            var betterGreeting = greetingAugmenter.BetterGreeting(friendly);
+            Assert.Equal("I am literally friendly! Let me buy you a drink!", betterGreeting);
+        }
+
         [Fact(DisplayName = Prefix + nameof(Structs_StepBuilders), Skip = "There is no fluent API for C#")]
         public void Structs_StepBuilders()
         {
@@ -842,7 +854,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             obj.GiveMeUndefinedInsideAnObject(new NullShouldBeTreatedAsUndefinedData
             {
                 ThisShouldBeUndefined = null,
-                ArrayWithThreeElementsAndUndefinedAsSecondArgument = new[] { "hello", null, "world" }
+                ArrayWithThreeElementsAndUndefinedAsSecondArgument = new[] {"hello", null, "world"}
             });
 
             // property

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -36,17 +36,6 @@ namespace Amazon.JSII.Runtime.Services.Converters
 
             Type type = value.GetType();
 
-            /*if (type.GetCustomAttribute<JsiiTypeProxyAttribute>() != null)
-            {
-                throw new ArgumentException
-                (
-                    "Interface proxies are one-way (jsii to framework). " +
-                    "They may not be converted back to jsii. " +
-                    "Instead, use a concrete type that implements the interface.",
-                    nameof(value)
-                );
-            }*/
-
             if (value is DeputyBase deputyValue)
             {
                 result = deputyValue.Reference;

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -1,10 +1,11 @@
-﻿using Amazon.JSII.JsonModel.Spec;
-using Amazon.JSII.Runtime.Deputy;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Amazon.JSII.JsonModel.Spec;
+using Amazon.JSII.Runtime.Deputy;
+using Newtonsoft.Json.Linq;
+using Type = System.Type;
 
 namespace Amazon.JSII.Runtime.Services.Converters
 {
@@ -33,9 +34,9 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return true;
             }
 
-            System.Type type = value.GetType();
+            Type type = value.GetType();
 
-            if (type.GetCustomAttribute<JsiiTypeProxyAttribute>() != null)
+            /*if (type.GetCustomAttribute<JsiiTypeProxyAttribute>() != null)
             {
                 throw new ArgumentException
                 (
@@ -44,7 +45,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                     "Instead, use a concrete type that implements the interface.",
                     nameof(value)
                 );
-            }
+            }*/
 
             if (value is DeputyBase deputyValue)
             {
@@ -56,7 +57,8 @@ namespace Amazon.JSII.Runtime.Services.Converters
             return false;
         }
 
-        protected override bool TryConvertEnum(object value, bool isOptional, string fullyQualifiedName, out object result)
+        protected override bool TryConvertEnum(object value, bool isOptional, string fullyQualifiedName,
+            out object result)
         {
             if (value == null)
             {
@@ -64,7 +66,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return isOptional;
             }
 
-            System.Type valueType = value.GetType();
+            Type valueType = value.GetType();
             JsiiEnumAttribute attribute = value.GetType().GetCustomAttribute<JsiiEnumAttribute>();
 
             if (attribute == null || attribute.FullyQualifiedName != fullyQualifiedName)
@@ -121,7 +123,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
 
             if (value.GetType().IsAssignableFrom(typeof(DateTime)))
             {
-                result = new DateValue((DateTime)value);
+                result = new DateValue((DateTime) value);
                 return true;
             }
 
@@ -175,7 +177,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
 
             if (value.GetType().IsAssignableFrom(typeof(string)))
             {
-                result = (string)value;
+                result = (string) value;
                 return true;
             }
 
@@ -183,7 +185,8 @@ namespace Amazon.JSII.Runtime.Services.Converters
             return false;
         }
 
-        protected override bool TryConvertArray(IReferenceMap referenceMap, TypeReference elementType, object value, out object result)
+        protected override bool TryConvertArray(IReferenceMap referenceMap, TypeReference elementType, object value,
+            out object result)
         {
             if (value == null)
             {
@@ -197,7 +200,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return false;
             }
 
-            Array array = (Array)value;
+            Array array = (Array) value;
 
             JArray resultArray = new JArray();
             foreach (object element in array)
@@ -220,7 +223,8 @@ namespace Amazon.JSII.Runtime.Services.Converters
             return true;
         }
 
-        protected override bool TryConvertMap(IReferenceMap referenceMap, TypeReference elementType, object value, out object result)
+        protected override bool TryConvertMap(IReferenceMap referenceMap, TypeReference elementType, object value,
+            out object result)
         {
             if (value == null)
             {
@@ -228,33 +232,36 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return true;
             }
 
-            System.Type valueType = value.GetType();
-            System.Type dictionaryInterface = valueType.GetInterfaces()
+            Type valueType = value.GetType();
+            Type dictionaryInterface = valueType.GetInterfaces()
                 .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 
-            if (dictionaryInterface == null || !dictionaryInterface.GetGenericArguments()[0].IsAssignableFrom(typeof(string)))
+            if (dictionaryInterface == null ||
+                !dictionaryInterface.GetGenericArguments()[0].IsAssignableFrom(typeof(string)))
             {
                 result = null;
                 return false;
             }
 
-            IEnumerable<string> keys = (IEnumerable<string>)valueType.GetProperty("Keys").GetValue(value);
+            IEnumerable<string> keys = (IEnumerable<string>) valueType.GetProperty("Keys").GetValue(value);
             PropertyInfo indexer = ReflectionUtils.GetIndexer(valueType);
 
             JObject resultObject = new JObject();
             foreach (string key in keys)
             {
-                object element = indexer.GetValue(value, new object[] { key });
+                object element = indexer.GetValue(value, new object[] {key});
                 if (!TryConvert(elementType, referenceMap, element, out object convertedElement))
                 {
                     result = null;
                     return false;
                 }
 
-                if (convertedElement != null && !(convertedElement is String) && !convertedElement.GetType().IsPrimitive)
+                if (convertedElement != null && !(convertedElement is String) &&
+                    !convertedElement.GetType().IsPrimitive)
                 {
                     convertedElement = JObject.FromObject(convertedElement);
                 }
+
                 resultObject.Add(new JProperty(key, convertedElement));
             }
 
@@ -269,7 +276,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
             return InferType(referenceMap, value.GetType());
         }
 
-        TypeReference InferType(IReferenceMap referenceMap, System.Type type)
+        TypeReference InferType(IReferenceMap referenceMap, Type type)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
 
@@ -322,7 +329,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 );
             }
 
-            System.Type dictionaryInterface = type.GetInterfaces()
+            Type dictionaryInterface = type.GetInterfaces()
                 .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
             if (dictionaryInterface != null)
             {
@@ -331,7 +338,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                     throw new ArgumentException("All dictionaries must have string keys", nameof(type));
                 }
 
-                System.Type elementType = dictionaryInterface.GetGenericArguments()[1];
+                Type elementType = dictionaryInterface.GetGenericArguments()[1];
                 return new TypeReference
                 (
                     collection: new CollectionTypeReference

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -14,6 +14,7 @@ import software.amazon.jsii.tests.calculator.DerivedStruct;
 import software.amazon.jsii.tests.calculator.DoNotOverridePrivates;
 import software.amazon.jsii.tests.calculator.DoubleTrouble;
 import software.amazon.jsii.tests.calculator.GiveMeStructs;
+import software.amazon.jsii.tests.calculator.GreetingAugmenter;
 import software.amazon.jsii.tests.calculator.IFriendlier;
 import software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator;
 import software.amazon.jsii.tests.calculator.InterfaceWithProperties;
@@ -703,6 +704,17 @@ public class ComplianceTest {
         IFriendlyRandomGenerator gen = obj.giveMeFriendlyGenerator();
         assertEquals("giveMeFriendlyGenerator", gen.hello());
         assertEquals(42, gen.next());
+    }
+
+    @Test
+    public void testInterfaceParameter() {
+        JSObjectLiteralForInterface obj = new JSObjectLiteralForInterface();
+        IFriendly friendly = obj.giveMeFriendly();
+        assertEquals("I am literally friendly!", friendly.hello());
+
+        GreetingAugmenter greetingAugmenter = new GreetingAugmenter();
+        String betterGreeting = greetingAugmenter.betterGreeting(friendly);
+        assertEquals("I am literally friendly! Let me buy you a drink!", betterGreeting);
     }
 
     @Test

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1481,6 +1481,31 @@
         }
       ]
     },
+    "jsii-calc.GreetingAugmenter": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.GreetingAugmenter",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "betterGreeting",
+          "parameters": [
+            {
+              "name": "friendly",
+              "type": {
+                "fqn": "@scope/jsii-calc-lib.IFriendly"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "name": "GreetingAugmenter"
+    },
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
@@ -3646,5 +3671,5 @@
     }
   },
   "version": "0.7.10",
-  "fingerprint": "rxx0uqvwitnI8U0/tQLwhghDWxc85lS6Gghk4xDtIx0="
+  "fingerprint": "FD4+eWzYL86xxcqBEJh/D6O533Bbjwo/LHD4si6frmg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(GreetingAugmenter), "jsii-calc.GreetingAugmenter", "[]")]
+    public class GreetingAugmenter : DeputyBase
+    {
+        public GreetingAugmenter(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected GreetingAugmenter(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected GreetingAugmenter(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod("betterGreeting", "{\"primitive\":\"string\"}", "[{\"name\":\"friendly\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}]")]
+        public virtual string BetterGreeting(IIFriendly friendly)
+        {
+            return InvokeInstanceMethod<string>(new object[]{friendly});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -40,6 +40,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.DontComplainAboutVariadicAfterOptional": return software.amazon.jsii.tests.calculator.DontComplainAboutVariadicAfterOptional.class;
             case "jsii-calc.DoubleTrouble": return software.amazon.jsii.tests.calculator.DoubleTrouble.class;
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
+            case "jsii-calc.GreetingAugmenter": return software.amazon.jsii.tests.calculator.GreetingAugmenter.class;
             case "jsii-calc.IFriendlier": return software.amazon.jsii.tests.calculator.IFriendlier.class;
             case "jsii-calc.IFriendlyRandomGenerator": return software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class;
             case "jsii-calc.IInterfaceThatShouldNotBeADataType": return software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -1,0 +1,17 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.GreetingAugmenter")
+public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
+    protected GreetingAugmenter(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public GreetingAugmenter() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public java.lang.String betterGreeting(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
+        return this.jsiiCall("betterGreeting", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(friendly, "friendly is required")).toArray());
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1572,6 +1572,41 @@ GiveMeStructs
       :type: :py:class:`@scope/jsii-calc-lib.StructWithOnlyOptionals`\  *(readonly)*
 
 
+GreetingAugmenter
+^^^^^^^^^^^^^^^^^
+
+.. py:class:: GreetingAugmenter()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.GreetingAugmenter;
+
+      .. code-tab:: javascript
+
+         const { GreetingAugmenter } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { GreetingAugmenter } from 'jsii-calc';
+
+
+
+
+   .. py:method:: betterGreeting(friendly) -> string
+
+      :param friendly: 
+      :type friendly: :py:class:`@scope/jsii-calc-lib.IFriendly`\ 
+      :rtype: string
+
+
 IFriendlier (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Proxy types when passed as parameters were throwing an exception in the dotnet runtime. Removing the check and throw did not have an
adverse effect on the runtime, so it was removed.

Compliance test added that passes an interface as a parameter.

Fixes #316

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
