### PR TITLE
feat: JSII_AGENT

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1196,3 +1196,15 @@ export interface LoadBalancedFargateServiceProps {
      */
     publicTasks?: boolean;
 }
+
+/**
+ * Host runtime version should be set via JSII_AGENT
+ */
+export class JsiiAgent {
+    /**
+     * Returns the value of the JSII_AGENT environment variable.
+     */
+    public static get jsiiAgent(): string | undefined {
+        return process.env.JSII_AGENT;
+    }
+};

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3762,5 +3762,5 @@
     }
   },
   "version": "0.7.11",
-  "fingerprint": "Wd0MWG0v1qaBoROkgYUltcLONrS4+yQU9Y+lwHTb5NA="
+  "fingerprint": "l8bUuUzVdVn151P/XjDEVN9kHkLfJ+d5fmgZVODpQkg="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -2057,6 +2057,32 @@
         }
       ]
     },
+    "jsii-calc.JsiiAgent": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "comment": "Host runtime version should be set via JSII_AGENT"
+      },
+      "fqn": "jsii-calc.JsiiAgent",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "JsiiAgent",
+      "properties": [
+        {
+          "docs": {
+            "comment": "Returns the value of the JSII_AGENT environment variable."
+          },
+          "immutable": true,
+          "name": "jsiiAgent",
+          "static": true,
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.LoadBalancedFargateServiceProps": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -3671,5 +3697,5 @@
     }
   },
   "version": "0.7.11",
-  "fingerprint": "2o7FtEirv0LpuaJ1G+wAxoHTW7FHr4U1taZ5GcVYt2o="
+  "fingerprint": "Wd0MWG0v1qaBoROkgYUltcLONrS4+yQU9Y+lwHTb5NA="
 }

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -861,6 +861,12 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             obj.ChangeMeToUndefined = null;
             obj.VerifyPropertyIsUndefined();
         }
+        
+        [Fact(DisplayName = Prefix + nameof(JsiiAgent))]
+        public void JsiiAgent()
+        {
+            Assert.Equal("DotNet/" + Environment.Version.ToString(), JsiiAgent_.JsiiAgent);
+        }
 
         class NumberReturner : DeputyBase, IIReturnsNumber
         {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/NodeProcess.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/NodeProcess.cs
@@ -26,6 +26,8 @@ namespace Amazon.JSII.Runtime.Services
                 }
             };
 
+            _process.StartInfo.EnvironmentVariables.Add("JSII_AGENT", "DotNet/" + Environment.Version.ToString());
+
             _logger.LogDebug("Starting jsii runtime...");
             _logger.LogDebug($"{_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
 

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -37,6 +37,7 @@ import software.amazon.jsii.tests.calculator.Sum;
 import software.amazon.jsii.tests.calculator.SyncVirtualMethods;
 import software.amazon.jsii.tests.calculator.UnionProperties;
 import software.amazon.jsii.tests.calculator.UsesInterfaceWithProperties;
+import software.amazon.jsii.tests.calculator.JsiiAgent;
 import software.amazon.jsii.tests.calculator.composition.CompositeOperation;
 import software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule;
 import software.amazon.jsii.tests.calculator.lib.IFriendly;
@@ -951,6 +952,11 @@ public class ComplianceTest {
                 .build());
         obj.setChangeMeToUndefined(null);
         obj.verifyPropertyIsUndefined();
+    }
+    
+    @Test
+    public void testJsiiAgent() {
+        assertEquals("Java/" + System.getProperty("java.version"), JsiiAgent.getJsiiAgent());
     }
 
     static class MulTen extends Multiply {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -222,6 +222,8 @@ public final class JsiiRuntime {
         if (traceEnabled) {
             pb.environment().put("JSII_DEBUG", "1");
         }
+        
+        pb.environment().put("JSII_AGENT", "Java/" + System.getProperty("java.version"));
 
         try {
             this.childProcess = pb.start();

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -959,6 +959,10 @@ defineTest('nulls are converted to undefined - properties', async (_test, sandbo
     sandbox.invoke({ objref, method: 'verifyPropertyIsUndefined' });
 });
 
+defineTest('JSII_AGENT is undefined in node.js', async (test, sandbox) => {
+    test.equal(sandbox.sget({ fqn: 'jsii-calc.JsiiAgent', property: 'jsiiAgent' }).value, undefined);
+});
+
 // =================================================================================================
 
 const testNames: { [name: string]: boolean } = { };

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3762,5 +3762,5 @@
     }
   },
   "version": "0.7.11",
-  "fingerprint": "Wd0MWG0v1qaBoROkgYUltcLONrS4+yQU9Y+lwHTb5NA="
+  "fingerprint": "l8bUuUzVdVn151P/XjDEVN9kHkLfJ+d5fmgZVODpQkg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -2057,6 +2057,32 @@
         }
       ]
     },
