### PR TITLE
fix(jsii-dotnet-runtime): Fix EPIPE on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules/
 lerna-debug.log
 .DS_Store
 .idea
-dist
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 lerna-debug.log
 .DS_Store
 .idea
+dist

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -861,7 +861,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             obj.ChangeMeToUndefined = null;
             obj.VerifyPropertyIsUndefined();
         }
-        
+
         [Fact(DisplayName = Prefix + nameof(JsiiAgent))]
         public void JsiiAgent()
         {

--- a/packages/jsii-dotnet-runtime/.gitignore
+++ b/packages/jsii-dotnet-runtime/.gitignore
@@ -23,3 +23,4 @@ coverage/
 bin/
 cli/
 obj/
+*.DotSettings.user

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Client/RuntimeTests.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Client/RuntimeTests.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using Amazon.JSII.Runtime.Services;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using Xunit;
+
+namespace Amazon.JSII.Runtime.UnitTests.Client
+{
+    public class RuntimeTests
+    {
+        private const string Prefix = "Runtime.";
+
+        private INodeProcess _nodeProcessMock;
+        private TextReader _standardOutputMock;
+        private TextReader _standardErrorMock;
+
+        private IRuntime _sut;
+
+        public RuntimeTests()
+        {
+            _nodeProcessMock = Substitute.For<INodeProcess>();
+            _standardOutputMock = Substitute.For<TextReader>();
+            _standardErrorMock = Substitute.For<TextReader>();
+
+            _nodeProcessMock.StandardOutput.Returns(_standardOutputMock);
+            _nodeProcessMock.StandardError.Returns(_standardErrorMock);
+
+            _sut = new Services.Runtime(_nodeProcessMock);
+        }
+
+        [Fact(DisplayName = Prefix + nameof(ThrowsJsiiExceptionWhenResponseNotReceived))]
+        public void ThrowsJsiiExceptionWhenResponseNotReceived()
+        {
+            _nodeProcessMock.StandardOutput.ReadLine().ReturnsNull();
+            _nodeProcessMock.StandardError.ReadToEnd().Returns("This is a test.");
+
+            var ex = Assert.Throws<JsiiException>(() => _sut.ReadResponse());
+            Assert.Equal("Child process exited unexpectedly: This is a test.", ex.Message);
+        }
+    }
+}

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/JsiiException.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/JsiiException.cs
@@ -1,11 +1,15 @@
-﻿using Amazon.JSII.JsonModel.Api.Response;
-using System;
+﻿using System;
+using Amazon.JSII.JsonModel.Api.Response;
 
 namespace Amazon.JSII.Runtime
 {
     public class JsiiException : Exception
     {
         public ErrorResponse ErrorResponse { get; }
+
+        public JsiiException(string message) : base(message)
+        {
+        }
 
         public JsiiException(string message, Exception innerException)
             : base(message, innerException)

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/INodeProcess.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/INodeProcess.cs
@@ -5,8 +5,10 @@ namespace Amazon.JSII.Runtime.Services
 {
     public interface INodeProcess : IDisposable
     {
-        StreamWriter StandardInput { get; }
+        TextWriter StandardInput { get; }
 
-        StreamReader StandardOutput { get; }
+        TextReader StandardOutput { get; }
+
+        TextReader StandardError { get; }
     }
 }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/NodeProcess.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/NodeProcess.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
+using Microsoft.Extensions.Logging;
 
 namespace Amazon.JSII.Runtime.Services
 {
@@ -23,10 +23,11 @@ namespace Amazon.JSII.Runtime.Services
                     Arguments = "--max-old-space-size=4096 " + jsiiRuntimeProvider.JsiiRuntimePath,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
+                    RedirectStandardError = true
                 }
             };
 
-            _process.StartInfo.EnvironmentVariables.Add("JSII_AGENT", "DotNet/" + Environment.Version.ToString());
+            _process.StartInfo.EnvironmentVariables.Add("JSII_AGENT", "DotNet/" + Environment.Version);
 
             _logger.LogDebug("Starting jsii runtime...");
             _logger.LogDebug($"{_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
@@ -34,12 +35,17 @@ namespace Amazon.JSII.Runtime.Services
             _process.Start();
         }
 
-        public StreamWriter StandardInput => _process.StandardInput;
+        public TextWriter StandardInput => _process.StandardInput;
 
-        public StreamReader StandardOutput => _process.StandardOutput;
+        public TextReader StandardOutput => _process.StandardOutput;
+
+        public TextReader StandardError => _process.StandardError;
 
         void IDisposable.Dispose()
         {
+            StandardInput.Dispose();
+            StandardOutput.Dispose();
+            StandardError.Dispose();
             _process.Dispose();
         }
     }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Runtime.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Runtime.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Amazon.JSII.Runtime.Services
 {
@@ -9,11 +10,22 @@ namespace Amazon.JSII.Runtime.Services
         public Runtime(INodeProcess nodeProcess)
         {
             _nodeProcess = nodeProcess ?? throw new ArgumentNullException(nameof(nodeProcess));
+            if (Environment.GetEnvironmentVariable("JSII_DEBUG") != null)
+            {
+                Task.Run(() => RedirectStandardError());
+            }
         }
 
         public string ReadResponse()
         {
-            return _nodeProcess.StandardOutput.ReadLine();
+            var response = _nodeProcess.StandardOutput.ReadLine();
+            if (string.IsNullOrEmpty(response))
+            {
+                var errorMessage = _nodeProcess.StandardError.ReadToEnd();
+                throw new JsiiException("Child process exited unexpectedly: " + errorMessage);
+            }
+
+            return response;
         }
 
         public void WriteRequest(string request)
@@ -30,6 +42,14 @@ namespace Amazon.JSII.Runtime.Services
 
             _nodeProcess.StandardInput.WriteLine(request);
             _nodeProcess.StandardInput.Flush();
+        }
+
+        private void RedirectStandardError()
+        {
+            while (true)
+            {
+                Console.WriteLine(_nodeProcess.StandardError.ReadLine());
+            }
         }
     }
 }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Runtime.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Runtime.cs
@@ -48,7 +48,7 @@ namespace Amazon.JSII.Runtime.Services
         {
             while (true)
             {
-                Console.WriteLine(_nodeProcess.StandardError.ReadLine());
+                Console.Error.WriteLine(_nodeProcess.StandardError.ReadLine());
             }
         }
     }


### PR DESCRIPTION
* The JSII runtime for DotNet applications did not properly dispose of the IO streams in use for communication between the dotnet and jsii processes. This has been fixed, which solves the EPIPE error.
* During this investigation, it was found that the DotNet runtime did not redirect stderr, which disabled the use of JSII_DEBUG. Fixed.
* If the node process is closed unexpectedly, the application will now throw an exception with the contents of STDERR.
* Added Unit Test for node process closing unexpectedly.
* Added gitignore rule for "dist" folders, which are created by pack.

Fixes #341

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