+    "jsii-calc.JsiiAgent": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "comment": "Host runtime version should be set via JSII_AGENT"
+      },
+      "fqn": "jsii-calc.JsiiAgent",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "name": "JsiiAgent",
+      "properties": [
+        {
+          "docs": {
+            "comment": "Returns the value of the JSII_AGENT environment variable."
+          },
+          "immutable": true,
+          "name": "jsiiAgent",
+          "static": true,
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.LoadBalancedFargateServiceProps": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -3671,5 +3697,5 @@
     }
   },
   "version": "0.7.11",
-  "fingerprint": "2o7FtEirv0LpuaJ1G+wAxoHTW7FHr4U1taZ5GcVYt2o="
+  "fingerprint": "Wd0MWG0v1qaBoROkgYUltcLONrS4+yQU9Y+lwHTb5NA="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JsiiAgent_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JsiiAgent_.cs
@@ -1,0 +1,28 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Host runtime version should be set via JSII_AGENT</summary>
+    [JsiiClass(typeof(JsiiAgent_), "jsii-calc.JsiiAgent", "[]")]
+    public class JsiiAgent_ : DeputyBase
+    {
+        public JsiiAgent_(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected JsiiAgent_(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected JsiiAgent_(DeputyProps props): base(props)
+        {
+        }
+
+        /// <summary>Returns the value of the JSII_AGENT environment variable.</summary>
+        [JsiiProperty("jsiiAgent", "{\"primitive\":\"string\",\"optional\":true}")]
+        public static string JsiiAgent
+        {
+            get => GetStaticProperty<string>(typeof(JsiiAgent_));
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -59,6 +59,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.JSObjectLiteralToNative": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNative.class;
             case "jsii-calc.JSObjectLiteralToNativeClass": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class;
             case "jsii-calc.JavaReservedWords": return software.amazon.jsii.tests.calculator.JavaReservedWords.class;
+            case "jsii-calc.JsiiAgent": return software.amazon.jsii.tests.calculator.JsiiAgent.class;
             case "jsii-calc.LoadBalancedFargateServiceProps": return software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps.class;
             case "jsii-calc.Multiply": return software.amazon.jsii.tests.calculator.Multiply.class;
             case "jsii-calc.MutableObjectLiteral": return software.amazon.jsii.tests.calculator.MutableObjectLiteral.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
@@ -1,0 +1,24 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Host runtime version should be set via JSII_AGENT
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JsiiAgent")
+public class JsiiAgent extends software.amazon.jsii.JsiiObject {
+    protected JsiiAgent(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public JsiiAgent() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    /**
+     * Returns the value of the JSII_AGENT environment variable.
+     */
+    @javax.annotation.Nullable
+    public static java.lang.String getJsiiAgent() {
+        return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.JsiiAgent.class, "jsiiAgent", java.lang.String.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -2596,6 +2596,47 @@ JavaReservedWords
       :type: string
 
 
+JsiiAgent
+^^^^^^^^^
+
+.. py:class:: JsiiAgent()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.JsiiAgent;
+
+      .. code-tab:: javascript
+
+         const { JsiiAgent } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { JsiiAgent } from 'jsii-calc';
+
+
+
+   Host runtime version should be set via JSII_AGENT
+
+
+
+
+   .. py:attribute:: jsiiAgent
+
+      Returns the value of the JSII_AGENT environment variable.
+
+
+
+      :type: string *(optional)* *(readonly)* *(static)*
+
+
 LoadBalancedFargateServiceProps (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -1337,11 +1337,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1354,15 +1356,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1465,7 +1470,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1475,6 +1481,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1487,17 +1494,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -1514,6 +1524,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1586,7 +1597,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1596,6 +1608,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1701,6 +1714,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Language runtimes now set JSII_AGENT to include the runtime version
such as "DotNet/1.2.3.4" or "Java/1.8.44".

Fixes #324

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
