### PR TITLE
chore: Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-regex": {
@@ -26,7 +26,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argparse": {
@@ -35,7 +35,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"asn1": {
@@ -44,7 +44,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -71,44 +71,6 @@
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -122,7 +84,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bind-obj-methods": {
@@ -143,7 +105,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -171,9 +133,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"clean-yaml-object": {
@@ -215,14 +177,8 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
-		},
-		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -242,12 +198,12 @@
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"dev": true,
 			"requires": {
-				"growl": "1.10.5",
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.88.0"
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"cross-spawn": {
@@ -256,8 +212,8 @@
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -266,7 +222,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -297,8 +253,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ejs": {
@@ -317,12 +273,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
 		"events-to-array": {
@@ -361,8 +311,8 @@
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "4.0.2",
-				"signal-exit": "3.0.2"
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"forever-agent": {
@@ -377,9 +327,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-exists-cached": {
@@ -406,7 +356,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -415,12 +365,12 @@
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -447,17 +397,8 @@
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "2.1.1"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -472,9 +413,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"imurmurhash": {
@@ -489,8 +430,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -523,20 +464,14 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -588,45 +523,45 @@
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"chalk": "2.4.1",
-				"cmd-shim": "2.0.2",
-				"columnify": "1.5.4",
-				"command-join": "2.0.0",
-				"conventional-changelog-cli": "1.3.22",
-				"conventional-recommended-bump": "1.2.1",
-				"dedent": "0.7.0",
-				"execa": "0.8.0",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"get-port": "3.2.0",
-				"glob": "7.1.3",
-				"glob-parent": "3.1.0",
-				"globby": "6.1.0",
-				"graceful-fs": "4.1.11",
-				"hosted-git-info": "2.7.1",
-				"inquirer": "3.3.0",
-				"is-ci": "1.2.0",
-				"load-json-file": "4.0.0",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"npmlog": "4.1.2",
-				"p-finally": "1.0.0",
-				"package-json": "4.0.1",
-				"path-exists": "3.0.0",
-				"read-cmd-shim": "1.0.1",
-				"read-pkg": "3.0.0",
-				"rimraf": "2.6.2",
-				"safe-buffer": "5.1.2",
-				"semver": "5.5.1",
-				"signal-exit": "3.0.2",
-				"slash": "1.0.0",
-				"strong-log-transformer": "1.0.6",
-				"temp-write": "3.4.0",
-				"write-file-atomic": "2.3.0",
-				"write-json-file": "2.3.0",
-				"write-pkg": "3.2.0",
-				"yargs": "8.0.2"
+				"async": "^1.5.0",
+				"chalk": "^2.1.0",
+				"cmd-shim": "^2.0.2",
+				"columnify": "^1.5.4",
+				"command-join": "^2.0.0",
+				"conventional-changelog-cli": "^1.3.13",
+				"conventional-recommended-bump": "^1.2.1",
+				"dedent": "^0.7.0",
+				"execa": "^0.8.0",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.1",
+				"get-port": "^3.2.0",
+				"glob": "^7.1.2",
+				"glob-parent": "^3.1.0",
+				"globby": "^6.1.0",
+				"graceful-fs": "^4.1.11",
+				"hosted-git-info": "^2.5.0",
+				"inquirer": "^3.2.2",
+				"is-ci": "^1.0.10",
+				"load-json-file": "^4.0.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"package-json": "^4.0.1",
+				"path-exists": "^3.0.0",
+				"read-cmd-shim": "^1.0.1",
+				"read-pkg": "^3.0.0",
+				"rimraf": "^2.6.1",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.4.1",
+				"signal-exit": "^3.0.2",
+				"slash": "^1.0.0",
+				"strong-log-transformer": "^1.0.6",
+				"temp-write": "^3.3.0",
+				"write-file-atomic": "^2.3.0",
+				"write-json-file": "^2.2.0",
+				"write-pkg": "^3.1.0",
+				"yargs": "^8.0.2"
 			},
 			"dependencies": {
 				"JSONStream": {
@@ -635,8 +570,8 @@
 					"integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
 					"dev": true,
 					"requires": {
-						"jsonparse": "1.3.1",
-						"through": "2.3.8"
+						"jsonparse": "^1.2.0",
+						"through": ">=2.2.7 <3"
 					}
 				},
 				"add-stream": {
@@ -651,9 +586,9 @@
 					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -664,7 +599,7 @@
 				},
 				"ansi-escapes": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
 					"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 					"dev": true
 				},
@@ -686,8 +621,8 @@
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"array-find-index": {
@@ -708,7 +643,7 @@
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"dev": true,
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -748,9 +683,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -774,8 +709,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chardet": {
@@ -796,7 +731,7 @@
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "2.0.0"
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"cli-width": {
@@ -812,8 +747,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -838,8 +773,8 @@
 					"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"mkdirp": "0.5.1"
+						"graceful-fs": "^4.1.2",
+						"mkdirp": "~0.5.0"
 					}
 				},
 				"code-point-at": {
@@ -854,8 +789,8 @@
 					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 					"dev": true,
 					"requires": {
-						"strip-ansi": "3.0.1",
-						"wcwidth": "1.0.1"
+						"strip-ansi": "^3.0.0",
+						"wcwidth": "^1.0.0"
 					}
 				},
 				"command-join": {
@@ -870,8 +805,8 @@
 					"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 					"dev": true,
 					"requires": {
-						"array-ify": "1.0.0",
-						"dot-prop": "3.0.0"
+						"array-ify": "^1.0.0",
+						"dot-prop": "^3.0.0"
 					}
 				},
 				"concat-stream": {
@@ -880,10 +815,10 @@
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "1.1.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.6",
-						"typedarray": "0.0.6"
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					}
 				},
 				"console-control-strings": {
@@ -898,17 +833,17 @@
 					"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
 					"dev": true,
 					"requires": {
-						"conventional-changelog-angular": "1.6.6",
-						"conventional-changelog-atom": "0.2.8",
-						"conventional-changelog-codemirror": "0.3.8",
-						"conventional-changelog-core": "2.0.11",
-						"conventional-changelog-ember": "0.3.12",
-						"conventional-changelog-eslint": "1.0.9",
-						"conventional-changelog-express": "0.3.6",
-						"conventional-changelog-jquery": "0.1.0",
-						"conventional-changelog-jscs": "0.1.0",
-						"conventional-changelog-jshint": "0.3.8",
-						"conventional-changelog-preset-loader": "1.1.8"
+						"conventional-changelog-angular": "^1.6.6",
+						"conventional-changelog-atom": "^0.2.8",
+						"conventional-changelog-codemirror": "^0.3.8",
+						"conventional-changelog-core": "^2.0.11",
+						"conventional-changelog-ember": "^0.3.12",
+						"conventional-changelog-eslint": "^1.0.9",
+						"conventional-changelog-express": "^0.3.6",
+						"conventional-changelog-jquery": "^0.1.0",
+						"conventional-changelog-jscs": "^0.1.0",
+						"conventional-changelog-jshint": "^0.3.8",
+						"conventional-changelog-preset-loader": "^1.1.8"
 					}
 				},
 				"conventional-changelog-angular": {
@@ -917,8 +852,8 @@
 					"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"q": "1.5.1"
+						"compare-func": "^1.3.1",
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-atom": {
@@ -927,7 +862,7 @@
 					"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-cli": {
@@ -936,11 +871,11 @@
 					"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
 					"dev": true,
 					"requires": {
-						"add-stream": "1.0.0",
-						"conventional-changelog": "1.1.24",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"tempfile": "1.1.1"
+						"add-stream": "^1.0.0",
+						"conventional-changelog": "^1.1.24",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"tempfile": "^1.1.1"
 					}
 				},
 				"conventional-changelog-codemirror": {
@@ -949,7 +884,7 @@
 					"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-core": {
@@ -958,19 +893,19 @@
 					"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
 					"dev": true,
 					"requires": {
-						"conventional-changelog-writer": "3.0.9",
-						"conventional-commits-parser": "2.1.7",
-						"dateformat": "3.0.3",
-						"get-pkg-repo": "1.4.0",
-						"git-raw-commits": "1.3.6",
-						"git-remote-origin-url": "2.0.0",
-						"git-semver-tags": "1.3.6",
-						"lodash": "4.17.10",
-						"normalize-package-data": "2.4.0",
-						"q": "1.5.1",
-						"read-pkg": "1.1.0",
-						"read-pkg-up": "1.0.1",
-						"through2": "2.0.3"
+						"conventional-changelog-writer": "^3.0.9",
+						"conventional-commits-parser": "^2.1.7",
+						"dateformat": "^3.0.0",
+						"get-pkg-repo": "^1.0.0",
+						"git-raw-commits": "^1.3.6",
+						"git-remote-origin-url": "^2.0.0",
+						"git-semver-tags": "^1.3.6",
+						"lodash": "^4.2.1",
+						"normalize-package-data": "^2.3.5",
+						"q": "^1.5.1",
+						"read-pkg": "^1.1.0",
+						"read-pkg-up": "^1.0.1",
+						"through2": "^2.0.0"
 					},
 					"dependencies": {
 						"load-json-file": {
@@ -979,11 +914,11 @@
 							"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"parse-json": {
@@ -992,7 +927,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-type": {
@@ -1001,9 +936,9 @@
 							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -1018,9 +953,9 @@
 							"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"strip-bom": {
@@ -1029,7 +964,7 @@
 							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						}
 					}
@@ -1040,7 +975,7 @@
 					"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-eslint": {
@@ -1049,7 +984,7 @@
 					"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-express": {
@@ -1058,7 +993,7 @@
 					"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-jquery": {
@@ -1067,7 +1002,7 @@
 					"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.4.1"
 					}
 				},
 				"conventional-changelog-jscs": {
@@ -1076,7 +1011,7 @@
 					"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
 					"dev": true,
 					"requires": {
-						"q": "1.5.1"
+						"q": "^1.4.1"
 					}
 				},
 				"conventional-changelog-jshint": {
@@ -1085,8 +1020,8 @@
 					"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"q": "1.5.1"
+						"compare-func": "^1.3.1",
+						"q": "^1.5.1"
 					}
 				},
 				"conventional-changelog-preset-loader": {
@@ -1101,16 +1036,16 @@
 					"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"conventional-commits-filter": "1.1.6",
-						"dateformat": "3.0.3",
-						"handlebars": "4.0.11",
-						"json-stringify-safe": "5.0.1",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"semver": "5.5.1",
-						"split": "1.0.1",
-						"through2": "2.0.3"
+						"compare-func": "^1.3.1",
+						"conventional-commits-filter": "^1.1.6",
+						"dateformat": "^3.0.0",
+						"handlebars": "^4.0.2",
+						"json-stringify-safe": "^5.0.1",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"semver": "^5.5.0",
+						"split": "^1.0.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"conventional-commits-filter": {
@@ -1119,8 +1054,8 @@
 					"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 					"dev": true,
 					"requires": {
-						"is-subset": "0.1.1",
-						"modify-values": "1.0.1"
+						"is-subset": "^0.1.1",
+						"modify-values": "^1.0.0"
 					}
 				},
 				"conventional-commits-parser": {
@@ -1129,13 +1064,13 @@
 					"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 					"dev": true,
 					"requires": {
-						"JSONStream": "1.3.4",
-						"is-text-path": "1.0.1",
-						"lodash": "4.17.10",
-						"meow": "4.0.1",
-						"split2": "2.2.0",
-						"through2": "2.0.3",
-						"trim-off-newlines": "1.0.1"
+						"JSONStream": "^1.0.4",
+						"is-text-path": "^1.0.0",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0",
+						"trim-off-newlines": "^1.0.0"
 					}
 				},
 				"conventional-recommended-bump": {
@@ -1144,13 +1079,13 @@
 					"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
 					"dev": true,
 					"requires": {
-						"concat-stream": "1.6.2",
-						"conventional-commits-filter": "1.1.6",
-						"conventional-commits-parser": "2.1.7",
-						"git-raw-commits": "1.3.6",
-						"git-semver-tags": "1.3.6",
-						"meow": "3.7.0",
-						"object-assign": "4.1.1"
+						"concat-stream": "^1.4.10",
+						"conventional-commits-filter": "^1.1.1",
+						"conventional-commits-parser": "^2.1.1",
+						"git-raw-commits": "^1.3.0",
+						"git-semver-tags": "^1.3.0",
+						"meow": "^3.3.0",
+						"object-assign": "^4.0.1"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -1165,8 +1100,8 @@
 							"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 							"dev": true,
 							"requires": {
-								"camelcase": "2.1.1",
-								"map-obj": "1.0.1"
+								"camelcase": "^2.0.0",
+								"map-obj": "^1.0.0"
 							}
 						},
 						"indent-string": {
@@ -1175,7 +1110,7 @@
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"map-obj": {
@@ -1190,16 +1125,16 @@
 							"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 							"dev": true,
 							"requires": {
-								"camelcase-keys": "2.1.0",
-								"decamelize": "1.2.0",
-								"loud-rejection": "1.6.0",
-								"map-obj": "1.0.1",
-								"minimist": "1.2.0",
-								"normalize-package-data": "2.4.0",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"redent": "1.0.0",
-								"trim-newlines": "1.0.0"
+								"camelcase-keys": "^2.0.0",
+								"decamelize": "^1.1.2",
+								"loud-rejection": "^1.0.0",
+								"map-obj": "^1.0.1",
+								"minimist": "^1.1.3",
+								"normalize-package-data": "^2.3.4",
+								"object-assign": "^4.0.1",
+								"read-pkg-up": "^1.0.1",
+								"redent": "^1.0.0",
+								"trim-newlines": "^1.0.0"
 							}
 						},
 						"minimist": {
@@ -1214,8 +1149,8 @@
 							"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 							"dev": true,
 							"requires": {
-								"indent-string": "2.1.0",
-								"strip-indent": "1.0.1"
+								"indent-string": "^2.1.0",
+								"strip-indent": "^1.0.1"
 							}
 						},
 						"strip-indent": {
@@ -1224,7 +1159,7 @@
 							"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 							"dev": true,
 							"requires": {
-								"get-stdin": "4.0.1"
+								"get-stdin": "^4.0.1"
 							}
 						},
 						"trim-newlines": {
@@ -1241,7 +1176,7 @@
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"dev": true,
 					"requires": {
-						"capture-stack-trace": "1.0.0"
+						"capture-stack-trace": "^1.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -1250,9 +1185,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"currently-unhandled": {
@@ -1261,7 +1196,7 @@
 					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 					"dev": true,
 					"requires": {
-						"array-find-index": "1.0.2"
+						"array-find-index": "^1.0.1"
 					}
 				},
 				"dargs": {
@@ -1270,7 +1205,7 @@
 					"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"dateformat": {
@@ -1291,8 +1226,8 @@
 					"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 					"dev": true,
 					"requires": {
-						"decamelize": "1.2.0",
-						"map-obj": "1.0.1"
+						"decamelize": "^1.1.0",
+						"map-obj": "^1.0.0"
 					},
 					"dependencies": {
 						"map-obj": {
@@ -1321,7 +1256,7 @@
 					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"dev": true,
 					"requires": {
-						"clone": "1.0.4"
+						"clone": "^1.0.2"
 					}
 				},
 				"delegates": {
@@ -1342,12 +1277,12 @@
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 					"dev": true,
 					"requires": {
-						"is-obj": "1.0.1"
+						"is-obj": "^1.0.0"
 					}
 				},
 				"duplexer": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 					"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 					"dev": true
 				},
@@ -1363,7 +1298,7 @@
 					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"execa": {
@@ -1372,13 +1307,13 @@
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"external-editor": {
@@ -1387,9 +1322,9 @@
 					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 					"dev": true,
 					"requires": {
-						"chardet": "0.4.2",
-						"iconv-lite": "0.4.24",
-						"tmp": "0.0.33"
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
 					}
 				},
 				"figures": {
@@ -1398,7 +1333,7 @@
 					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5"
+						"escape-string-regexp": "^1.0.5"
 					}
 				},
 				"find-up": {
@@ -1407,18 +1342,18 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"fs-extra": {
 					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+					"resolved": "http://localhost:4873/fs-extra/-/fs-extra-4.0.3.tgz",
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.2"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"gauge": {
@@ -1427,14 +1362,14 @@
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.3"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -1443,7 +1378,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -1452,9 +1387,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -1471,11 +1406,11 @@
 					"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"meow": "3.7.0",
-						"normalize-package-data": "2.4.0",
-						"parse-github-repo-url": "1.4.1",
-						"through2": "2.0.3"
+						"hosted-git-info": "^2.1.4",
+						"meow": "^3.3.0",
+						"normalize-package-data": "^2.3.0",
+						"parse-github-repo-url": "^1.3.0",
+						"through2": "^2.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -1486,12 +1421,12 @@
 						},
 						"camelcase-keys": {
 							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+							"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 							"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 							"dev": true,
 							"requires": {
-								"camelcase": "2.1.1",
-								"map-obj": "1.0.1"
+								"camelcase": "^2.0.0",
+								"map-obj": "^1.0.0"
 							}
 						},
 						"indent-string": {
@@ -1500,7 +1435,7 @@
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"map-obj": {
@@ -1511,20 +1446,20 @@
 						},
 						"meow": {
 							"version": "3.7.0",
-							"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+							"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 							"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 							"dev": true,
 							"requires": {
-								"camelcase-keys": "2.1.0",
-								"decamelize": "1.2.0",
-								"loud-rejection": "1.6.0",
-								"map-obj": "1.0.1",
-								"minimist": "1.2.0",
-								"normalize-package-data": "2.4.0",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"redent": "1.0.0",
-								"trim-newlines": "1.0.0"
+								"camelcase-keys": "^2.0.0",
+								"decamelize": "^1.1.2",
+								"loud-rejection": "^1.0.0",
+								"map-obj": "^1.0.1",
+								"minimist": "^1.1.3",
+								"normalize-package-data": "^2.3.4",
+								"object-assign": "^4.0.1",
+								"read-pkg-up": "^1.0.1",
+								"redent": "^1.0.0",
+								"trim-newlines": "^1.0.0"
 							}
 						},
 						"minimist": {
@@ -1539,8 +1474,8 @@
 							"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 							"dev": true,
 							"requires": {
-								"indent-string": "2.1.0",
-								"strip-indent": "1.0.1"
+								"indent-string": "^2.1.0",
+								"strip-indent": "^1.0.1"
 							}
 						},
 						"strip-indent": {
@@ -1549,7 +1484,7 @@
 							"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 							"dev": true,
 							"requires": {
-								"get-stdin": "4.0.1"
+								"get-stdin": "^4.0.1"
 							}
 						},
 						"trim-newlines": {
@@ -1584,11 +1519,11 @@
 					"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 					"dev": true,
 					"requires": {
-						"dargs": "4.1.0",
-						"lodash.template": "4.4.0",
-						"meow": "4.0.1",
-						"split2": "2.2.0",
-						"through2": "2.0.3"
+						"dargs": "^4.0.1",
+						"lodash.template": "^4.0.2",
+						"meow": "^4.0.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"git-remote-origin-url": {
@@ -1597,13 +1532,13 @@
 					"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 					"dev": true,
 					"requires": {
-						"gitconfiglocal": "1.0.0",
-						"pify": "2.3.0"
+						"gitconfiglocal": "^1.0.0",
+						"pify": "^2.3.0"
 					},
 					"dependencies": {
 						"pify": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 							"dev": true
 						}
@@ -1615,8 +1550,8 @@
 					"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 					"dev": true,
 					"requires": {
-						"meow": "4.0.1",
-						"semver": "5.5.1"
+						"meow": "^4.0.0",
+						"semver": "^5.5.0"
 					}
 				},
 				"gitconfiglocal": {
@@ -1625,7 +1560,7 @@
 					"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 					"dev": true,
 					"requires": {
-						"ini": "1.3.5"
+						"ini": "^1.3.2"
 					}
 				},
 				"glob-parent": {
@@ -1634,8 +1569,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					}
 				},
 				"globby": {
@@ -1644,11 +1579,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.3",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -1665,17 +1600,17 @@
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
-						"create-error-class": "3.0.2",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"is-redirect": "1.0.0",
-						"is-retry-allowed": "1.1.0",
-						"is-stream": "1.1.0",
-						"lowercase-keys": "1.0.1",
-						"safe-buffer": "5.1.2",
-						"timed-out": "4.0.1",
-						"unzip-response": "2.0.1",
-						"url-parse-lax": "1.0.0"
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
 					}
 				},
 				"handlebars": {
@@ -1684,10 +1619,10 @@
 					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					}
 				},
 				"has-unicode": {
@@ -1708,7 +1643,7 @@
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"indent-string": {
@@ -1729,20 +1664,20 @@
 					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.2.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.10",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rx-lite": "4.0.8",
-						"rx-lite-aggregates": "4.0.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -1751,7 +1686,7 @@
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -1776,11 +1711,11 @@
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-ci": {
@@ -1789,7 +1724,7 @@
 					"integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
 					"dev": true,
 					"requires": {
-						"ci-info": "1.4.0"
+						"ci-info": "^1.3.0"
 					}
 				},
 				"is-extglob": {
@@ -1804,7 +1739,7 @@
 					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1819,12 +1754,12 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.0"
 					}
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 					"dev": true
 				},
@@ -1870,7 +1805,7 @@
 					"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 					"dev": true,
 					"requires": {
-						"text-extensions": "1.7.0"
+						"text-extensions": "^1.0.0"
 					}
 				},
 				"is-utf8": {
@@ -1891,7 +1826,7 @@
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"jsonparse": {
@@ -1906,7 +1841,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -1922,7 +1857,7 @@
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -1931,10 +1866,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -1943,8 +1878,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
@@ -1965,8 +1900,8 @@
 					"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0",
-						"lodash.templatesettings": "4.1.0"
+						"lodash._reinterpolate": "~3.0.0",
+						"lodash.templatesettings": "^4.0.0"
 					}
 				},
 				"lodash.templatesettings": {
@@ -1975,7 +1910,7 @@
 					"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0"
+						"lodash._reinterpolate": "~3.0.0"
 					}
 				},
 				"longest": {
@@ -1990,8 +1925,8 @@
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 					"dev": true,
 					"requires": {
-						"currently-unhandled": "0.4.1",
-						"signal-exit": "3.0.2"
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"lowercase-keys": {
@@ -2006,7 +1941,7 @@
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -2021,7 +1956,7 @@
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"meow": {
@@ -2030,15 +1965,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2053,8 +1988,8 @@
 							"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 							"dev": true,
 							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "3.0.0"
+								"find-up": "^2.0.0",
+								"read-pkg": "^3.0.0"
 							}
 						}
 					}
@@ -2077,8 +2012,8 @@
 					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"is-plain-obj": "1.1.0"
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
 					}
 				},
 				"modify-values": {
@@ -2105,10 +2040,10 @@
 					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.1",
-						"validate-npm-package-license": "3.0.4"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -2117,7 +2052,7 @@
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"npmlog": {
@@ -2126,10 +2061,10 @@
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"requires": {
-						"are-we-there-yet": "1.1.5",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2150,7 +2085,7 @@
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"optimist": {
@@ -2159,8 +2094,8 @@
 					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.10",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-locale": {
@@ -2169,9 +2104,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					},
 					"dependencies": {
 						"execa": {
@@ -2180,13 +2115,13 @@
 							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 							"dev": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							}
 						}
 					}
@@ -2209,7 +2144,7 @@
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -2218,7 +2153,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "1.3.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2233,10 +2168,10 @@
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"dev": true,
 					"requires": {
-						"got": "6.7.1",
-						"registry-auth-token": "3.3.2",
-						"registry-url": "3.1.0",
-						"semver": "5.5.1"
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
 					}
 				},
 				"parse-github-repo-url": {
@@ -2251,8 +2186,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-dirname": {
@@ -2279,7 +2214,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -2300,7 +2235,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"prepend-http": {
@@ -2327,10 +2262,10 @@
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"requires": {
-						"deep-extend": "0.6.0",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2347,7 +2282,7 @@
 					"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.2"
 					}
 				},
 				"read-pkg": {
@@ -2356,9 +2291,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2367,8 +2302,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2377,8 +2312,8 @@
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"load-json-file": {
@@ -2387,11 +2322,11 @@
 							"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"parse-json": {
@@ -2400,7 +2335,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-exists": {
@@ -2409,7 +2344,7 @@
 							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 							"dev": true,
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-type": {
@@ -2418,9 +2353,9 @@
 							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -2435,9 +2370,9 @@
 							"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"strip-bom": {
@@ -2446,7 +2381,7 @@
 							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						}
 					}
@@ -2457,8 +2392,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"registry-auth-token": {
@@ -2467,8 +2402,8 @@
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"dev": true,
 					"requires": {
-						"rc": "1.2.8",
-						"safe-buffer": "5.1.2"
+						"rc": "^1.1.6",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"registry-url": {
@@ -2477,7 +2412,7 @@
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"dev": true,
 					"requires": {
-						"rc": "1.2.8"
+						"rc": "^1.0.1"
 					}
 				},
 				"repeat-string": {
@@ -2492,7 +2427,7 @@
 					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 					"dev": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2513,8 +2448,8 @@
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"dev": true,
 					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"right-align": {
@@ -2524,7 +2459,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"run-async": {
@@ -2533,7 +2468,7 @@
 					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 					"dev": true,
 					"requires": {
-						"is-promise": "2.1.0"
+						"is-promise": "^2.1.0"
 					}
 				},
 				"rx-lite": {
@@ -2548,7 +2483,7 @@
 					"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 					"dev": true,
 					"requires": {
-						"rx-lite": "4.0.8"
+						"rx-lite": "*"
 					}
 				},
 				"set-blocking": {
@@ -2563,7 +2498,7 @@
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2584,7 +2519,7 @@
 					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 					"dev": true,
 					"requires": {
-						"is-plain-obj": "1.1.0"
+						"is-plain-obj": "^1.0.0"
 					}
 				},
 				"source-map": {
@@ -2593,7 +2528,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				},
 				"spdx-correct": {
@@ -2602,8 +2537,8 @@
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2618,8 +2553,8 @@
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2634,7 +2569,7 @@
 					"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 					"dev": true,
 					"requires": {
-						"through": "2.3.8"
+						"through": "2"
 					}
 				},
 				"split2": {
@@ -2643,7 +2578,7 @@
 					"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 					"dev": true,
 					"requires": {
-						"through2": "2.0.3"
+						"through2": "^2.0.2"
 					}
 				},
 				"string-width": {
@@ -2652,8 +2587,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -2662,7 +2597,7 @@
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -2675,7 +2610,7 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
@@ -2697,11 +2632,11 @@
 					"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
 					"dev": true,
 					"requires": {
-						"byline": "5.0.0",
-						"duplexer": "0.1.1",
-						"minimist": "0.1.0",
-						"moment": "2.22.2",
-						"through": "2.3.8"
+						"byline": "^5.0.0",
+						"duplexer": "^0.1.1",
+						"minimist": "^0.1.0",
+						"moment": "^2.6.0",
+						"through": "^2.3.4"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2724,12 +2659,12 @@
 					"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"is-stream": "1.1.0",
-						"make-dir": "1.3.0",
-						"pify": "3.0.0",
-						"temp-dir": "1.0.0",
-						"uuid": "3.3.2"
+						"graceful-fs": "^4.1.2",
+						"is-stream": "^1.1.0",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"temp-dir": "^1.0.0",
+						"uuid": "^3.0.1"
 					},
 					"dependencies": {
 						"uuid": {
@@ -2746,8 +2681,8 @@
 					"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2",
-						"uuid": "2.0.3"
+						"os-tmpdir": "^1.0.0",
+						"uuid": "^2.0.1"
 					}
 				},
 				"text-extensions": {
@@ -2758,7 +2693,7 @@
 				},
 				"through": {
 					"version": "2.3.8",
-					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+					"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 					"dev": true
 				},
@@ -2768,8 +2703,8 @@
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"dev": true,
 					"requires": {
-						"readable-stream": "2.3.6",
-						"xtend": "4.0.1"
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
 					}
 				},
 				"timed-out": {
@@ -2784,7 +2719,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				},
 				"trim-newlines": {
@@ -2812,9 +2747,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2831,9 +2766,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -2864,7 +2799,7 @@
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "1.0.4"
+						"prepend-http": "^1.0.1"
 					}
 				},
 				"uuid": {
@@ -2879,8 +2814,8 @@
 					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"wcwidth": {
@@ -2889,7 +2824,7 @@
 					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"dev": true,
 					"requires": {
-						"defaults": "1.0.3"
+						"defaults": "^1.0.3"
 					}
 				},
 				"which-module": {
@@ -2904,7 +2839,7 @@
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"window-size": {
@@ -2922,12 +2857,12 @@
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -2936,7 +2871,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -2945,9 +2880,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -2958,12 +2893,12 @@
 					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 					"dev": true,
 					"requires": {
-						"detect-indent": "5.0.0",
-						"graceful-fs": "4.1.11",
-						"make-dir": "1.3.0",
-						"pify": "3.0.0",
-						"sort-keys": "2.0.0",
-						"write-file-atomic": "2.3.0"
+						"detect-indent": "^5.0.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"sort-keys": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"write-pkg": {
@@ -2972,8 +2907,8 @@
 					"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 					"dev": true,
 					"requires": {
-						"sort-keys": "2.0.0",
-						"write-json-file": "2.3.0"
+						"sort-keys": "^2.0.0",
+						"write-json-file": "^2.2.0"
 					}
 				},
 				"xtend": {
@@ -2994,19 +2929,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3021,9 +2956,9 @@
 							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wrap-ansi": "^2.0.0"
 							},
 							"dependencies": {
 								"string-width": {
@@ -3032,9 +2967,9 @@
 									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 									"dev": true,
 									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
 									}
 								}
 							}
@@ -3045,7 +2980,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"load-json-file": {
@@ -3054,10 +2989,10 @@
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"strip-bom": "3.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"strip-bom": "^3.0.0"
 							}
 						},
 						"parse-json": {
@@ -3066,7 +3001,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.2"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-type": {
@@ -3075,7 +3010,7 @@
 							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 							"dev": true,
 							"requires": {
-								"pify": "2.3.0"
+								"pify": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -3090,9 +3025,9 @@
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "2.0.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "2.0.0"
+								"load-json-file": "^2.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^2.0.0"
 							}
 						},
 						"read-pkg-up": {
@@ -3101,8 +3036,8 @@
 							"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 							"dev": true,
 							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "2.0.0"
+								"find-up": "^2.0.0",
+								"read-pkg": "^2.0.0"
 							}
 						}
 					}
@@ -3113,7 +3048,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3138,8 +3073,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"mime-db": {
@@ -3154,7 +3089,7 @@
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "~1.36.0"
 			}
 		},
 		"minimatch": {
@@ -3163,7 +3098,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -3178,8 +3113,8 @@
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2",
-				"yallist": "3.0.2"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3219,150 +3154,165 @@
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
 			"dev": true,
 			"requires": {
-				"ejs": "2.6.1",
-				"tap": "12.0.1"
+				"ejs": "^2.5.2",
+				"tap": "^12.0.1"
 			}
 		},
 		"nyc": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.0.1.tgz",
-			"integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+			"integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
 			"dev": true,
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "2.0.0",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"find-cache-dir": "2.0.0",
-				"find-up": "3.0.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "2.0.1",
-				"istanbul-lib-hook": "2.0.1",
-				"istanbul-lib-instrument": "2.3.2",
-				"istanbul-lib-report": "2.0.1",
-				"istanbul-lib-source-maps": "2.0.1",
-				"istanbul-reports": "2.0.0",
-				"make-dir": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"resolve-from": "4.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "5.0.0",
-				"uuid": "3.3.2",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^2.0.0",
+				"convert-source-map": "^1.6.0",
+				"debug-log": "^1.0.1",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-hook": "^2.0.1",
+				"istanbul-lib-instrument": "^3.0.0",
+				"istanbul-lib-report": "^2.0.2",
+				"istanbul-lib-source-maps": "^2.0.1",
+				"istanbul-reports": "^2.0.1",
+				"make-dir": "^1.3.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.0.0",
+				"uuid": "^3.3.2",
 				"yargs": "11.1.0",
-				"yargs-parser": "9.0.2"
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-					"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "7.0.0-beta.51"
+						"@babel/highlight": "^7.0.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-					"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+					"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.0.0-beta.51",
-						"jsesc": "2.5.1",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"@babel/types": "^7.3.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.10",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-					"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.51",
-						"@babel/template": "7.0.0-beta.51",
-						"@babel/types": "7.0.0-beta.51"
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-					"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.0.0-beta.51"
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-					"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+					"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.0.0-beta.51"
+						"@babel/types": "^7.0.0"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-					"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-					"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+					"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-					"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.51",
-						"@babel/parser": "7.0.0-beta.51",
-						"@babel/types": "7.0.0-beta.51",
-						"lodash": "4.17.10"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.2.2",
+						"@babel/types": "^7.2.2"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-					"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+					"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.51",
-						"@babel/generator": "7.0.0-beta.51",
-						"@babel/helper-function-name": "7.0.0-beta.51",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.51",
-						"@babel/parser": "7.0.0-beta.51",
-						"@babel/types": "7.0.0-beta.51",
-						"debug": "3.1.0",
-						"globals": "11.7.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.2.2",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/parser": "^7.2.3",
+						"@babel/types": "^7.2.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.10"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"dev": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"dev": true
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.0.0-beta.51",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-					"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+					"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "2.0.0"
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.10",
+						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"align-text": {
@@ -3370,9 +3320,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -3390,7 +3340,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "2.0.0"
+						"default-require-extensions": "^2.0.0"
 					}
 				},
 				"archy": {
@@ -3418,7 +3368,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3432,10 +3382,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"make-dir": "1.3.0",
-						"md5-hex": "2.0.0",
-						"package-hash": "2.0.0",
-						"write-file-atomic": "2.3.0"
+						"make-dir": "^1.0.0",
+						"md5-hex": "^2.0.0",
+						"package-hash": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"camelcase": {
@@ -3450,8 +3400,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"cliui": {
@@ -3460,8 +3410,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -3489,17 +3439,20 @@
 					"dev": true
 				},
 				"convert-source-map": {
-					"version": "1.5.1",
+					"version": "1.6.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -3525,7 +3478,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "3.0.0"
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"error-ex": {
@@ -3533,7 +3486,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"es6-error": {
@@ -3541,18 +3494,24 @@
 					"bundled": true,
 					"dev": true
 				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+					"dev": true
+				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -3560,9 +3519,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.1"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -3572,9 +3531,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"make-dir": "1.3.0",
-						"pkg-dir": "3.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
 					}
 				},
 				"find-up": {
@@ -3582,7 +3541,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"foreground-child": {
@@ -3590,8 +3549,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fs.realpath": {
@@ -3610,22 +3569,22 @@
 					"dev": true
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
-					"version": "11.7.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 					"dev": true
 				},
 				"graceful-fs": {
@@ -3638,10 +3597,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3649,7 +3608,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -3674,23 +3633,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
 					"dev": true
-				},
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "1.4.0"
-					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
@@ -3712,7 +3662,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -3740,32 +3690,32 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "1.0.0"
+						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-					"integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+					"integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "7.0.0-beta.51",
-						"@babel/parser": "7.0.0-beta.51",
-						"@babel/template": "7.0.0-beta.51",
-						"@babel/traverse": "7.0.0-beta.51",
-						"@babel/types": "7.0.0-beta.51",
-						"istanbul-lib-coverage": "2.0.1",
-						"semver": "5.5.0"
+						"@babel/generator": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"istanbul-lib-coverage": "^2.0.1",
+						"semver": "^5.5.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "2.0.1",
+					"version": "2.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "2.0.1",
-						"make-dir": "1.3.0",
-						"supports-color": "5.4.0"
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
@@ -3773,11 +3723,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "2.0.1",
-						"make-dir": "1.3.0",
-						"rimraf": "2.6.2",
-						"source-map": "0.6.1"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3788,17 +3738,23 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.11"
 					}
 				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				},
 				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 					"dev": true
 				},
 				"json-parse-better-errors": {
@@ -3811,7 +3767,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -3825,7 +3781,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -3833,10 +3789,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -3844,14 +3800,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "3.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 					"dev": true
 				},
 				"lodash.flattendeep": {
@@ -3864,22 +3820,13 @@
 					"bundled": true,
 					"dev": true
 				},
-				"loose-envify": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-					"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-					"dev": true,
-					"requires": {
-						"js-tokens": "3.0.2"
-					}
-				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -3887,7 +3834,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"md5-hex": {
@@ -3895,7 +3842,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -3908,7 +3855,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
@@ -3916,7 +3863,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -3936,7 +3883,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3969,10 +3916,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.7.1",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -3980,7 +3927,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3993,7 +3940,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
@@ -4001,8 +3948,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.10",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -4015,9 +3962,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -4030,7 +3977,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
@@ -4038,7 +3985,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
@@ -4051,10 +3998,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"lodash.flattendeep": "4.4.0",
-						"md5-hex": "2.0.0",
-						"release-zalgo": "1.0.0"
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
 					}
 				},
 				"parse-json": {
@@ -4062,8 +4009,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-exists": {
@@ -4086,7 +4033,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -4099,7 +4046,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "3.0.0"
+						"find-up": "^3.0.0"
 					}
 				},
 				"pseudomap": {
@@ -4112,9 +4059,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4122,8 +4069,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "3.0.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"release-zalgo": {
@@ -4131,7 +4078,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"es6-error": "4.1.1"
+						"es6-error": "^4.0.1"
 					}
 				},
 				"repeat-string": {
@@ -4160,7 +4107,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
@@ -4168,8 +4115,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.5.0",
@@ -4186,7 +4138,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -4209,12 +4161,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.1"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
@@ -4222,8 +4174,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -4236,8 +4188,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -4250,8 +4202,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4259,7 +4211,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4277,7 +4229,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"test-exclude": {
@@ -4285,10 +4237,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"minimatch": "3.0.4",
-						"read-pkg-up": "4.0.0",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"to-fast-properties": {
@@ -4309,9 +4261,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -4320,9 +4272,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -4344,8 +4296,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
@@ -4353,7 +4305,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -4377,8 +4329,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -4391,7 +4343,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -4399,9 +4351,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -4409,7 +4361,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
@@ -4424,9 +4376,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"signal-exit": "3.0.2"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"y18n": {
@@ -4444,18 +4396,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"cliui": {
@@ -4463,9 +4415,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"find-up": {
@@ -4473,7 +4425,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"locate-path": "2.0.0"
+								"locate-path": "^2.0.0"
 							}
 						},
 						"locate-path": {
@@ -4481,8 +4433,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-locate": "2.0.0",
-								"path-exists": "3.0.0"
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
 							}
 						},
 						"p-limit": {
@@ -4490,7 +4442,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-try": "1.0.0"
+								"p-try": "^1.0.0"
 							}
 						},
 						"p-locate": {
@@ -4498,7 +4450,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-limit": "1.3.0"
+								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
@@ -4513,7 +4465,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -4537,7 +4489,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"opener": {
@@ -4564,19 +4516,13 @@
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
 			"dev": true,
 			"requires": {
-				"own-or": "1.0.0"
+				"own-or": "^1.0.0"
 			}
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
 		"performance-now": {
@@ -4621,13 +4567,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"request": {
@@ -4636,35 +4582,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"dev": true,
-			"requires": {
-				"path-parse": "1.0.6"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"rimraf": {
@@ -4673,7 +4610,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -4712,8 +4649,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"sprintf-js": {
@@ -4728,15 +4665,15 @@
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -4751,7 +4688,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -4760,7 +4697,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -4769,7 +4706,7 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"tap": {
@@ -4778,35 +4715,35 @@
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
 			"dev": true,
 			"requires": {
-				"bind-obj-methods": "2.0.0",
-				"bluebird": "3.5.1",
-				"clean-yaml-object": "0.1.0",
-				"color-support": "1.1.3",
-				"coveralls": "3.0.2",
-				"foreground-child": "1.5.6",
-				"fs-exists-cached": "1.0.0",
-				"function-loop": "1.0.1",
-				"glob": "7.1.3",
-				"isexe": "2.0.0",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4",
-				"mkdirp": "0.5.1",
-				"nyc": "11.9.0",
-				"opener": "1.5.1",
-				"os-homedir": "1.0.2",
-				"own-or": "1.0.0",
-				"own-or-env": "1.0.1",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"source-map-support": "0.5.9",
-				"stack-utils": "1.0.1",
-				"tap-mocha-reporter": "3.0.7",
-				"tap-parser": "7.0.0",
-				"tmatch": "4.0.0",
-				"trivial-deferred": "1.0.1",
-				"tsame": "2.0.0",
-				"write-file-atomic": "2.3.0",
-				"yapool": "1.0.0"
+				"bind-obj-methods": "^2.0.0",
+				"bluebird": "^3.5.1",
+				"clean-yaml-object": "^0.1.0",
+				"color-support": "^1.1.0",
+				"coveralls": "^3.0.1",
+				"foreground-child": "^1.3.3",
+				"fs-exists-cached": "^1.0.0",
+				"function-loop": "^1.0.1",
+				"glob": "^7.0.0",
+				"isexe": "^2.0.0",
+				"js-yaml": "^3.11.0",
+				"minipass": "^2.3.0",
+				"mkdirp": "^0.5.1",
+				"nyc": "^11.8.0",
+				"opener": "^1.4.1",
+				"os-homedir": "^1.0.2",
+				"own-or": "^1.0.0",
+				"own-or-env": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.0",
+				"source-map-support": "^0.5.6",
+				"stack-utils": "^1.0.0",
+				"tap-mocha-reporter": "^3.0.7",
+				"tap-parser": "^7.0.0",
+				"tmatch": "^4.0.0",
+				"trivial-deferred": "^1.0.1",
+				"tsame": "^2.0.0",
+				"write-file-atomic": "^2.3.0",
+				"yapool": "^1.0.0"
 			},
 			"dependencies": {
 				"nyc": {
@@ -4815,33 +4752,33 @@
 					"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 					"dev": true,
 					"requires": {
-						"archy": "1.0.0",
-						"arrify": "1.0.1",
-						"caching-transform": "1.0.1",
-						"convert-source-map": "1.5.1",
-						"debug-log": "1.0.1",
-						"default-require-extensions": "1.0.0",
-						"find-cache-dir": "0.1.1",
-						"find-up": "2.1.0",
-						"foreground-child": "1.5.6",
-						"glob": "7.1.2",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-hook": "1.1.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-report": "1.1.3",
-						"istanbul-lib-source-maps": "1.2.3",
-						"istanbul-reports": "1.4.0",
-						"md5-hex": "1.3.0",
-						"merge-source-map": "1.1.0",
-						"micromatch": "3.1.10",
-						"mkdirp": "0.5.1",
-						"resolve-from": "2.0.0",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"spawn-wrap": "1.4.2",
-						"test-exclude": "4.2.1",
+						"archy": "^1.0.0",
+						"arrify": "^1.0.1",
+						"caching-transform": "^1.0.0",
+						"convert-source-map": "^1.5.1",
+						"debug-log": "^1.0.1",
+						"default-require-extensions": "^1.0.0",
+						"find-cache-dir": "^0.1.1",
+						"find-up": "^2.1.0",
+						"foreground-child": "^1.5.3",
+						"glob": "^7.0.6",
+						"istanbul-lib-coverage": "^1.1.2",
+						"istanbul-lib-hook": "^1.1.0",
+						"istanbul-lib-instrument": "^1.10.0",
+						"istanbul-lib-report": "^1.1.3",
+						"istanbul-lib-source-maps": "^1.2.3",
+						"istanbul-reports": "^1.4.0",
+						"md5-hex": "^1.2.0",
+						"merge-source-map": "^1.1.0",
+						"micromatch": "^3.1.10",
+						"mkdirp": "^0.5.0",
+						"resolve-from": "^2.0.0",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.1",
+						"spawn-wrap": "^1.4.2",
+						"test-exclude": "^4.2.0",
 						"yargs": "11.1.0",
-						"yargs-parser": "8.1.0"
+						"yargs-parser": "^8.0.0"
 					},
 					"dependencies": {
 						"align-text": {
@@ -4849,9 +4786,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2",
-								"longest": "1.0.1",
-								"repeat-string": "1.6.1"
+								"kind-of": "^3.0.2",
+								"longest": "^1.0.1",
+								"repeat-string": "^1.5.2"
 							}
 						},
 						"amdefine": {
@@ -4874,7 +4811,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"default-require-extensions": "1.0.0"
+								"default-require-extensions": "^1.0.0"
 							}
 						},
 						"archy": {
@@ -4927,9 +4864,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"chalk": "1.1.3",
-								"esutils": "2.0.2",
-								"js-tokens": "3.0.2"
+								"chalk": "^1.1.3",
+								"esutils": "^2.0.2",
+								"js-tokens": "^3.0.2"
 							}
 						},
 						"babel-generator": {
@@ -4937,14 +4874,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"detect-indent": "4.0.0",
-								"jsesc": "1.3.0",
-								"lodash": "4.17.10",
-								"source-map": "0.5.7",
-								"trim-right": "1.0.1"
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"detect-indent": "^4.0.0",
+								"jsesc": "^1.3.0",
+								"lodash": "^4.17.4",
+								"source-map": "^0.5.7",
+								"trim-right": "^1.0.1"
 							}
 						},
 						"babel-messages": {
@@ -4952,7 +4889,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0"
+								"babel-runtime": "^6.22.0"
 							}
 						},
 						"babel-runtime": {
@@ -4960,8 +4897,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-js": "2.5.6",
-								"regenerator-runtime": "0.11.1"
+								"core-js": "^2.4.0",
+								"regenerator-runtime": "^0.11.0"
 							}
 						},
 						"babel-template": {
@@ -4969,11 +4906,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"lodash": "4.17.10"
+								"babel-runtime": "^6.26.0",
+								"babel-traverse": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-traverse": {
@@ -4981,15 +4918,15 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-code-frame": "6.26.0",
-								"babel-messages": "6.23.0",
-								"babel-runtime": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"debug": "2.6.9",
-								"globals": "9.18.0",
-								"invariant": "2.2.4",
-								"lodash": "4.17.10"
+								"babel-code-frame": "^6.26.0",
+								"babel-messages": "^6.23.0",
+								"babel-runtime": "^6.26.0",
+								"babel-types": "^6.26.0",
+								"babylon": "^6.18.0",
+								"debug": "^2.6.8",
+								"globals": "^9.18.0",
+								"invariant": "^2.2.2",
+								"lodash": "^4.17.4"
 							}
 						},
 						"babel-types": {
@@ -4997,10 +4934,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-runtime": "6.26.0",
-								"esutils": "2.0.2",
-								"lodash": "4.17.10",
-								"to-fast-properties": "1.0.3"
+								"babel-runtime": "^6.26.0",
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.4",
+								"to-fast-properties": "^1.0.3"
 							}
 						},
 						"babylon": {
@@ -5018,13 +4955,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cache-base": "1.0.1",
-								"class-utils": "0.3.6",
-								"component-emitter": "1.2.1",
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"mixin-deep": "1.3.1",
-								"pascalcase": "0.1.1"
+								"cache-base": "^1.0.1",
+								"class-utils": "^0.3.5",
+								"component-emitter": "^1.2.1",
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.1",
+								"mixin-deep": "^1.2.0",
+								"pascalcase": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5032,7 +4969,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -5040,7 +4977,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5048,7 +4985,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5056,9 +4993,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -5078,7 +5015,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"balanced-match": "1.0.0",
+								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
 							}
 						},
@@ -5087,16 +5024,16 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -5104,7 +5041,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5119,15 +5056,15 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"collection-visit": "1.0.0",
-								"component-emitter": "1.2.1",
-								"get-value": "2.0.6",
-								"has-value": "1.0.0",
-								"isobject": "3.0.1",
-								"set-value": "2.0.0",
-								"to-object-path": "0.3.0",
-								"union-value": "1.0.0",
-								"unset-value": "1.0.0"
+								"collection-visit": "^1.0.0",
+								"component-emitter": "^1.2.1",
+								"get-value": "^2.0.6",
+								"has-value": "^1.0.0",
+								"isobject": "^3.0.1",
+								"set-value": "^2.0.0",
+								"to-object-path": "^0.3.0",
+								"union-value": "^1.0.0",
+								"unset-value": "^1.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5142,9 +5079,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"md5-hex": "1.3.0",
-								"mkdirp": "0.5.1",
-								"write-file-atomic": "1.3.4"
+								"md5-hex": "^1.2.0",
+								"mkdirp": "^0.5.1",
+								"write-file-atomic": "^1.1.4"
 							}
 						},
 						"camelcase": {
@@ -5159,8 +5096,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4",
-								"lazy-cache": "1.0.4"
+								"align-text": "^0.1.3",
+								"lazy-cache": "^1.0.3"
 							}
 						},
 						"chalk": {
@@ -5168,11 +5105,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-styles": "2.2.1",
-								"escape-string-regexp": "1.0.5",
-								"has-ansi": "2.0.0",
-								"strip-ansi": "3.0.1",
-								"supports-color": "2.0.0"
+								"ansi-styles": "^2.2.1",
+								"escape-string-regexp": "^1.0.2",
+								"has-ansi": "^2.0.0",
+								"strip-ansi": "^3.0.0",
+								"supports-color": "^2.0.0"
 							}
 						},
 						"class-utils": {
@@ -5180,10 +5117,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"define-property": "0.2.5",
-								"isobject": "3.0.1",
-								"static-extend": "0.1.2"
+								"arr-union": "^3.1.0",
+								"define-property": "^0.2.5",
+								"isobject": "^3.0.0",
+								"static-extend": "^0.1.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5191,7 +5128,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"isobject": {
@@ -5207,8 +5144,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"center-align": "0.1.3",
-								"right-align": "0.1.3",
+								"center-align": "^0.1.1",
+								"right-align": "^0.1.1",
 								"wordwrap": "0.0.2"
 							},
 							"dependencies": {
@@ -5230,8 +5167,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"map-visit": "1.0.0",
-								"object-visit": "1.0.1"
+								"map-visit": "^1.0.0",
+								"object-visit": "^1.0.0"
 							}
 						},
 						"commondir": {
@@ -5269,8 +5206,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"which": "^1.2.9"
 							}
 						},
 						"debug": {
@@ -5301,7 +5238,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"strip-bom": "2.0.0"
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"define-property": {
@@ -5309,8 +5246,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2",
-								"isobject": "3.0.1"
+								"is-descriptor": "^1.0.2",
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"is-accessor-descriptor": {
@@ -5318,7 +5255,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5326,7 +5263,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5334,9 +5271,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -5356,7 +5293,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						},
 						"error-ex": {
@@ -5364,7 +5301,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-arrayish": "0.2.1"
+								"is-arrayish": "^0.2.1"
 							}
 						},
 						"escape-string-regexp": {
@@ -5382,13 +5319,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							},
 							"dependencies": {
 								"cross-spawn": {
@@ -5396,9 +5333,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"lru-cache": "4.1.3",
-										"shebang-command": "1.2.0",
-										"which": "1.3.0"
+										"lru-cache": "^4.0.1",
+										"shebang-command": "^1.2.0",
+										"which": "^1.2.9"
 									}
 								}
 							}
@@ -5408,13 +5345,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5422,7 +5359,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -5430,7 +5367,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5440,8 +5377,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"assign-symbols": "1.0.0",
-								"is-extendable": "1.0.1"
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
@@ -5449,7 +5386,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -5459,14 +5396,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -5474,7 +5411,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
@@ -5482,7 +5419,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -5490,7 +5427,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -5498,7 +5435,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -5506,9 +5443,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"kind-of": {
@@ -5523,10 +5460,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -5534,7 +5471,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -5544,9 +5481,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"commondir": "1.0.1",
-								"mkdirp": "0.5.1",
-								"pkg-dir": "1.0.0"
+								"commondir": "^1.0.1",
+								"mkdirp": "^0.5.1",
+								"pkg-dir": "^1.0.0"
 							}
 						},
 						"find-up": {
@@ -5554,7 +5491,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"locate-path": "2.0.0"
+								"locate-path": "^2.0.0"
 							}
 						},
 						"for-in": {
@@ -5567,8 +5504,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cross-spawn": "4.0.2",
-								"signal-exit": "3.0.2"
+								"cross-spawn": "^4",
+								"signal-exit": "^3.0.0"
 							}
 						},
 						"fragment-cache": {
@@ -5576,7 +5513,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"map-cache": "0.2.2"
+								"map-cache": "^0.2.2"
 							}
 						},
 						"fs.realpath": {
@@ -5604,12 +5541,12 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"fs.realpath": "1.0.0",
-								"inflight": "1.0.6",
-								"inherits": "2.0.3",
-								"minimatch": "3.0.4",
-								"once": "1.4.0",
-								"path-is-absolute": "1.0.1"
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
 							}
 						},
 						"globals": {
@@ -5627,10 +5564,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"async": "1.5.2",
-								"optimist": "0.6.1",
-								"source-map": "0.4.4",
-								"uglify-js": "2.8.29"
+								"async": "^1.4.0",
+								"optimist": "^0.6.1",
+								"source-map": "^0.4.4",
+								"uglify-js": "^2.6"
 							},
 							"dependencies": {
 								"source-map": {
@@ -5638,7 +5575,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"amdefine": "1.0.1"
+										"amdefine": ">=0.0.4"
 									}
 								}
 							}
@@ -5648,7 +5585,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"has-flag": {
@@ -5661,9 +5598,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "1.0.0",
-								"isobject": "3.0.1"
+								"get-value": "^2.0.6",
+								"has-values": "^1.0.0",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5678,8 +5615,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"kind-of": "4.0.0"
+								"is-number": "^3.0.0",
+								"kind-of": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
@@ -5687,7 +5624,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -5695,7 +5632,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -5705,7 +5642,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -5725,8 +5662,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"once": "1.4.0",
-								"wrappy": "1.0.2"
+								"once": "^1.3.0",
+								"wrappy": "1"
 							}
 						},
 						"inherits": {
@@ -5739,7 +5676,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"loose-envify": "1.3.1"
+								"loose-envify": "^1.0.0"
 							}
 						},
 						"invert-kv": {
@@ -5752,7 +5689,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-arrayish": {
@@ -5770,7 +5707,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"builtin-modules": "1.1.1"
+								"builtin-modules": "^1.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -5778,7 +5715,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -5786,9 +5723,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -5808,7 +5745,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"is-fullwidth-code-point": {
@@ -5821,7 +5758,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-odd": {
@@ -5829,7 +5766,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "4.0.0"
+								"is-number": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
@@ -5844,7 +5781,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -5894,7 +5831,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"append-transform": "0.4.0"
+								"append-transform": "^0.4.0"
 							}
 						},
 						"istanbul-lib-instrument": {
@@ -5902,13 +5839,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"babel-generator": "6.26.1",
-								"babel-template": "6.26.0",
-								"babel-traverse": "6.26.0",
-								"babel-types": "6.26.0",
-								"babylon": "6.18.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"semver": "5.5.0"
+								"babel-generator": "^6.18.0",
+								"babel-template": "^6.16.0",
+								"babel-traverse": "^6.18.0",
+								"babel-types": "^6.18.0",
+								"babylon": "^6.18.0",
+								"istanbul-lib-coverage": "^1.2.0",
+								"semver": "^5.3.0"
 							}
 						},
 						"istanbul-lib-report": {
@@ -5916,10 +5853,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"path-parse": "1.0.5",
-								"supports-color": "3.2.3"
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"path-parse": "^1.0.5",
+								"supports-color": "^3.1.2"
 							},
 							"dependencies": {
 								"supports-color": {
@@ -5927,7 +5864,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"has-flag": "1.0.0"
+										"has-flag": "^1.0.0"
 									}
 								}
 							}
@@ -5937,11 +5874,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "3.1.0",
-								"istanbul-lib-coverage": "1.2.0",
-								"mkdirp": "0.5.1",
-								"rimraf": "2.6.2",
-								"source-map": "0.5.7"
+								"debug": "^3.1.0",
+								"istanbul-lib-coverage": "^1.1.2",
+								"mkdirp": "^0.5.1",
+								"rimraf": "^2.6.1",
+								"source-map": "^0.5.3"
 							},
 							"dependencies": {
 								"debug": {
@@ -5959,7 +5896,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"handlebars": "4.0.11"
+								"handlebars": "^4.0.3"
 							}
 						},
 						"js-tokens": {
@@ -5977,7 +5914,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						},
 						"lazy-cache": {
@@ -5991,7 +5928,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"invert-kv": "1.0.0"
+								"invert-kv": "^1.0.0"
 							}
 						},
 						"load-json-file": {
@@ -5999,11 +5936,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1",
-								"strip-bom": "2.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0",
+								"strip-bom": "^2.0.0"
 							}
 						},
 						"locate-path": {
@@ -6011,8 +5948,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-locate": "2.0.0",
-								"path-exists": "3.0.0"
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
 							},
 							"dependencies": {
 								"path-exists": {
@@ -6037,7 +5974,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"js-tokens": "3.0.2"
+								"js-tokens": "^3.0.0"
 							}
 						},
 						"lru-cache": {
@@ -6045,8 +5982,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pseudomap": "1.0.2",
-								"yallist": "2.1.2"
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
 							}
 						},
 						"map-cache": {
@@ -6059,7 +5996,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"object-visit": "1.0.1"
+								"object-visit": "^1.0.0"
 							}
 						},
 						"md5-hex": {
@@ -6067,7 +6004,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"md5-o-matic": "0.1.1"
+								"md5-o-matic": "^0.1.1"
 							}
 						},
 						"md5-o-matic": {
@@ -6080,7 +6017,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"mimic-fn": "1.2.0"
+								"mimic-fn": "^1.0.0"
 							}
 						},
 						"merge-source-map": {
@@ -6088,7 +6025,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"source-map": "0.6.1"
+								"source-map": "^0.6.1"
 							},
 							"dependencies": {
 								"source-map": {
@@ -6103,19 +6040,19 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6135,7 +6072,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"brace-expansion": "1.1.11"
+								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
@@ -6148,8 +6085,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"for-in": "1.0.2",
-								"is-extendable": "1.0.1"
+								"for-in": "^1.0.2",
+								"is-extendable": "^1.0.1"
 							},
 							"dependencies": {
 								"is-extendable": {
@@ -6157,7 +6094,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-plain-object": "2.0.4"
+										"is-plain-object": "^2.0.4"
 									}
 								}
 							}
@@ -6180,18 +6117,18 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"fragment-cache": "0.2.1",
-								"is-odd": "2.0.0",
-								"is-windows": "1.0.2",
-								"kind-of": "6.0.2",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"fragment-cache": "^0.2.1",
+								"is-odd": "^2.0.0",
+								"is-windows": "^1.0.2",
+								"kind-of": "^6.0.2",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -6216,10 +6153,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"hosted-git-info": "2.6.0",
-								"is-builtin-module": "1.0.0",
-								"semver": "5.5.0",
-								"validate-npm-package-license": "3.0.3"
+								"hosted-git-info": "^2.1.4",
+								"is-builtin-module": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
 							}
 						},
 						"npm-run-path": {
@@ -6227,7 +6164,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-key": "2.0.1"
+								"path-key": "^2.0.0"
 							}
 						},
 						"number-is-nan": {
@@ -6245,9 +6182,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"copy-descriptor": "0.1.1",
-								"define-property": "0.2.5",
-								"kind-of": "3.2.2"
+								"copy-descriptor": "^0.1.0",
+								"define-property": "^0.2.5",
+								"kind-of": "^3.0.3"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6255,7 +6192,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -6265,7 +6202,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -6280,7 +6217,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isobject": "3.0.1"
+								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
@@ -6295,7 +6232,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"wrappy": "1.0.2"
+								"wrappy": "1"
 							}
 						},
 						"optimist": {
@@ -6303,8 +6240,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"minimist": "0.0.8",
-								"wordwrap": "0.0.3"
+								"minimist": "~0.0.1",
+								"wordwrap": "~0.0.2"
 							}
 						},
 						"os-homedir": {
@@ -6317,9 +6254,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"execa": "0.7.0",
-								"lcid": "1.0.0",
-								"mem": "1.1.0"
+								"execa": "^0.7.0",
+								"lcid": "^1.0.0",
+								"mem": "^1.1.0"
 							}
 						},
 						"p-finally": {
@@ -6332,7 +6269,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-try": "1.0.0"
+								"p-try": "^1.0.0"
 							}
 						},
 						"p-locate": {
@@ -6340,7 +6277,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-limit": "1.2.0"
+								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
@@ -6353,7 +6290,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.1"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"pascalcase": {
@@ -6366,7 +6303,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-is-absolute": {
@@ -6389,9 +6326,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"pify": "2.3.0",
-								"pinkie-promise": "2.0.1"
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -6409,7 +6346,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pinkie": "2.0.4"
+								"pinkie": "^2.0.0"
 							}
 						},
 						"pkg-dir": {
@@ -6417,7 +6354,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"find-up": "1.1.2"
+								"find-up": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
@@ -6425,8 +6362,8 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -6446,9 +6383,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"load-json-file": "1.1.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "1.1.0"
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
 							}
 						},
 						"read-pkg-up": {
@@ -6456,8 +6393,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"find-up": "1.1.2",
-								"read-pkg": "1.1.0"
+								"find-up": "^1.0.0",
+								"read-pkg": "^1.0.0"
 							},
 							"dependencies": {
 								"find-up": {
@@ -6465,8 +6402,8 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"path-exists": "2.1.0",
-										"pinkie-promise": "2.0.1"
+										"path-exists": "^2.0.0",
+										"pinkie-promise": "^2.0.0"
 									}
 								}
 							}
@@ -6481,8 +6418,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "3.0.2",
-								"safe-regex": "1.1.0"
+								"extend-shallow": "^3.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"repeat-element": {
@@ -6500,7 +6437,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-finite": "1.0.2"
+								"is-finite": "^1.0.0"
 							}
 						},
 						"require-directory": {
@@ -6534,7 +6471,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"align-text": "0.1.4"
+								"align-text": "^0.1.1"
 							}
 						},
 						"rimraf": {
@@ -6542,7 +6479,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"glob": "7.1.2"
+								"glob": "^7.0.5"
 							}
 						},
 						"safe-regex": {
@@ -6550,7 +6487,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ret": "0.1.15"
+								"ret": "~0.1.10"
 							}
 						},
 						"semver": {
@@ -6568,10 +6505,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"split-string": "3.1.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.3",
+								"split-string": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -6579,7 +6516,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -6589,7 +6526,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"shebang-regex": "1.0.0"
+								"shebang-regex": "^1.0.0"
 							}
 						},
 						"shebang-regex": {
@@ -6612,14 +6549,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"base": "0.11.2",
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"map-cache": "0.2.2",
-								"source-map": "0.5.7",
-								"source-map-resolve": "0.5.1",
-								"use": "3.1.0"
+								"base": "^0.11.1",
+								"debug": "^2.2.0",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"map-cache": "^0.2.2",
+								"source-map": "^0.5.6",
+								"source-map-resolve": "^0.5.0",
+								"use": "^3.1.0"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6627,7 +6564,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -6635,7 +6572,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -6645,9 +6582,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "1.0.0",
-								"isobject": "3.0.1",
-								"snapdragon-util": "3.0.1"
+								"define-property": "^1.0.0",
+								"isobject": "^3.0.0",
+								"snapdragon-util": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6655,7 +6592,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -6663,7 +6600,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -6671,7 +6608,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -6679,9 +6616,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"isobject": {
@@ -6701,7 +6638,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.2.0"
 							}
 						},
 						"source-map": {
@@ -6714,11 +6651,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"atob": "2.1.1",
-								"decode-uri-component": "0.2.0",
-								"resolve-url": "0.2.1",
-								"source-map-url": "0.4.0",
-								"urix": "0.1.0"
+								"atob": "^2.0.0",
+								"decode-uri-component": "^0.2.0",
+								"resolve-url": "^0.2.1",
+								"source-map-url": "^0.4.0",
+								"urix": "^0.1.0"
 							}
 						},
 						"source-map-url": {
@@ -6731,12 +6668,12 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"foreground-child": "1.5.6",
-								"mkdirp": "0.5.1",
-								"os-homedir": "1.0.2",
-								"rimraf": "2.6.2",
-								"signal-exit": "3.0.2",
-								"which": "1.3.0"
+								"foreground-child": "^1.5.6",
+								"mkdirp": "^0.5.0",
+								"os-homedir": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"signal-exit": "^3.0.2",
+								"which": "^1.3.0"
 							}
 						},
 						"spdx-correct": {
@@ -6744,8 +6681,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-expression-parse": "3.0.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-expression-parse": "^3.0.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-exceptions": {
@@ -6758,8 +6695,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-exceptions": "2.1.0",
-								"spdx-license-ids": "3.0.0"
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
 							}
 						},
 						"spdx-license-ids": {
@@ -6772,7 +6709,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "3.0.2"
+								"extend-shallow": "^3.0.0"
 							}
 						},
 						"static-extend": {
@@ -6780,8 +6717,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "0.2.5",
-								"object-copy": "0.1.0"
+								"define-property": "^0.2.5",
+								"object-copy": "^0.1.0"
 							},
 							"dependencies": {
 								"define-property": {
@@ -6789,7 +6726,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								}
 							}
@@ -6799,8 +6736,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-fullwidth-code-point": "2.0.0",
-								"strip-ansi": "4.0.0"
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -6813,7 +6750,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								}
 							}
@@ -6823,7 +6760,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"strip-bom": {
@@ -6831,7 +6768,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						},
 						"strip-eof": {
@@ -6849,11 +6786,11 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arrify": "1.0.1",
-								"micromatch": "3.1.10",
-								"object-assign": "4.1.1",
-								"read-pkg-up": "1.0.1",
-								"require-main-filename": "1.0.1"
+								"arrify": "^1.0.1",
+								"micromatch": "^3.1.8",
+								"object-assign": "^4.1.0",
+								"read-pkg-up": "^1.0.1",
+								"require-main-filename": "^1.0.1"
 							},
 							"dependencies": {
 								"arr-diff": {
@@ -6871,16 +6808,16 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"arr-flatten": "1.1.0",
-										"array-unique": "0.3.2",
-										"extend-shallow": "2.0.1",
-										"fill-range": "4.0.0",
-										"isobject": "3.0.1",
-										"repeat-element": "1.1.2",
-										"snapdragon": "0.8.2",
-										"snapdragon-node": "2.1.1",
-										"split-string": "3.1.0",
-										"to-regex": "3.0.2"
+										"arr-flatten": "^1.1.0",
+										"array-unique": "^0.3.2",
+										"extend-shallow": "^2.0.1",
+										"fill-range": "^4.0.0",
+										"isobject": "^3.0.1",
+										"repeat-element": "^1.1.2",
+										"snapdragon": "^0.8.1",
+										"snapdragon-node": "^2.0.1",
+										"split-string": "^3.0.2",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"extend-shallow": {
@@ -6888,7 +6825,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -6898,13 +6835,13 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"debug": "2.6.9",
-										"define-property": "0.2.5",
-										"extend-shallow": "2.0.1",
-										"posix-character-classes": "0.1.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"debug": "^2.3.3",
+										"define-property": "^0.2.5",
+										"extend-shallow": "^2.0.1",
+										"posix-character-classes": "^0.1.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
@@ -6912,7 +6849,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-descriptor": "0.1.6"
+												"is-descriptor": "^0.1.0"
 											}
 										},
 										"extend-shallow": {
@@ -6920,7 +6857,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										},
 										"is-accessor-descriptor": {
@@ -6928,7 +6865,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
@@ -6936,7 +6873,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -6946,7 +6883,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"kind-of": "3.2.2"
+												"kind-of": "^3.0.2"
 											},
 											"dependencies": {
 												"kind-of": {
@@ -6954,7 +6891,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"is-buffer": "1.1.6"
+														"is-buffer": "^1.1.5"
 													}
 												}
 											}
@@ -6964,9 +6901,9 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-accessor-descriptor": "0.1.6",
-												"is-data-descriptor": "0.1.4",
-												"kind-of": "5.1.0"
+												"is-accessor-descriptor": "^0.1.6",
+												"is-data-descriptor": "^0.1.4",
+												"kind-of": "^5.0.0"
 											}
 										},
 										"kind-of": {
@@ -6981,14 +6918,14 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"array-unique": "0.3.2",
-										"define-property": "1.0.0",
-										"expand-brackets": "2.1.4",
-										"extend-shallow": "2.0.1",
-										"fragment-cache": "0.2.1",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"array-unique": "^0.3.2",
+										"define-property": "^1.0.0",
+										"expand-brackets": "^2.1.4",
+										"extend-shallow": "^2.0.1",
+										"fragment-cache": "^0.2.1",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.1"
 									},
 									"dependencies": {
 										"define-property": {
@@ -6996,7 +6933,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-descriptor": "1.0.2"
+												"is-descriptor": "^1.0.0"
 											}
 										},
 										"extend-shallow": {
@@ -7004,7 +6941,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -7014,10 +6951,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-number": "3.0.0",
-										"repeat-string": "1.6.1",
-										"to-regex-range": "2.1.1"
+										"extend-shallow": "^2.0.1",
+										"is-number": "^3.0.0",
+										"repeat-string": "^1.6.1",
+										"to-regex-range": "^2.1.0"
 									},
 									"dependencies": {
 										"extend-shallow": {
@@ -7025,7 +6962,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-extendable": "0.1.1"
+												"is-extendable": "^0.1.0"
 											}
 										}
 									}
@@ -7035,7 +6972,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-data-descriptor": {
@@ -7043,7 +6980,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "6.0.2"
+										"kind-of": "^6.0.0"
 									}
 								},
 								"is-descriptor": {
@@ -7051,9 +6988,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "1.0.0",
-										"is-data-descriptor": "1.0.0",
-										"kind-of": "6.0.2"
+										"is-accessor-descriptor": "^1.0.0",
+										"is-data-descriptor": "^1.0.0",
+										"kind-of": "^6.0.2"
 									}
 								},
 								"is-number": {
@@ -7061,7 +6998,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -7069,7 +7006,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -7089,19 +7026,19 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"arr-diff": "4.0.0",
-										"array-unique": "0.3.2",
-										"braces": "2.3.2",
-										"define-property": "2.0.2",
-										"extend-shallow": "3.0.2",
-										"extglob": "2.0.4",
-										"fragment-cache": "0.2.1",
-										"kind-of": "6.0.2",
-										"nanomatch": "1.2.9",
-										"object.pick": "1.3.0",
-										"regex-not": "1.0.2",
-										"snapdragon": "0.8.2",
-										"to-regex": "3.0.2"
+										"arr-diff": "^4.0.0",
+										"array-unique": "^0.3.2",
+										"braces": "^2.3.1",
+										"define-property": "^2.0.2",
+										"extend-shallow": "^3.0.2",
+										"extglob": "^2.0.4",
+										"fragment-cache": "^0.2.1",
+										"kind-of": "^6.0.2",
+										"nanomatch": "^1.2.9",
+										"object.pick": "^1.3.0",
+										"regex-not": "^1.0.0",
+										"snapdragon": "^0.8.1",
+										"to-regex": "^3.0.2"
 									}
 								}
 							}
@@ -7116,7 +7053,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"to-regex": {
@@ -7124,10 +7061,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"regex-not": "1.0.2",
-								"safe-regex": "1.1.0"
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"regex-not": "^1.0.2",
+								"safe-regex": "^1.1.0"
 							}
 						},
 						"to-regex-range": {
@@ -7135,8 +7072,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1"
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1"
 							},
 							"dependencies": {
 								"is-number": {
@@ -7144,7 +7081,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									}
 								}
 							}
@@ -7160,9 +7097,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"source-map": "0.5.7",
-								"uglify-to-browserify": "1.0.2",
-								"yargs": "3.10.0"
+								"source-map": "~0.5.1",
+								"uglify-to-browserify": "~1.0.0",
+								"yargs": "~3.10.0"
 							},
 							"dependencies": {
 								"yargs": {
@@ -7171,9 +7108,9 @@
 									"dev": true,
 									"optional": true,
 									"requires": {
-										"camelcase": "1.2.1",
-										"cliui": "2.1.0",
-										"decamelize": "1.2.0",
+										"camelcase": "^1.0.2",
+										"cliui": "^2.1.0",
+										"decamelize": "^1.0.0",
 										"window-size": "0.1.0"
 									}
 								}
@@ -7190,10 +7127,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-union": "3.1.0",
-								"get-value": "2.0.6",
-								"is-extendable": "0.1.1",
-								"set-value": "0.4.3"
+								"arr-union": "^3.1.0",
+								"get-value": "^2.0.6",
+								"is-extendable": "^0.1.1",
+								"set-value": "^0.4.3"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -7201,7 +7138,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"set-value": {
@@ -7209,10 +7146,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"extend-shallow": "2.0.1",
-										"is-extendable": "0.1.1",
-										"is-plain-object": "2.0.4",
-										"to-object-path": "0.3.0"
+										"extend-shallow": "^2.0.1",
+										"is-extendable": "^0.1.1",
+										"is-plain-object": "^2.0.1",
+										"to-object-path": "^0.3.0"
 									}
 								}
 							}
@@ -7222,8 +7159,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-value": "0.3.1",
-								"isobject": "3.0.1"
+								"has-value": "^0.3.1",
+								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"has-value": {
@@ -7231,9 +7168,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"get-value": "2.0.6",
-										"has-values": "0.1.4",
-										"isobject": "2.1.0"
+										"get-value": "^2.0.3",
+										"has-values": "^0.1.4",
+										"isobject": "^2.0.0"
 									},
 									"dependencies": {
 										"isobject": {
@@ -7268,7 +7205,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7283,8 +7220,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"spdx-correct": "3.0.0",
-								"spdx-expression-parse": "3.0.0"
+								"spdx-correct": "^3.0.0",
+								"spdx-expression-parse": "^3.0.0"
 							}
 						},
 						"which": {
@@ -7292,7 +7229,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"isexe": "2.0.0"
+								"isexe": "^2.0.0"
 							}
 						},
 						"which-module": {
@@ -7316,8 +7253,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1"
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1"
 							},
 							"dependencies": {
 								"is-fullwidth-code-point": {
@@ -7325,7 +7262,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"number-is-nan": "1.0.1"
+										"number-is-nan": "^1.0.0"
 									}
 								},
 								"string-width": {
@@ -7333,9 +7270,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
 									}
 								}
 							}
@@ -7350,9 +7287,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"imurmurhash": "0.1.4",
-								"slide": "1.1.6"
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"slide": "^1.1.5"
 							}
 						},
 						"y18n": {
@@ -7370,18 +7307,18 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"cliui": "4.1.0",
-								"decamelize": "1.2.0",
-								"find-up": "2.1.0",
-								"get-caller-file": "1.0.2",
-								"os-locale": "2.1.0",
-								"require-directory": "2.1.1",
-								"require-main-filename": "1.0.1",
-								"set-blocking": "2.0.0",
-								"string-width": "2.1.1",
-								"which-module": "2.0.0",
-								"y18n": "3.2.1",
-								"yargs-parser": "9.0.2"
+								"cliui": "^4.0.0",
+								"decamelize": "^1.1.1",
+								"find-up": "^2.1.0",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^2.0.0",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^2.0.0",
+								"which-module": "^2.0.0",
+								"y18n": "^3.2.1",
+								"yargs-parser": "^9.0.2"
 							},
 							"dependencies": {
 								"ansi-regex": {
@@ -7399,9 +7336,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"string-width": "2.1.1",
-										"strip-ansi": "4.0.0",
-										"wrap-ansi": "2.1.0"
+										"string-width": "^2.1.1",
+										"strip-ansi": "^4.0.0",
+										"wrap-ansi": "^2.0.0"
 									}
 								},
 								"strip-ansi": {
@@ -7409,7 +7346,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"ansi-regex": "3.0.0"
+										"ansi-regex": "^3.0.0"
 									}
 								},
 								"yargs-parser": {
@@ -7417,7 +7354,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"camelcase": "4.1.0"
+										"camelcase": "^4.1.0"
 									}
 								}
 							}
@@ -7427,7 +7364,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							},
 							"dependencies": {
 								"camelcase": {
@@ -7447,15 +7384,15 @@
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
 			"dev": true,
 			"requires": {
-				"color-support": "1.1.3",
-				"debug": "2.6.9",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"readable-stream": "2.3.6",
-				"tap-parser": "5.4.0",
-				"unicode-length": "1.0.3"
+				"color-support": "^1.1.0",
+				"debug": "^2.1.3",
+				"diff": "^1.3.2",
+				"escape-string-regexp": "^1.0.3",
+				"glob": "^7.0.5",
+				"js-yaml": "^3.3.1",
+				"readable-stream": "^2.1.5",
+				"tap-parser": "^5.1.0",
+				"unicode-length": "^1.0.0"
 			},
 			"dependencies": {
 				"tap-parser": {
@@ -7464,9 +7401,9 @@
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 					"dev": true,
 					"requires": {
-						"events-to-array": "1.1.2",
-						"js-yaml": "3.12.0",
-						"readable-stream": "2.3.6"
+						"events-to-array": "^1.0.1",
+						"js-yaml": "^3.2.7",
+						"readable-stream": "^2"
 					}
 				}
 			}
@@ -7477,9 +7414,9 @@
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
 			"dev": true,
 			"requires": {
-				"events-to-array": "1.1.2",
-				"js-yaml": "3.12.0",
-				"minipass": "2.3.4"
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
 			}
 		},
 		"tmatch": {
@@ -7494,8 +7431,8 @@
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			}
 		},
 		"trivial-deferred": {
@@ -7510,47 +7447,127 @@
 			"integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw==",
 			"dev": true
 		},
-		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-			"dev": true
-		},
 		"tslint": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+			"integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.1",
-				"commander": "2.17.1",
-				"diff": "3.5.0",
-				"glob": "7.1.3",
-				"js-yaml": "3.12.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.1",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"dev": true,
+					"requires": {
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "1.1.3",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^2.2.1",
+								"escape-string-regexp": "^1.0.2",
+								"has-ansi": "^2.0.0",
+								"strip-ansi": "^3.0.0",
+								"supports-color": "^2.0.0"
+							}
+						}
+					}
+				},
+				"commander": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+					"dev": true
+				},
 				"diff": {
 					"version": "3.5.0",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+					"dev": true
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
+				"tslib": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+					"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+					"dev": true
+				},
+				"tsutils": {
+					"version": "2.29.0",
+					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+					"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.8.1"
+					}
 				}
-			}
-		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"dev": true,
-			"requires": {
-				"tslib": "1.9.3"
 			}
 		},
 		"tunnel-agent": {
@@ -7559,7 +7576,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -7570,9 +7587,9 @@
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
 			"dev": true
 		},
 		"unicode-length": {
@@ -7581,8 +7598,8 @@
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1",
-				"strip-ansi": "3.0.1"
+				"punycode": "^1.3.2",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"util-deprecate": {
@@ -7603,9 +7620,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -7614,7 +7631,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {
@@ -7629,9 +7646,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"yallist": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"devDependencies": {
 		"lerna": "^2.11.0",
 		"nodeunit": "^0.11.3",
-		"nyc": "^13.0.1",
-		"tslint": "^5.11.0",
-		"typescript": "^3.1.6"
+		"nyc": "^13.1.0",
+		"tslint": "^5.12.1",
+		"typescript": "^3.2.4"
 	}
 }

--- a/packages/codemaker/package-lock.json
+++ b/packages/codemaker/package-lock.json
@@ -1,21 +1,26 @@
 {
-	"requires": true,
+	"name": "codemaker",
+	"version": "0.7.13",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@types/camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@types/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha512-nsaprOtNLvUrLyFX5+mRpE9h2Q0d5YzQRr+Lav3fxdYtc1/E/U7G+Ld861NWBDDtWY3MnwKoUOhCrE1nrVxUQA=="
+			"integrity": "sha512-nsaprOtNLvUrLyFX5+mRpE9h2Q0d5YzQRr+Lav3fxdYtc1/E/U7G+Ld861NWBDDtWY3MnwKoUOhCrE1nrVxUQA==",
+			"dev": true
 		},
 		"@types/decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-viw/LG++yGW9GP7ggfDpR+qpBz/NHFEbRTWNumTzebeUlURwfX+sjQfdfbiEoxXgJrj+1G8p4VN/bLquur7Hmg=="
+			"integrity": "sha512-viw/LG++yGW9GP7ggfDpR+qpBz/NHFEbRTWNumTzebeUlURwfX+sjQfdfbiEoxXgJrj+1G8p4VN/bLquur7Hmg==",
+			"dev": true
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
 			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -23,17 +28,20 @@
 		"@types/node": {
 			"version": "8.10.37",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
+			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
+			"dev": true
 		},
 		"@types/nodeunit": {
 			"version": "0.0.30",
 			"resolved": "https://registry.npmjs.org/@types/nodeunit/-/nodeunit-0.0.30.tgz",
-			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng="
+			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng=",
+			"dev": true
 		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -44,12 +52,14 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -58,6 +68,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -65,32 +76,38 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -99,17 +116,20 @@
 		"bind-obj-methods": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-			"integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw=="
+			"integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -118,37 +138,43 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -156,17 +182,20 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"coveralls": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -180,6 +209,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
@@ -189,6 +219,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -197,6 +228,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -219,17 +251,20 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"diff": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -239,47 +274,56 @@
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"events-to-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"foreground-child": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^4",
 				"signal-exit": "^3.0.0"
@@ -288,12 +332,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
@@ -303,12 +349,13 @@
 		"fs-exists-cached": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
+			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+			"dev": true
 		},
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -318,17 +365,20 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-loop": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
-			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw="
+			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -337,6 +387,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -354,17 +405,20 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
 				"har-schema": "^2.0.0"
@@ -374,6 +428,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -383,12 +438,14 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -397,33 +454,39 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true,
 			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -433,22 +496,26 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -462,6 +529,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -472,17 +540,20 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -491,12 +562,14 @@
 		"mime-db": {
 			"version": "1.36.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.20",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+			"dev": true,
 			"requires": {
 				"mime-db": "~1.36.0"
 			}
@@ -505,6 +578,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -512,12 +586,14 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
 		},
 		"minipass": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -526,7 +602,8 @@
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+					"dev": true
 				}
 			}
 		},
@@ -534,6 +611,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -541,19 +619,22 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
 				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"nodeunit": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
+			"dev": true,
 			"requires": {
 				"ejs": "^2.5.2",
 				"tap": "^12.0.1"
@@ -563,6 +644,7 @@
 			"version": "11.9.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
@@ -596,6 +678,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -604,62 +687,76 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"atob": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "^1.1.3",
 						"esutils": "^2.0.2",
@@ -669,6 +766,7 @@
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "^6.23.0",
 						"babel-runtime": "^6.26.0",
@@ -683,6 +781,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.22.0"
 					}
@@ -690,6 +789,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -698,6 +798,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -709,6 +810,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -724,6 +826,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -733,15 +836,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"base": {
 					"version": "0.11.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cache-base": "^1.0.1",
 						"class-utils": "^0.3.5",
@@ -755,6 +861,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -762,6 +869,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -769,6 +877,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -776,6 +885,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -784,17 +894,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -803,6 +916,7 @@
 				"braces": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -819,6 +933,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -827,11 +942,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"collection-visit": "^1.0.0",
 						"component-emitter": "^1.2.1",
@@ -846,13 +963,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "^1.2.0",
 						"mkdirp": "^0.5.1",
@@ -862,11 +981,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
@@ -876,6 +997,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -887,6 +1009,7 @@
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"define-property": "^0.2.5",
@@ -897,19 +1020,22 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -920,17 +1046,20 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-visit": "^1.0.0",
 						"object-visit": "^1.0.0"
@@ -938,31 +1067,38 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -971,25 +1107,30 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "^2.0.0"
 					}
@@ -997,6 +1138,7 @@
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.2",
 						"isobject": "^3.0.1"
@@ -1005,6 +1147,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1012,6 +1155,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1019,6 +1163,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -1027,17 +1172,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -1045,21 +1193,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -1073,6 +1225,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -1084,6 +1237,7 @@
 				"expand-brackets": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -1097,6 +1251,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -1104,6 +1259,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1113,6 +1269,7 @@
 				"extend-shallow": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"assign-symbols": "^1.0.0",
 						"is-extendable": "^1.0.1"
@@ -1121,6 +1278,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -1130,6 +1288,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -1144,6 +1303,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -1151,6 +1311,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1158,6 +1319,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1165,6 +1327,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1172,6 +1335,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -1180,13 +1344,15 @@
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"fill-range": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -1197,6 +1363,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1206,6 +1373,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"mkdirp": "^0.5.1",
@@ -1215,17 +1383,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
@@ -1234,29 +1405,35 @@
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -1268,15 +1445,18 @@
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -1287,6 +1467,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
@@ -1296,17 +1477,20 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"has-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.6",
 						"has-values": "^1.0.0",
@@ -1315,13 +1499,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"kind-of": "^4.0.0"
@@ -1330,6 +1516,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -1337,6 +1524,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -1346,6 +1534,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -1354,15 +1543,18 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -1370,37 +1562,44 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
@@ -1408,6 +1607,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -1415,6 +1615,7 @@
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -1423,28 +1624,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-number": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -1452,60 +1658,72 @@
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "^0.4.0"
 					}
@@ -1513,6 +1731,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "^6.18.0",
 						"babel-template": "^6.16.0",
@@ -1526,6 +1745,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "^1.1.2",
 						"mkdirp": "^0.5.1",
@@ -1536,6 +1756,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "^1.0.0"
 							}
@@ -1545,6 +1766,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"istanbul-lib-coverage": "^1.1.2",
@@ -1556,6 +1778,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -1565,21 +1788,25 @@
 				"istanbul-reports": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -1587,11 +1814,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -1599,6 +1828,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -1610,6 +1840,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -1617,21 +1848,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.10",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "^3.0.0"
 					}
@@ -1639,6 +1874,7 @@
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -1646,11 +1882,13 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"object-visit": "^1.0.0"
 					}
@@ -1658,17 +1896,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -1676,19 +1917,22 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -1707,28 +1951,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "^1.0.2",
 						"is-extendable": "^1.0.1"
@@ -1737,6 +1986,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -1746,17 +1996,20 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -1774,21 +2027,25 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -1799,21 +2056,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"copy-descriptor": "^0.1.0",
 						"define-property": "^0.2.5",
@@ -1823,6 +2084,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -1832,32 +2094,37 @@
 				"object-visit": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1865,6 +2132,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -1872,11 +2140,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -1885,11 +2155,13 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -1897,47 +2169,56 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -1946,15 +2227,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -1962,6 +2246,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					},
@@ -1969,6 +2254,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -1978,15 +2264,18 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -1996,6 +2285,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -2004,6 +2294,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -2013,11 +2304,13 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-not": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.2",
 						"safe-regex": "^1.1.0"
@@ -2025,42 +2318,51 @@
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -2069,6 +2371,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -2076,21 +2379,25 @@
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-value": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -2101,6 +2408,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2110,25 +2418,30 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"base": "^0.11.1",
 						"debug": "^2.2.0",
@@ -2143,6 +2456,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -2150,6 +2464,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2159,6 +2474,7 @@
 				"snapdragon-node": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^1.0.0",
 						"isobject": "^3.0.0",
@@ -2168,6 +2484,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -2175,6 +2492,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2182,6 +2500,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2189,6 +2508,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -2197,28 +2517,33 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"atob": "^2.0.0",
 						"decode-uri-component": "^0.2.0",
@@ -2229,11 +2554,13 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -2246,6 +2573,7 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2253,11 +2581,13 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2265,11 +2595,13 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"split-string": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.0"
 					}
@@ -2277,6 +2609,7 @@
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^0.2.5",
 						"object-copy": "^0.1.0"
@@ -2285,6 +2618,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -2294,6 +2628,7 @@
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -2301,11 +2636,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -2315,6 +2652,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2322,21 +2660,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
 						"micromatch": "^3.1.8",
@@ -2347,15 +2689,18 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"braces": {
 							"version": "2.3.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -2372,6 +2717,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2381,6 +2727,7 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -2394,6 +2741,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -2401,6 +2749,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2408,6 +2757,7 @@
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -2415,6 +2765,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -2424,6 +2775,7 @@
 								"is-data-descriptor": {
 									"version": "0.1.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -2431,6 +2783,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -2440,6 +2793,7 @@
 								"is-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^0.1.6",
 										"is-data-descriptor": "^0.1.4",
@@ -2448,13 +2802,15 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -2469,6 +2825,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -2476,6 +2833,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2485,6 +2843,7 @@
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -2495,6 +2854,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2504,6 +2864,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2511,6 +2872,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2518,6 +2880,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -2527,6 +2890,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -2534,6 +2898,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -2542,15 +2907,18 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"micromatch": {
 							"version": "3.1.10",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -2571,11 +2939,13 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -2583,6 +2953,7 @@
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^2.0.2",
 						"extend-shallow": "^3.0.2",
@@ -2593,6 +2964,7 @@
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
@@ -2601,6 +2973,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -2609,11 +2982,13 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -2624,6 +2999,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -2637,11 +3013,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"get-value": "^2.0.6",
@@ -2652,6 +3030,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2659,6 +3038,7 @@
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -2671,6 +3051,7 @@
 				"unset-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"has-value": "^0.3.1",
 						"isobject": "^3.0.0"
@@ -2679,6 +3060,7 @@
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"get-value": "^2.0.3",
 								"has-values": "^0.1.4",
@@ -2688,6 +3070,7 @@
 								"isobject": {
 									"version": "2.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -2696,34 +3079,40 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"use": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -2732,26 +3121,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -2760,6 +3154,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -2767,6 +3162,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -2777,11 +3173,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -2790,15 +3188,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -2816,15 +3217,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
@@ -2834,6 +3238,7 @@
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -2841,6 +3246,7 @@
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							}
@@ -2850,13 +3256,15 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -2865,12 +3273,14 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -2878,22 +3288,26 @@
 		"opener": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
+			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"own-or": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw="
+			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+			"dev": true
 		},
 		"own-or-env": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+			"dev": true,
 			"requires": {
 				"own-or": "^1.0.0"
 			}
@@ -2901,43 +3315,51 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true,
 			"optional": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.29",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -2953,6 +3375,7 @@
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -2980,6 +3403,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -2987,27 +3411,32 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.5.9",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -3016,12 +3445,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3037,12 +3468,14 @@
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -3052,6 +3485,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -3060,6 +3494,7 @@
 			"version": "12.0.1",
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
+			"dev": true,
 			"requires": {
 				"bind-obj-methods": "^2.0.0",
 				"bluebird": "^3.5.1",
@@ -3096,6 +3531,7 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
+			"dev": true,
 			"requires": {
 				"color-support": "^1.1.0",
 				"debug": "^2.1.3",
@@ -3112,6 +3548,7 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+					"dev": true,
 					"requires": {
 						"events-to-array": "^1.0.1",
 						"js-yaml": "^3.2.7",
@@ -3124,6 +3561,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+			"dev": true,
 			"requires": {
 				"events-to-array": "^1.0.1",
 				"js-yaml": "^3.2.7",
@@ -3133,12 +3571,14 @@
 		"tmatch": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tmatch/-/tmatch-4.0.0.tgz",
-			"integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg=="
+			"integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg==",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"dev": true,
 			"requires": {
 				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
@@ -3147,17 +3587,20 @@
 		"trivial-deferred": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
-			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM="
+			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+			"dev": true
 		},
 		"tsame": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.0.tgz",
-			"integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw=="
+			"integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3166,17 +3609,20 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+			"dev": true
 		},
 		"unicode-length": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+			"dev": true,
 			"requires": {
 				"punycode": "^1.3.2",
 				"strip-ansi": "^3.0.1"
@@ -3191,17 +3637,20 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true,
 			"optional": true
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -3212,6 +3661,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -3219,12 +3669,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -3234,12 +3686,14 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yapool": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+			"dev": true
 		}
 	}
 }

--- a/packages/codemaker/package.json
+++ b/packages/codemaker/package.json
@@ -15,14 +15,14 @@
     "@types/decamelize": "^1.2.0",
     "@types/fs-extra": "^5.0.4",
     "@types/node": "^8.10.37",
-    "@types/nodeunit": "0.0.30",
+    "@types/nodeunit": "^0.0.30",
     "nodeunit": "^0.11.3",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "dependencies": {
-    "camelcase": "^4.1.0",
+    "camelcase": "^5.0.0",
     "decamelize": "^2.0.0",
-    "fs-extra": "^7.0.0"
+    "fs-extra": "^7.0.1"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-build-tools/package-lock.json
+++ b/packages/jsii-build-tools/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",

--- a/packages/jsii-build-tools/package.json
+++ b/packages/jsii-build-tools/package.json
@@ -14,7 +14,7 @@
     "build": "chmod +x bin/*"
   },
   "dependencies": {
-    "fs-extra": "^7.0.0"
+    "fs-extra": "^7.0.1"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-calc-base-of-base/package-lock.json
+++ b/packages/jsii-calc-base-of-base/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-calc-base-of-base/package.json
+++ b/packages/jsii-calc-base-of-base/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "jsii": "^0.7.13",
     "jsii-build-tools": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-calc-base/package-lock.json
+++ b/packages/jsii-calc-base/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-calc-base/package.json
+++ b/packages/jsii-calc-base/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "jsii": "^0.7.13",
     "jsii-build-tools": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "dependencies": {
     "@scope/jsii-calc-base-of-base": "^0.7.13"

--- a/packages/jsii-calc-lib/package-lock.json
+++ b/packages/jsii-calc-lib/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-calc-lib/package.json
+++ b/packages/jsii-calc-lib/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "jsii": "^0.7.13",
     "jsii-build-tools": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "dependencies": {
     "@scope/jsii-calc-base": "^0.7.13"

--- a/packages/jsii-calc/package-lock.json
+++ b/packages/jsii-calc/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^8.10.37",
     "jsii": "^0.7.13",
     "jsii-build-tools": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-dotnet-jsonmodel/package-lock.json
+++ b/packages/jsii-dotnet-jsonmodel/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-dotnet-jsonmodel/package.json
+++ b/packages/jsii-dotnet-jsonmodel/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/node": "^8.10.37",
     "jsii-build-tools": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-dotnet-runtime-test/package-lock.json
+++ b/packages/jsii-dotnet-runtime-test/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-dotnet-runtime-test/package.json
+++ b/packages/jsii-dotnet-runtime-test/package.json
@@ -15,7 +15,7 @@
     "jsii-calc": "^0.7.13",
     "jsii-dotnet-runtime": "^0.7.13",
     "jsii-pacmak": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-dotnet-runtime/package-lock.json
+++ b/packages/jsii-dotnet-runtime/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-dotnet-runtime/package.json
+++ b/packages/jsii-dotnet-runtime/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^8.10.37",
     "jsii-build-tools": "^0.7.13",
     "jsii-runtime": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "dependencies": {
     "jsii-dotnet-jsonmodel": "^0.7.13"

--- a/packages/jsii-java-runtime/package-lock.json
+++ b/packages/jsii-java-runtime/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-java-runtime/package.json
+++ b/packages/jsii-java-runtime/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^8.10.37",
     "jsii-build-tools": "^0.7.13",
     "jsii-runtime": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-kernel/package-lock.json
+++ b/packages/jsii-kernel/package-lock.json
@@ -158,9 +158,9 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -227,9 +227,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -374,9 +374,9 @@
 			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
 		},
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -625,9 +625,9 @@
 			}
 		},
 		"minizlib": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-			"integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -3084,11 +3084,11 @@
 			}
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"rimraf": {
@@ -3110,9 +3110,9 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -3263,9 +3263,9 @@
 			}
 		},
 		"tar": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz",
-			"integrity": "sha512-mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
@@ -3277,9 +3277,9 @@
 			},
 			"dependencies": {
 				"yallist": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -3313,9 +3313,9 @@
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tslint": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+			"integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"builtin-modules": "^1.1.1",
@@ -3361,9 +3361,9 @@
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"unicode-length": {
 			"version": "1.0.3",

--- a/packages/jsii-kernel/package.json
+++ b/packages/jsii-kernel/package.json
@@ -16,19 +16,19 @@
     "@scope/jsii-calc-lib": "^0.7.13",
     "@types/fs-extra": "^5.0.4",
     "@types/node": "^8.10.37",
-    "@types/nodeunit": "0.0.30",
+    "@types/nodeunit": "^0.0.30",
     "@types/tar": "^4.0.0",
-    "fs-extra": "^7.0.0",
+    "fs-extra": "^7.0.1",
     "jsii-build-tools": "^0.7.13",
     "jsii-calc": "^0.7.13",
     "nodeunit": "^0.11.3",
-    "tslint": "*",
-    "typescript": "^3.1.6"
+    "tslint": "^5.12.1",
+    "typescript": "^3.2.4"
   },
   "dependencies": {
     "jsii-spec": "^0.7.13",
-    "source-map": "^0.7.0",
-    "tar": "^4.4.7"
+    "source-map": "^0.7.3",
+    "tar": "^4.4.8"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -86,7 +86,7 @@ import { VERSION_DESC } from '../lib/version';
     const rootDir = path.resolve(process.cwd(), argv._[0] || '.');
 
     const visited = new Set<string>();
-    await buildPackage(rootDir, true /* isRoot */, argv.forceSubdirectory);
+    await buildPackage(rootDir, true /* isRoot */, argv['force-subdirectory']);
 
     async function buildPackage(packageDir: string, isRoot: boolean, forceSubdirectory: boolean) {
         if (visited.has(packageDir)) {
@@ -133,9 +133,11 @@ import { VERSION_DESC } from '../lib/version';
             const tarball = await npmPack(packageDir, tmpdir);
             for (const targetName of targets) {
                 // if we are targeting a single language, output to outdir, otherwise outdir/<target>
-                const targetOutputDir = (targets.length > 1 || forceSubdirectory) ? path.join(outDir, targetName) : outDir;
+                const targetOutputDir = (targets.length > 1 || forceSubdirectory)
+                                      ? path.join(outDir, targetName.toString())
+                                      : outDir;
                 logging.debug(`Building ${pkg.name}/${targetName}: ${targetOutputDir}`);
-                await generateTarget(packageDir, targetName, targetOutputDir, tarball);
+                await generateTarget(packageDir, targetName.toString(), targetOutputDir, tarball);
             }
         } finally {
             logging.debug(`Removing ${tmpdir}`);

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -26,14 +26,14 @@
 			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng="
 		},
 		"@types/xmlbuilder": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz",
-			"integrity": "sha512-pYpeUBPFwOga4mkz9kpfua5dUBNUjPGiasg+O1HFYJpJy/NqQhnhm95NFMD9U1825AIrEVyWx0kvAKsV3+CZAA=="
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.34.tgz",
+			"integrity": "sha512-yVsHfYqJblSEg3DvUhGndpCZBZz2GiGVmqMa04fbGro2xzxRj85Q7MQ4os+MaXmKcpCDD42MXuxUWfoUKTuVdQ=="
 		},
 		"@types/yargs": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-11.1.2.tgz",
-			"integrity": "sha512-zG61PAp2OcoIBjRV44wftJj6AJgzJrOc32LCYOBqk9bdgcdzK5DCJHV9QZJ60+Fu+fOn79g8Ks3Gixm4CfkZ+w=="
+			"version": "12.0.8",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.8.tgz",
+			"integrity": "sha512-OMSKUmZ09gbzITzx4nxnJqhprWC7JqsmlrEsVtb+cv3GXHNpv0kktqxhboKX52FnMggkQvT5ezt8pxTWyKpJHA=="
 		},
 		"ajv": {
 			"version": "5.5.2",
@@ -160,9 +160,9 @@
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -170,9 +170,9 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -269,9 +269,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -322,12 +322,9 @@
 			}
 		},
 		"decamelize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-			"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-			"requires": {
-				"xregexp": "4.0.0"
-			}
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -354,6 +351,14 @@
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -375,12 +380,12 @@
 			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
 		},
 		"execa": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-			"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
 				"cross-spawn": "^6.0.0",
-				"get-stream": "^3.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
@@ -460,33 +465,13 @@
 			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
 		},
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
-			},
-			"dependencies": {
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-				}
 			}
 		},
 		"fs.realpath": {
@@ -505,9 +490,12 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -667,6 +655,14 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -715,16 +711,16 @@
 			}
 		},
 		"map-age-cleaner": {
-			"version": "0.1.2",
-			"resolved": "http://localhost:4873/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-			"integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
 		},
 		"mem": {
 			"version": "4.0.0",
-			"resolved": "http://localhost:4873/mem/-/mem-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
 			"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
@@ -3153,11 +3149,11 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-			"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"lcid": "^2.0.0",
 				"mem": "^4.0.0"
 			}
@@ -3177,23 +3173,23 @@
 		},
 		"p-defer": {
 			"version": "1.0.0",
-			"resolved": "http://localhost:4873/p-defer/-/p-defer-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
 		"p-finally": {
 			"version": "1.0.0",
-			"resolved": "http://localhost:4873/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://localhost:4873/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
-			"version": "2.0.0",
-			"resolved": "http://localhost:4873/p-limit/-/p-limit-2.0.0.tgz",
-			"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -3251,6 +3247,15 @@
 			"version": "1.1.29",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
 			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "1.4.1",
@@ -3315,11 +3320,11 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"rimraf": {
@@ -3341,9 +3346,9 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -3383,9 +3388,9 @@
 			}
 		},
 		"spdx-license-list": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-4.1.0.tgz",
-			"integrity": "sha512-nlyjgQUe1PgBGU0RdXIwo+N1VHI0XV/hxCBms8fhRDV7qottuPdX3gcTB4dpNnnQ/fIC3ymb/oWB6S8T6nQEnw=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-5.0.0.tgz",
+			"integrity": "sha512-N5u9tEFRBUzQDjMKRRt8SHxC/UaqYApPmdF4MMFnICQg3z52onNbnneuro/sWw2rd+eGu9agQOzUbD671Xia7Q=="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -3456,7 +3461,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"supports-color": {
@@ -3568,9 +3573,9 @@
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tslint": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+			"integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"builtin-modules": "^1.1.1",
@@ -3616,9 +3621,9 @@
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"unicode-length": {
 			"version": "1.0.3",
@@ -3628,6 +3633,11 @@
 				"punycode": "^1.3.2",
 				"strip-ansi": "^3.0.1"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -3660,12 +3670,12 @@
 		},
 		"which-module": {
 			"version": "2.0.0",
-			"resolved": "http://localhost:4873/which-module/-/which-module-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://localhost:4873/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -3674,7 +3684,7 @@
 			"dependencies": {
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "http://localhost:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -3682,7 +3692,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "http://localhost:4873/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -3712,11 +3722,6 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
 			"integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="
 		},
-		"xregexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
-		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -3733,12 +3738,12 @@
 			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
 		},
 		"yargs": {
-			"version": "12.0.2",
-			"resolved": "http://localhost:4873/yargs/-/yargs-12.0.2.tgz",
-			"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^2.0.0",
+				"decamelize": "^1.2.0",
 				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^3.0.0",
@@ -3748,15 +3753,16 @@
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^10.1.0"
+				"yargs-parser": "^11.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "10.1.0",
-			"resolved": "http://localhost:4873/yargs-parser/-/yargs-parser-10.1.0.tgz",
-			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -20,22 +20,22 @@
     "aws"
   ],
   "dependencies": {
-    "clone": "^2.1.1",
+    "clone": "^2.1.2",
     "codemaker": "^0.7.13",
-    "fs-extra": "^7.0.0",
+    "fs-extra": "^7.0.1",
     "jsii-spec": "^0.7.13",
-    "spdx-license-list": "^4.1.0",
+    "spdx-license-list": "^5.0.0",
     "xmlbuilder": "^10.1.1",
-    "yargs": "^12.0.2"
+    "yargs": "^12.0.5"
   },
   "devDependencies": {
     "@scope/jsii-calc-lib": "^0.7.13",
     "@types/clone": "^0.1.30",
     "@types/fs-extra": "^5.0.4",
     "@types/node": "^8.10.37",
-    "@types/nodeunit": "0.0.30",
-    "@types/xmlbuilder": "^0.0.32",
-    "@types/yargs": "^11.1.2",
+    "@types/nodeunit": "^0.0.30",
+    "@types/xmlbuilder": "^0.0.34",
+    "@types/yargs": "^12.0.8",
     "jsii-build-tools": "^0.7.13",
     "jsii-calc": "^0.7.13",
     "jsii-dotnet-generator": "^0.7.13",
@@ -43,8 +43,8 @@
     "jsii-dotnet-runtime": "^0.7.13",
     "jsii-java-runtime": "^0.7.13",
     "nodeunit": "^0.11.3",
-    "tslint": "*",
-    "typescript": "^3.1.6"
+    "tslint": "^5.12.1",
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-reflect/bin/jsii-tree.ts
+++ b/packages/jsii-reflect/bin/jsii-tree.ts
@@ -7,8 +7,8 @@ import { TypeSystem, TypeSystemTree } from '../lib';
 async function main() {
   const options = yargs
     .usage('$0 <JSII-FILE | MODULE-DIR...>', 'Prints an ASCII tree representation of a jsii type system.', args => args
-      .positional('JSII-FILE', { desc: 'path to a .jsii file to load, all dependency .jsii files must be explicitly supplied' })
-      .positional('MODULE_DIR', { desc: 'path to an jsii npm module directory, all jsii dependencies will be loaded transitively' }))
+      .positional('JSII-FILE', { type: 'string', desc: 'path to a .jsii file to load, all dependency .jsii files must be explicitly supplied' })
+      .positional('MODULE-DIR', { type: 'string', desc: 'path to an jsii npm module directory, all jsii dependencies will be loaded transitively' }))
     .option('all', { type: 'boolean', alias: 'a', desc: 'show all details', default: false })
     .option('colors', { type: 'boolean', desc: 'enable/disable ANSI colors in output', default: true })
     .option('dependencies', { type: 'boolean', alias: 'd', desc: 'show assembly dependencies', default: false })
@@ -20,7 +20,7 @@ async function main() {
 
   const typesys = new TypeSystem();
 
-  for (const fileOrDirectory of options.jsiiFile) {
+  for (const fileOrDirectory of options.jsiiFile as string[]) {
     await typesys.load(fileOrDirectory);
   }
 

--- a/packages/jsii-reflect/jest.config.js
+++ b/packages/jsii-reflect/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/jsii-reflect/package-lock.json
+++ b/packages/jsii-reflect/package-lock.json
@@ -10,6 +10,90 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+      "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helpers": "^7.2.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/template": "^7.2.2",
+        "@babel/traverse": "^7.2.2",
+        "@babel/types": "^7.2.2",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+      "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+      "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+      "requires": {
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.3.0"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -18,13 +102,55 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+      "integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA=="
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+      "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@types/fs-extra": {
@@ -36,9 +162,9 @@
       }
     },
     "@types/jest": {
-      "version": "23.3.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.10.tgz",
-      "integrity": "sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ=="
+      "version": "23.3.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.13.tgz",
+      "integrity": "sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA=="
     },
     "@types/node": {
       "version": "10.12.12",
@@ -46,9 +172,9 @@
       "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
     },
     "@types/yargs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.1.tgz",
-      "integrity": "sha512-UVjo2oH79aRNcsDlFlnQ/iJ67Jd7j6uSg7jUJP/RZ/nUjAh5ElmnwlD5K/6eGgETJUgCHkiWn91B8JjXQ6ubAw=="
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.8.tgz",
+      "integrity": "sha512-OMSKUmZ09gbzITzx4nxnJqhprWC7JqsmlrEsVtb+cv3GXHNpv0kktqxhboKX52FnMggkQvT5ezt8pxTWyKpJHA=="
     },
     "abab": {
       "version": "2.0.0",
@@ -70,9 +196,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+          "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
         }
       }
     },
@@ -82,9 +208,9 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -93,9 +219,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -117,264 +243,14 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        }
       }
     },
     "append-transform": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "argparse": {
@@ -386,12 +262,9 @@
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -405,13 +278,13 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "arrify": {
       "version": "1.0.1",
@@ -474,256 +347,38 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
     "babel-jest": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-      "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.0.0.tgz",
+      "integrity": "sha512-YGKRbZUjoRmNIAyG7x4wYxUyHvHPFpYXj6Mx1A5cslhaQOUgP/+LF3wtFgMuOQkIpjbVNBufmOnVY0QVwB5v9Q==",
       "requires": {
-        "babel-plugin-istanbul": "^4.1.6",
-        "babel-preset-jest": "^23.2.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.0.0"
       }
     },
     "babel-plugin-istanbul": {
-      "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz",
+      "integrity": "sha512-CLoXPRSUWiR8yao8bShqZUIC6qLfZVVY3X1wj+QPNXu0wfmrRRfarh1LYy+dYMVI+bDj0ghy3tuqFFRFZmL1Nw==",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "test-exclude": "^4.2.1"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        }
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.0.0",
+        "test-exclude": "^5.0.0"
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-      "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.0.0.tgz",
+      "integrity": "sha512-ipefE7YWNyRNVaV/MonUb/I5nef53ZRFR74P9meMGmJxqt8s1BJmfhw11YeIMbcjXN4fxtWUaskZZe8yreXE1Q=="
     },
     "babel-preset-jest": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-      "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.0.0.tgz",
+      "integrity": "sha512-ECMMOLvNDCmsn3geBa3JkwzylcfpThMpAdfreONQm8EmXcs4tXUpXZDQPxiIMg7nMobTuAC2zDGIKrbrBXW2Vg==",
       "requires": {
-        "babel-plugin-jest-hoist": "^23.2.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.0.0"
       }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -777,16 +432,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -808,13 +453,30 @@
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "browser-process-hrtime": {
@@ -870,19 +532,12 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
     },
     "callsites": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw=="
     },
     "camelcase": {
       "version": "5.0.0",
@@ -903,9 +558,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -913,9 +568,9 @@
       }
     },
     "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -935,11 +590,6 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -986,9 +636,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -1003,6 +653,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
       "optional": true
+    },
+    "compare-versions": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1026,11 +681,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1093,11 +743,11 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -1116,11 +766,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "^3.0.0"
       }
     },
     "define-properties": {
@@ -1165,16 +815,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -1183,23 +823,15 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    "diff-sequences": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.0.0.tgz",
+      "integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -1218,6 +850,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1227,15 +867,16 @@
       }
     },
     "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "requires": {
-        "es-to-primitive": "^1.1.1",
+        "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -1321,32 +962,60 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "^2.1.0"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "expect": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-      "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.0.0.tgz",
+      "integrity": "sha512-qDHRU4lGsme0xjg8dXp/RQhvO9XIo9FWqVo7dTHDPBwzy25JGEHAWFsnpmRYErB50tgi/6euo3ir5e/kF9LUTA==",
       "requires": {
         "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.6.0",
-        "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0"
+        "jest-get-type": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "jest-message-util": "^24.0.0",
+        "jest-regex-util": "^24.0.0"
       }
     },
     "extend": {
@@ -1374,11 +1043,62 @@
       }
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -1409,11 +1129,6 @@
         "bser": "^2.0.0"
       }
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-    },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -1424,15 +1139,24 @@
       }
     },
     "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -1447,14 +1171,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "^1.0.1"
-      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1495,9 +1211,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -1519,7 +1235,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1529,37 +1245,32 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1575,7 +1286,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "optional": true
         },
@@ -1618,7 +1329,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1636,11 +1347,11 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -1662,8 +1373,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1673,7 +1383,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1686,27 +1395,24 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1716,7 +1422,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1727,7 +1432,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1737,17 +1442,17 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -1763,12 +1468,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1789,8 +1494,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1800,7 +1504,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1835,11 +1538,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -1867,15 +1570,15 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true
         },
         "safer-buffer": {
@@ -1889,7 +1592,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "optional": true
         },
@@ -1906,7 +1609,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1934,16 +1636,16 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -1953,11 +1655,11 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -1965,7 +1667,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }
@@ -2011,27 +1713,10 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "^2.0.0"
-      }
-    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
     },
     "graceful-fs": {
       "version": "4.1.15",
@@ -2083,21 +1768,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        }
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2116,13 +1786,6 @@
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
     },
     "has-values": {
@@ -2134,24 +1797,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -2160,15 +1805,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2203,11 +1839,11 @@
       }
     },
     "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "requires": {
-        "pkg-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
       }
     },
@@ -2249,6 +1885,16 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -2263,7 +1909,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -2275,11 +1921,11 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-data-descriptor": {
@@ -2288,6 +1934,16 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -2312,36 +1968,10 @@
         }
       }
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -2349,24 +1979,26 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+      "integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g=="
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-plain-object": {
@@ -2375,24 +2007,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -2420,11 +2035,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2441,12 +2051,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -2454,142 +2061,184 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-      "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.0.tgz",
+      "integrity": "sha512-+Ygg4t1StoiNlBGc6x0f8q/Bv26FbZqP/+jegzfNpU7Q8o+4ZRoJxJPhBkgE/UonpAjtxnE4zCZIyJX+MwLRMQ==",
       "requires": {
-        "async": "^2.1.4",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.2.1",
-        "istanbul-lib-hook": "^1.2.2",
-        "istanbul-lib-instrument": "^1.10.2",
-        "istanbul-lib-report": "^1.1.5",
-        "istanbul-lib-source-maps": "^1.2.6",
-        "istanbul-reports": "^1.5.1",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
+        "async": "^2.6.1",
+        "compare-versions": "^3.2.1",
+        "fileset": "^2.0.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.1.0",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.0",
+        "js-yaml": "^3.12.0",
+        "make-dir": "^1.3.0",
+        "minimatch": "^3.0.4",
         "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-      "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw=="
     },
     "istanbul-lib-hook": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-      "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+      "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-      "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.1",
-        "semver": "^5.3.0"
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
+        "semver": "^5.5.0"
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-      "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+      "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
       "requires": {
-        "istanbul-lib-coverage": "^1.2.1",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "^2.0.3",
+        "make-dir": "^1.3.0",
+        "supports-color": "^6.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
         "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-      "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+      "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.2.1",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.3",
+        "make-dir": "^1.3.0",
+        "rimraf": "^2.6.2",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
     "istanbul-reports": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-      "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.0.tgz",
+      "integrity": "sha512-azQdSX+dtTtkQEfqq20ICxWi6eOHXyHIgMFw1VOOVi8iIPWeCWRgCyFh/CsBKIhcgskMI8ExXmU7rjXTRCIJ+A==",
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "^4.0.11"
       }
     },
     "jest": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-      "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.0.0.tgz",
+      "integrity": "sha512-1Z2EblP4BnERbWZGtipGb9zjHDq7nCHgCY7V57F5SYaFRJV4DE1HKoOz+CRC5OrAThN9OVhRlUhTzsTFArg2iQ==",
       "requires": {
-        "import-local": "^1.0.0",
-        "jest-cli": "^23.6.0"
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.0.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
         },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+        "jest-cli": {
+          "version": "24.0.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.0.0.tgz",
+          "integrity": "sha512-mElnFipLaGxo1SiQ1CLvuaz3eX07MJc4HcyKrApSJf8xSdY1/EwaHurKwu1g2cDiwIgY8uHj7UcF5OYbtiBOWg==",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.15",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "istanbul-api": "^2.0.8",
+            "istanbul-lib-coverage": "^2.0.2",
+            "istanbul-lib-instrument": "^3.0.1",
+            "istanbul-lib-source-maps": "^3.0.1",
+            "jest-changed-files": "^24.0.0",
+            "jest-config": "^24.0.0",
+            "jest-environment-jsdom": "^24.0.0",
+            "jest-get-type": "^24.0.0",
+            "jest-haste-map": "^24.0.0",
+            "jest-message-util": "^24.0.0",
+            "jest-regex-util": "^24.0.0",
+            "jest-resolve-dependencies": "^24.0.0",
+            "jest-runner": "^24.0.0",
+            "jest-runtime": "^24.0.0",
+            "jest-snapshot": "^24.0.0",
+            "jest-util": "^24.0.0",
+            "jest-validate": "^24.0.0",
+            "jest-watcher": "^24.0.0",
+            "jest-worker": "^24.0.0",
+            "micromatch": "^3.1.10",
+            "node-notifier": "^5.2.1",
+            "p-each-series": "^1.0.0",
+            "pirates": "^4.0.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.0.0",
+            "rimraf": "^2.5.4",
+            "slash": "^2.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^5.0.0",
+            "which": "^1.2.12",
+            "yargs": "^12.0.2"
           }
         },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.0.0.tgz",
+      "integrity": "sha512-nnuU510R9U+UX0WNb5XFEcsrMqriSiRLeO9KWDFgPrpToaQm60prfQYpxsXigdClpvNot5bekDY440x9dNGnsQ==",
+      "requires": {
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -2597,311 +2246,171 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "jest-cli": {
-          "version": "23.6.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-          "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "import-local": "^1.0.0",
-            "is-ci": "^1.0.10",
-            "istanbul-api": "^1.3.1",
-            "istanbul-lib-coverage": "^1.2.0",
-            "istanbul-lib-instrument": "^1.10.1",
-            "istanbul-lib-source-maps": "^1.2.4",
-            "jest-changed-files": "^23.4.2",
-            "jest-config": "^23.6.0",
-            "jest-environment-jsdom": "^23.4.0",
-            "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.6.0",
-            "jest-message-util": "^23.4.0",
-            "jest-regex-util": "^23.3.0",
-            "jest-resolve-dependencies": "^23.6.0",
-            "jest-runner": "^23.6.0",
-            "jest-runtime": "^23.6.0",
-            "jest-snapshot": "^23.6.0",
-            "jest-util": "^23.4.0",
-            "jest-validate": "^23.6.0",
-            "jest-watcher": "^23.4.0",
-            "jest-worker": "^23.2.0",
-            "micromatch": "^2.3.11",
-            "node-notifier": "^5.2.1",
-            "prompts": "^0.1.9",
-            "realpath-native": "^1.0.0",
-            "rimraf": "^2.5.4",
-            "slash": "^1.0.0",
-            "string-length": "^2.0.0",
-            "strip-ansi": "^4.0.0",
-            "which": "^1.2.12",
-            "yargs": "^11.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "requires": {
-            "camelcase": "^4.1.0"
+            "pump": "^3.0.0"
           }
         }
       }
     },
-    "jest-changed-files": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-      "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
-      "requires": {
-        "throat": "^4.0.0"
-      }
-    },
     "jest-config": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-      "integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.0.0.tgz",
+      "integrity": "sha512-9/soqWL5YSq1ZJtgVJ5YYPCL1f9Mi2lVCp5+OXuYBOaN8DHSFRCSWip0rQ6N+mPTOEIAlCvcUH8zaPOwK4hePg==",
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^23.6.0",
+        "@babel/core": "^7.1.0",
+        "babel-jest": "^24.0.0",
         "chalk": "^2.0.1",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^23.4.0",
-        "jest-environment-node": "^23.4.0",
-        "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.6.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.6.0",
-        "micromatch": "^2.3.11",
-        "pretty-format": "^23.6.0"
+        "jest-environment-jsdom": "^24.0.0",
+        "jest-environment-node": "^24.0.0",
+        "jest-get-type": "^24.0.0",
+        "jest-jasmine2": "^24.0.0",
+        "jest-regex-util": "^24.0.0",
+        "jest-resolve": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "jest-validate": "^24.0.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.0.0",
+        "realpath-native": "^1.0.2",
+        "uuid": "^3.3.2"
       }
     },
     "jest-diff": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-      "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.0.0.tgz",
+      "integrity": "sha512-XY5wMpRaTsuMoU+1/B2zQSKQ9RdE9gsLkGydx3nvApeyPijLA8GtEvIcPwISRCer+VDf9W1mStTYYq6fPt8ryA==",
       "requires": {
         "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.6.0"
+        "diff-sequences": "^24.0.0",
+        "jest-get-type": "^24.0.0",
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-docblock": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-      "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0.tgz",
+      "integrity": "sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==",
       "requires": {
         "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-      "integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.0.0.tgz",
+      "integrity": "sha512-gFcbY4Cu55yxExXMkjrnLXov3bWO3dbPAW7HXb31h/DNWdNc/6X8MtxGff8nh3/MjkF9DpVqnj0KsPKuPK0cpA==",
       "requires": {
         "chalk": "^2.0.1",
-        "pretty-format": "^23.6.0"
+        "jest-get-type": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-      "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.0.0.tgz",
+      "integrity": "sha512-1YNp7xtxajTRaxbylDc2pWvFnfDTH5BJJGyVzyGAKNt/lEULohwEV9zFqTgG4bXRcq7xzdd+sGFws+LxThXXOw==",
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0",
+        "jest-mock": "^24.0.0",
+        "jest-util": "^24.0.0",
         "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-      "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.0.0.tgz",
+      "integrity": "sha512-62fOFcaEdU0VLaq8JL90TqwI7hLn0cOKOl8vY2n477vRkCJRojiRRtJVRzzCcgFvs6gqU97DNqX5R0BrBP6Rxg==",
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0"
+        "jest-mock": "^24.0.0",
+        "jest-util": "^24.0.0"
       }
     },
     "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
+      "integrity": "sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w=="
     },
     "jest-haste-map": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-      "integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.0.0.tgz",
+      "integrity": "sha512-CcViJyUo41IQqttLxXVdI41YErkzBKbE6cS6dRAploCeutePYfUimWd3C9rQEWhX0YBOQzvNsC0O9nYxK2nnxQ==",
       "requires": {
         "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.11",
+        "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
-        "jest-docblock": "^23.2.0",
-        "jest-serializer": "^23.0.1",
-        "jest-worker": "^23.2.0",
-        "micromatch": "^2.3.11",
-        "sane": "^2.0.0"
+        "jest-serializer": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "jest-worker": "^24.0.0",
+        "micromatch": "^3.1.10",
+        "sane": "^3.0.0"
       }
     },
     "jest-jasmine2": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-      "integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.0.0.tgz",
+      "integrity": "sha512-q1xEV9KHM0bgfBj3yrkrjRF5kxpNDkWPCwVfSPN1DC+pD6J5wrM9/u2BgzhKhALXiaZUUhJ+f/OcEC0Gwpw90A==",
       "requires": {
-        "babel-traverse": "^6.0.0",
+        "@babel/traverse": "^7.1.0",
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^23.6.0",
-        "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.6.0",
-        "jest-each": "^23.6.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-snapshot": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "pretty-format": "^23.6.0"
+        "expect": "^24.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "jest-message-util": "^24.0.0",
+        "jest-snapshot": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-leak-detector": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-      "integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.0.0.tgz",
+      "integrity": "sha512-ZYHJYFeibxfsDSKowjDP332pStuiFT2xfc5R67Rjm/l+HFJWJgNIOCOlQGeXLCtyUn3A23+VVDdiCcnB6dTTrg==",
       "requires": {
-        "pretty-format": "^23.6.0"
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-      "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.0.0.tgz",
+      "integrity": "sha512-LQTDmO+aWRz1Tf9HJg+HlPHhDh1E1c65kVwRFo5mwCVp5aQDzlkz4+vCvXhOKFjitV2f0kMdHxnODrXVoi+rlA==",
       "requires": {
         "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.6.0"
+        "jest-diff": "^24.0.0",
+        "jest-get-type": "^24.0.0",
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-message-util": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-      "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.0.0.tgz",
+      "integrity": "sha512-J9ROJIwz/IeC+eV1XSwnRK4oAwPuhmxEyYx1+K5UI+pIYwFZDSrfZaiWTdq0d2xYFw4Xiu+0KQWsdsQpgJMf3Q==",
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.35",
+        "@babel/code-frame": "^7.0.0",
         "chalk": "^2.0.1",
-        "micromatch": "^2.3.11",
-        "slash": "^1.0.0",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
         "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-      "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.0.0.tgz",
+      "integrity": "sha512-sQp0Hu5fcf5NZEh1U9eIW2qD0BwJZjb63Yqd98PQJFvf/zzUTBoUAwv/Dc/HFeNHIw1f3hl/48vNn+j3STaI7A=="
     },
     "jest-regex-util": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-      "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.0.0.tgz",
+      "integrity": "sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q=="
     },
     "jest-resolve": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-      "integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.0.0.tgz",
+      "integrity": "sha512-uKDGyJqNaBQKox1DJzm27CJobADsIMNgZGusXhtYzl98LKu/fKuokkRsd7EBVgoDA80HKHc3LOPKuYLryMu1vw==",
       "requires": {
         "browser-resolve": "^1.11.3",
         "chalk": "^2.0.1",
@@ -2909,249 +2418,97 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-      "integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.0.0.tgz",
+      "integrity": "sha512-CJGS5ME2g5wL16o3Y22ga9p5ntNT5CUYX40/0lYj9ic9jB5YHm/qMKTgbFt9kowEBiMOFpXy15dWtBTEU54+zg==",
       "requires": {
-        "jest-regex-util": "^23.3.0",
-        "jest-snapshot": "^23.6.0"
+        "jest-regex-util": "^24.0.0",
+        "jest-snapshot": "^24.0.0"
       }
     },
     "jest-runner": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-      "integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.0.0.tgz",
+      "integrity": "sha512-XefXm2XimKtwdfi2am4364GfCmLD1tOjiRtDexY65diCXt4Rw23rxj2wiW7p9s8Nh9dzJQNmrheqZ5rzvn762g==",
       "requires": {
         "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.6.0",
-        "jest-docblock": "^23.2.0",
-        "jest-haste-map": "^23.6.0",
-        "jest-jasmine2": "^23.6.0",
-        "jest-leak-detector": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-runtime": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-worker": "^23.2.0",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.0.0",
+        "jest-docblock": "^24.0.0",
+        "jest-haste-map": "^24.0.0",
+        "jest-jasmine2": "^24.0.0",
+        "jest-leak-detector": "^24.0.0",
+        "jest-message-util": "^24.0.0",
+        "jest-runtime": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "jest-worker": "^24.0.0",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
       }
     },
     "jest-runtime": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-      "integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.0.0.tgz",
+      "integrity": "sha512-UeVoTGiij8upcqfyBlJvImws7IGY+ZWtgVpt1h4VmVbyei39tVGia/20VoP3yvodS6FdjTwBj+JzVNuoh/9UTw==",
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-plugin-istanbul": "^4.1.6",
+        "@babel/core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
         "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
         "exit": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.6.0",
-        "jest-haste-map": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.6.0",
-        "jest-snapshot": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.6.0",
-        "micromatch": "^2.3.11",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.0.0",
+        "jest-haste-map": "^24.0.0",
+        "jest-message-util": "^24.0.0",
+        "jest-regex-util": "^24.0.0",
+        "jest-resolve": "^24.0.0",
+        "jest-snapshot": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "jest-validate": "^24.0.0",
+        "micromatch": "^3.1.10",
         "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
+        "slash": "^2.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^11.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
+        "write-file-atomic": "^2.4.2",
+        "yargs": "^12.0.2"
       }
     },
     "jest-serializer": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-      "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0.tgz",
+      "integrity": "sha512-9FKxQyrFgHtx3ozU+1a8v938ILBE7S8Ko3uiAVjT8Yfi2o91j/fj81jacCQZ/Ihjiff/VsUCXVgQ+iF1XdImOw=="
     },
     "jest-snapshot": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-      "integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.0.0.tgz",
+      "integrity": "sha512-7OcrckVnfzVYxSGPYl2Sn+HyT30VpDv+FMBFbQxSQ6DV2K9Js6vYT6d4SBPKp6DfDiEL2txNssJBxtlvF+Dymw==",
       "requires": {
-        "babel-types": "^6.0.0",
+        "@babel/types": "^7.0.0",
         "chalk": "^2.0.1",
-        "jest-diff": "^23.6.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-resolve": "^23.6.0",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "jest-message-util": "^24.0.0",
+        "jest-resolve": "^24.0.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^23.6.0",
+        "pretty-format": "^24.0.0",
         "semver": "^5.5.0"
       }
     },
     "jest-util": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-      "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.0.0.tgz",
+      "integrity": "sha512-QxsALc4wguYS7cfjdQSOr5HTkmjzkHgmZvIDkcmPfl1ib8PNV8QUWLwbKefCudWS0PRKioV+VbQ0oCUPC691fQ==",
       "requires": {
-        "callsites": "^2.0.0",
+        "callsites": "^3.0.0",
         "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.11",
-        "is-ci": "^1.0.10",
-        "jest-message-util": "^23.4.0",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "jest-message-util": "^24.0.0",
         "mkdirp": "^0.5.1",
-        "slash": "^1.0.0",
+        "slash": "^2.0.0",
         "source-map": "^0.6.0"
       },
       "dependencies": {
@@ -3163,43 +2520,56 @@
       }
     },
     "jest-validate": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-      "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.0.0.tgz",
+      "integrity": "sha512-vMrKrTOP4BBFIeOWsjpsDgVXATxCspC9S1gqvbJ3Tnn/b9ACsJmteYeVx9830UMV28Cob1RX55x96Qq3Tfad4g==",
       "requires": {
+        "camelcase": "^5.0.0",
         "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
+        "jest-get-type": "^24.0.0",
         "leven": "^2.1.0",
-        "pretty-format": "^23.6.0"
+        "pretty-format": "^24.0.0"
       }
     },
     "jest-watcher": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-      "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.0.0.tgz",
+      "integrity": "sha512-GxkW2QrZ4YxmW1GUWER05McjVDunBlKMFfExu+VsGmXJmpej1saTEKvONdx5RJBlVdpPI5x6E3+EDQSIGgl53g==",
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
+        "jest-util": "^24.0.0",
         "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-      "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
+      "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
       "requires": {
-        "merge-stream": "^1.0.1"
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3244,9 +2614,14 @@
       }
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3264,9 +2639,19 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -3288,17 +2673,14 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "kleur": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-      "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.1.tgz",
+      "integrity": "sha512-P3kRv+B+Ra070ng2VKQqW4qW7gd/v3iD8sy/zOdcYRsfiD+QBokQNOps/AfP6Hr48cBhIIBFWckB9aO+IZhrWg=="
     },
     "lcid": {
       "version": "2.0.0",
@@ -3328,15 +2710,14 @@
       }
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -3366,13 +2747,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pify": "^3.0.0"
       }
     },
     "make-error": {
@@ -3409,11 +2789,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-    },
     "mem": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
@@ -3438,23 +2813,23 @@
       }
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime-db": {
@@ -3516,14 +2891,14 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
       "optional": true
     },
     "nanomatch": {
@@ -3542,23 +2917,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
       }
     },
     "natural-compare": {
@@ -3575,6 +2933,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "node-notifier": {
       "version": "5.3.0",
@@ -3629,11 +2992,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3651,6 +3009,14 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         }
       }
     },
@@ -3665,13 +3031,6 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -3683,28 +3042,12 @@
         "es-abstract": "^1.5.1"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
     },
     "once": {
@@ -3744,11 +3087,6 @@
         }
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-locale": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
@@ -3759,15 +3097,18 @@
         "mem": "^4.0.0"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-each-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -3795,28 +3136,23 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+    },
     "p-try": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      }
-    },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -3836,7 +3172,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -3850,13 +3186,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "pify": "^3.0.0"
       }
     },
     "performance-now": {
@@ -3865,69 +3199,24 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+    "pirates": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+      "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
       "requires": {
-        "pinkie": "^2.0.0"
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "requires": {
-        "find-up": "^2.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        }
+        "find-up": "^3.0.0"
       }
     },
     "pn": {
@@ -3945,24 +3234,21 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
     "pretty-format": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
+      "integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
       "requires": {
-        "ansi-regex": "^3.0.0",
+        "ansi-regex": "^4.0.0",
         "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+        }
       }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -3970,23 +3256,27 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "prompts": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-      "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.1.tgz",
+      "integrity": "sha512-8lnEOSIGQbgbnO47+13S+H204L8ISogGulyi0/NNEFAQ9D1VMNTrJ9SBX2Ra03V4iPn/zt36HQMndRYkaPoWiQ==",
       "requires": {
-        "kleur": "^2.0.1",
-        "sisteransi": "^0.1.1"
+        "kleur": "^3.0.0",
+        "sisteransi": "^1.0.0"
       }
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -3998,69 +3288,28 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "^1.0.0",
+        "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "path-type": "^3.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        }
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4078,19 +3327,6 @@
       "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
       "requires": {
         "util.promisify": "^1.0.0"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -4116,14 +3352,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
     },
     "request": {
       "version": "2.88.0",
@@ -4225,11 +3453,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "rsvp": {
@@ -4244,7 +3472,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -4256,13 +3484,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-      "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-3.1.0.tgz",
+      "integrity": "sha512-G5GClRRxT1cELXfdAq7UKtUsv8q/ZC5k8lQGmjEm4HcAl3HzBy68iglyNCmw4+0tiXPCBZntslHlRhbnsSws+Q==",
       "requires": {
         "anymatch": "^2.0.0",
         "capture-exit": "^1.2.0",
         "exec-sh": "^0.2.0",
+        "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
@@ -4271,257 +3500,31 @@
         "watch": "~0.18.0"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
+        "execa": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "pump": "^3.0.0"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -4586,14 +3589,14 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sisteransi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-      "integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
     "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -4610,6 +3613,14 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -4625,6 +3636,11 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -4671,16 +3687,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -4690,6 +3696,16 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "source-map": {
@@ -4710,11 +3726,19 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
       "requires": {
-        "source-map": "^0.5.6"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "source-map-url": {
@@ -4723,9 +3747,9 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -4746,9 +3770,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -4764,9 +3788,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4828,7 +3852,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -4843,12 +3867,9 @@
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -4869,14 +3890,13 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "test-exclude": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-      "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
+      "integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
       "requires": {
         "arrify": "^1.0.1",
-        "micromatch": "^2.3.11",
-        "object-assign": "^4.1.0",
-        "read-pkg-up": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
         "require-main-filename": "^1.0.1"
       }
     },
@@ -4891,9 +3911,9 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -4901,6 +3921,16 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "to-regex": {
@@ -4921,16 +3951,6 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        }
       }
     },
     "tough-cookie": {
@@ -5021,9 +4041,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -5113,11 +4133,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -5204,7 +4219,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -5303,9 +4318,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -5329,11 +4344,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "12.0.5",

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -14,7 +14,7 @@
     "package": "package-js"
   },
   "dependencies": {
-    "colors": "^1.3.2",
+    "colors": "^1.3.3",
     "fs-extra": "^7.0.1",
     "jsii-spec": "^0.7.13",
     "oo-ascii-tree": "^0.7.13",
@@ -23,13 +23,13 @@
   "devDependencies": {
     "@scope/jsii-calc-lib": "^0.7.13",
     "@types/fs-extra": "^5.0.4",
-    "@types/jest": "^23.3.10",
-    "@types/yargs": "^12.0.1",
-    "jest": "^23.6.0",
+    "@types/jest": "^23.3.13",
+    "@types/yargs": "^12.0.8",
+    "jest": "^24.0.0",
     "jsii-build-tools": "^0.7.13",
     "jsii-calc": "^0.7.13",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.2.1"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-ruby-runtime/package-lock.json
+++ b/packages/jsii-ruby-runtime/package-lock.json
@@ -8,9 +8,9 @@
 			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		}
 	}
 }

--- a/packages/jsii-ruby-runtime/package.json
+++ b/packages/jsii-ruby-runtime/package.json
@@ -19,7 +19,7 @@
     "jsii-calc": "^0.7.13",
     "jsii-pacmak": "^0.7.13",
     "jsii-runtime": "^0.7.13",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-runtime/bundle.sh
+++ b/packages/jsii-runtime/bundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-webpack
+./node_modules/.bin/webpack-cli
 
 # HACK: the 'source-map' library used by jsii-kernel requires __dirname/mappings.wasm
 # this means we need to make sure this is also brought in to the clients until we figure it

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -172,17 +172,14 @@
 			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
 		},
 		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 		},
 		"acorn-dynamic-import": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-			"requires": {
-				"acorn": "^5.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
 		},
 		"ajv": {
 			"version": "5.5.2",
@@ -195,10 +192,15 @@
 				"json-schema-traverse": "^0.3.0"
 			}
 		},
+		"ajv-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+		},
 		"ajv-keywords": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
+			"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -288,7 +290,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"requires": {
 						"inherits": "2.0.1"
@@ -476,7 +478,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -510,7 +512,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -541,7 +543,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
 				"base64-js": "^1.0.2",
@@ -565,23 +567,49 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"cacache": {
-			"version": "10.0.4",
-			"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.1",
-				"mississippi": "^2.0.0",
+				"bluebird": "^3.5.3",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"lru-cache": "^5.1.1",
+				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^2.6.2",
-				"ssri": "^5.2.4",
-				"unique-filename": "^1.1.0",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "3.5.3",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+					"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
 			}
 		},
 		"cache-base": {
@@ -611,9 +639,9 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -759,9 +787,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -849,7 +877,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -861,7 +889,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -986,6 +1014,11 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"detect-file": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+		},
 		"diff": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -993,7 +1026,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -1110,9 +1143,9 @@
 			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"events": {
-			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
 		},
 		"events-to-array": {
 			"version": "1.1.2",
@@ -1186,6 +1219,14 @@
 						"is-extendable": "^0.1.0"
 					}
 				}
+			}
+		},
+		"expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"requires": {
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"extend": {
@@ -1286,6 +1327,11 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
+		"figgy-pudding": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1308,21 +1354,42 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+			"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"pkg-dir": "^3.0.0"
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
+			}
+		},
+		"findup-sync": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+			"requires": {
+				"detect-file": "^1.0.0",
+				"is-glob": "^3.1.0",
+				"micromatch": "^3.0.4",
+				"resolve-dir": "^1.0.1"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
 		},
 		"flush-write-stream": {
@@ -1402,9 +1469,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -1418,8 +1485,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1427,7 +1493,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1437,37 +1503,32 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1483,7 +1544,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -1526,7 +1587,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1544,11 +1605,11 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -1570,8 +1631,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1581,7 +1641,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1594,27 +1653,24 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1624,7 +1680,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1635,7 +1690,7 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1645,17 +1700,17 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -1671,12 +1726,12 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1697,8 +1752,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1708,7 +1762,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1743,11 +1796,11 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -1775,17 +1828,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true,
-					"optional": true
+					"version": "5.1.2",
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1798,7 +1850,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -1815,7 +1867,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1833,7 +1884,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1844,16 +1894,16 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -1863,22 +1913,20 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
+					"version": "3.0.3",
+					"bundled": true
 				}
 			}
 		},
@@ -1898,17 +1946,6 @@
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 			"requires": {
 				"pump": "^3.0.0"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
 			}
 		},
 		"get-value": {
@@ -1956,10 +1993,32 @@
 				}
 			}
 		},
+		"global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"requires": {
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
+			}
+		},
 		"global-modules-path": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/global-modules-path/-/global-modules-path-2.3.1.tgz",
 			"integrity": "sha512-y+shkf4InI7mPRHSo2b/k6ix6+NLDtyccYv86whhxrSGX9wjPX1VMITmrDbE1eh7zkzhiWtW2sHklJYoQ62Cxg=="
+		},
+		"global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"requires": {
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
+			}
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
@@ -2029,9 +2088,9 @@
 			}
 		},
 		"hash.js": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -2045,6 +2104,14 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"homedir-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"requires": {
+				"parse-passwd": "^1.0.0"
 			}
 		},
 		"http-signature": {
@@ -2079,54 +2146,6 @@
 			"requires": {
 				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
 			}
 		},
 		"imurmurhash": {
@@ -2152,6 +2171,11 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -2382,10 +2406,15 @@
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
 			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
 		},
+		"lightercollective": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.1.0.tgz",
+			"integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ=="
+		},
 		"loader-runner": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
@@ -2398,11 +2427,11 @@
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -2575,9 +2604,9 @@
 			}
 		},
 		"mississippi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -2585,7 +2614,7 @@
 				"flush-write-stream": "^1.0.0",
 				"from2": "^2.1.0",
 				"parallel-transform": "^1.1.0",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"pumpify": "^1.3.3",
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
@@ -2644,9 +2673,9 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"optional": true
 		},
 		"nanomatch": {
@@ -2678,9 +2707,9 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"node-libs-browser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -2689,7 +2718,7 @@
 				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "^3.11.0",
 				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
+				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
@@ -2703,7 +2732,7 @@
 				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"util": "^0.11.0",
 				"vm-browserify": "0.0.4"
 			}
 		},
@@ -5147,34 +5176,34 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"pako": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -5187,16 +5216,22 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.1",
-			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+			"integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
 				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
 			}
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -5251,11 +5286,11 @@
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "^3.0.0"
 			}
 		},
 		"posix-character-classes": {
@@ -5307,9 +5342,9 @@
 			}
 		},
 		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -5323,6 +5358,17 @@
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
 				"pump": "^2.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
 			}
 		},
 		"punycode": {
@@ -5455,6 +5501,15 @@
 				"resolve-from": "^3.0.0"
 			}
 		},
+		"resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"requires": {
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
+			}
+		},
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
@@ -5502,7 +5557,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -5523,9 +5578,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.5.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -5551,9 +5606,9 @@
 			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
 		"serialize-javascript": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+			"integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -5588,7 +5643,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -5790,11 +5845,11 @@
 			}
 		},
 		"ssri": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 			"requires": {
-				"safe-buffer": "^5.1.1"
+				"figgy-pudding": "^3.5.1"
 			}
 		},
 		"stack-utils": {
@@ -5822,9 +5877,9 @@
 			}
 		},
 		"stream-browserify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -5898,7 +5953,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"supports-color": {
@@ -5984,16 +6039,74 @@
 			}
 		},
 		"tapable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
-			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
+			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
+		},
+		"terser": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
+			"integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
+			"requires": {
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1",
+				"source-map-support": "~0.5.6"
+			}
+		},
+		"terser-webpack-plugin": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
+			"integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
+			"requires": {
+				"cacache": "^11.0.2",
+				"find-cache-dir": "^2.0.0",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"terser": "^3.8.1",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
+			}
 		},
 		"through2": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.4.tgz",
-			"integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"requires": {
-				"readable-stream": "2 || 3",
+				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
 		},
@@ -6102,33 +6215,9 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
-		},
-		"uglify-es": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-			"requires": {
-				"commander": "~2.13.0",
-				"source-map": "~0.6.1"
-			}
-		},
-		"uglifyjs-webpack-plugin": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
-				"schema-utils": "^0.4.5",
-				"serialize-javascript": "^1.4.0",
-				"source-map": "^0.6.1",
-				"uglify-es": "^3.3.4",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
-			}
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"unicode-length": {
 			"version": "1.0.3",
@@ -6270,9 +6359,9 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -6647,16 +6736,16 @@
 			}
 		},
 		"webpack": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
-			"integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
+			"integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-module-context": "1.7.11",
 				"@webassemblyjs/wasm-edit": "1.7.11",
 				"@webassemblyjs/wasm-parser": "1.7.11",
-				"acorn": "^5.6.2",
-				"acorn-dynamic-import": "^3.0.0",
+				"acorn": "^6.0.5",
+				"acorn-dynamic-import": "^4.0.0",
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0",
 				"chrome-trace-event": "^1.0.0",
@@ -6672,15 +6761,15 @@
 				"node-libs-browser": "^2.0.0",
 				"schema-utils": "^0.4.4",
 				"tapable": "^1.1.0",
-				"uglifyjs-webpack-plugin": "^1.2.4",
+				"terser-webpack-plugin": "^1.1.0",
 				"watchpack": "^1.5.0",
 				"webpack-sources": "^1.3.0"
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.5.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -6701,20 +6790,23 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.1.2.tgz",
-			"integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.2.1.tgz",
+			"integrity": "sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==",
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
 				"enhanced-resolve": "^4.1.0",
+				"findup-sync": "^2.0.0",
+				"global-modules": "^1.0.0",
 				"global-modules-path": "^2.3.0",
 				"import-local": "^2.0.0",
 				"interpret": "^1.1.0",
+				"lightercollective": "^0.1.0",
 				"loader-utils": "^1.1.0",
 				"supports-color": "^5.5.0",
 				"v8-compile-cache": "^2.0.2",
-				"yargs": "^12.0.2"
+				"yargs": "^12.0.4"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -6763,7 +6855,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -6780,7 +6872,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -6842,46 +6934,6 @@
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1 || ^4.0.0",
 				"yargs-parser": "^11.1.1"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-				}
 			}
 		},
 		"yargs-parser": {

--- a/packages/jsii-runtime/package.json
+++ b/packages/jsii-runtime/package.json
@@ -21,10 +21,10 @@
     "jsii-calc": "^0.7.13",
     "nodeunit": "^0.11.3",
     "source-map-loader": "^0.2.4",
-    "typescript": "^3.1.6",
+    "typescript": "^3.2.4",
     "wasm-loader": "^1.3.0",
-    "webpack": "^4.25.1",
-    "webpack-cli": "^3.1.2"
+    "webpack": "^4.29.0",
+    "webpack-cli": "^3.2.1"
   },
   "dependencies": {
     "jsii-kernel": "^0.7.13",

--- a/packages/jsii-spec/package-lock.json
+++ b/packages/jsii-spec/package-lock.json
@@ -103,9 +103,9 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -214,12 +214,9 @@
 			}
 		},
 		"decamelize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-			"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-			"requires": {
-				"xregexp": "4.0.0"
-			}
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -246,6 +243,14 @@
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -262,12 +267,12 @@
 			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
 		},
 		"execa": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-			"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
 				"cross-spawn": "^6.0.0",
-				"get-stream": "^3.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
@@ -362,9 +367,12 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -572,9 +580,9 @@
 			}
 		},
 		"map-age-cleaner": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-			"integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -3010,11 +3018,11 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-			"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"lcid": "^2.0.0",
 				"mem": "^4.0.0"
 			}
@@ -3044,13 +3052,13 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-			"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -3103,6 +3111,15 @@
 			"version": "1.1.29",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
 			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "1.4.1",
@@ -3295,7 +3312,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"tap": {
@@ -3411,14 +3428,14 @@
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"typescript-json-schema": {
-			"version": "0.33.0",
-			"resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.33.0.tgz",
-			"integrity": "sha512-KfentDMvxaQzSQ59olU2KNIDF9QS6hullPJAWIILvQdbp351y4lJYrthOyL/rHmXRtVHHTfS6YASRo7dp+UOpw==",
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.34.0.tgz",
+			"integrity": "sha512-BCTqkHXEIOcI78kipp6tEMUFS8b5dbWIp8tpaPC5FFjmK7iFsE5qWS6L6S+lmt71+APp+RlapXb8EEyqkmOt/w==",
 			"requires": {
 				"glob": "~7.1.2",
 				"json-stable-stringify": "^1.0.1",
@@ -3471,7 +3488,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -3513,11 +3530,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"xregexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
-		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -3534,12 +3546,12 @@
 			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
 		},
 		"yargs": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-			"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^2.0.0",
+				"decamelize": "^1.2.0",
 				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^3.0.0",
@@ -3549,15 +3561,16 @@
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^10.1.0"
+				"yargs-parser": "^11.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/jsii-spec/package.json
+++ b/packages/jsii-spec/package.json
@@ -15,8 +15,8 @@
     "@types/nodeunit": "^0.0.30",
     "jsii-build-tools": "^0.7.13",
     "nodeunit": "^0.11.3",
-    "typescript": "^3.1.6",
-    "typescript-json-schema": "^0.33.0"
+    "typescript": "^3.2.4",
+    "typescript-json-schema": "^0.34.0"
   },
   "dependencies": {
     "jsonschema": "^1.2.4"

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import process = require('process');
 import ts = require('typescript');
 import yargs = require('yargs');
-import { Compiler, DIAGNOSTICS } from '../lib/compiler';
+import { Compiler, DIAGNOSTICS } from '../lib/compiler';
 import { hasDomain } from '../lib/emitter';
 import { loadProjectInfo } from '../lib/project-info';
 import utils = require('../lib/utils');
@@ -27,7 +27,7 @@ import { VERSION } from '../lib/version';
     const compiler = new Compiler({
         projectInfo: await loadProjectInfo(projectRoot),
         watch: argv.watch,
-        projectReferences: argv.projectReferences
+        projectReferences: argv['project-references']
     });
 
     return { projectRoot, emitResult: await compiler.emit() };

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -39,7 +39,7 @@ export interface CompilerOptions {
     /** The information about the project to be built */
     projectInfo: ProjectInfo;
     /** Whether the compiler should watch for changes or just compile once */
-    watch: boolean;
+    watch?: boolean;
     /** Whether to detect and generate TypeScript project references */
     projectReferences?: boolean;
 }

--- a/packages/jsii/package-lock.json
+++ b/packages/jsii/package-lock.json
@@ -1,23 +1,27 @@
 {
-	"requires": true,
+	"name": "jsii",
+	"version": "0.7.13",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.51"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+			"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.51",
+				"@babel/types": "^7.3.0",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
 			},
@@ -25,108 +29,124 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.51",
-				"@babel/template": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51"
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.51"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.51"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+			"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
+			"dev": true
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.51",
-				"@babel/parser": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51",
-				"lodash": "^4.17.5"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.51",
-				"@babel/generator": "7.0.0-beta.51",
-				"@babel/helper-function-name": "7.0.0-beta.51",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
-				"@babel/parser": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51",
-				"debug": "^3.1.0",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.17.5"
+				"lodash": "^4.17.10"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.51",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+			"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.10",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@types/clone": {
 			"version": "0.1.30",
 			"resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
-			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
+			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+			"dev": true
 		},
 		"@types/colors": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
 			"integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
+			"dev": true,
 			"requires": {
 				"colors": "*"
 			}
@@ -134,12 +154,14 @@
 		"@types/deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg=="
+			"integrity": "sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==",
+			"dev": true
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
 			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -148,6 +170,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@types/log4js/-/log4js-2.3.5.tgz",
 			"integrity": "sha512-SwF8LkSHqHy9A8GQ67NAYJiGl8zzP4Qtx65Wa+IOxDGdMHxKeoQZjg7m2M1erIT6VK0DYHpu2aTbdLkdkuMHjw==",
+			"dev": true,
 			"requires": {
 				"log4js": "*"
 			}
@@ -155,27 +178,32 @@
 		"@types/node": {
 			"version": "8.10.37",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
+			"integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
+			"dev": true
 		},
 		"@types/nodeunit": {
 			"version": "0.0.30",
 			"resolved": "https://registry.npmjs.org/@types/nodeunit/-/nodeunit-0.0.30.tgz",
-			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng="
+			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng=",
+			"dev": true
 		},
 		"@types/semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+			"dev": true
 		},
 		"@types/yargs": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-11.1.2.tgz",
-			"integrity": "sha512-zG61PAp2OcoIBjRV44wftJj6AJgzJrOc32LCYOBqk9bdgcdzK5DCJHV9QZJ60+Fu+fOn79g8Ks3Gixm4CfkZ+w=="
+			"version": "12.0.8",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.8.tgz",
+			"integrity": "sha512-OMSKUmZ09gbzITzx4nxnJqhprWC7JqsmlrEsVtb+cv3GXHNpv0kktqxhboKX52FnMggkQvT5ezt8pxTWyKpJHA==",
+			"dev": true
 		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -192,6 +220,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -200,6 +229,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -208,6 +238,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -215,32 +246,46 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"requires": {
+				"lodash": "^4.17.10"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -249,17 +294,20 @@
 		"bind-obj-methods": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-			"integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw=="
+			"integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -268,42 +316,41 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
 		"case": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/case/-/case-1.5.5.tgz",
-			"integrity": "sha512-tQm8bxc8L9Dk/6FGhtBtV89rrRzqytUbdLqGZxmGwYKqeAD0VmLc8kYSqm0GXOTsf9r1tc0bzq+CDLqtrjiuHw=="
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/case/-/case-1.6.1.tgz",
+			"integrity": "sha512-N0rDB5ftMDKANGsIBRWPWcG0VIKtirgqcXb2vKFi66ySAjXVEwbfCN7ass1mkdXO8fbol3RfbWlQ9KyBX2F/Gg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
 		},
-		"circular-json": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-			"integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
-		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "4.1.0",
@@ -333,12 +380,14 @@
 		"clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -349,6 +398,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -356,22 +406,25 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -379,17 +432,20 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"coveralls": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -403,6 +459,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
@@ -412,30 +469,29 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-format": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
-			"integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
+			"integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA=="
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
 		},
 		"decamelize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-			"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-			"requires": {
-				"xregexp": "4.0.0"
-			}
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
@@ -445,17 +501,20 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"diff": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -465,35 +524,48 @@
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"events-to-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+			"dev": true
 		},
 		"execa": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-			"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
 				"cross-spawn": "^6.0.0",
-				"get-stream": "^3.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
@@ -518,22 +590,26 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -543,10 +619,16 @@
 				"locate-path": "^3.0.0"
 			}
 		},
+		"flatted": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
+		},
 		"foreground-child": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^4",
 				"signal-exit": "^3.0.0"
@@ -555,12 +637,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
@@ -570,47 +654,30 @@
 		"fs-exists-cached": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
+			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+			"dev": true
 		},
 		"fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
-			},
-			"dependencies": {
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-				}
 			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-loop": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
-			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw="
+			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
@@ -618,14 +685,18 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -634,6 +705,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -644,9 +716,10 @@
 			}
 		},
 		"globals": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+			"dev": true
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
@@ -656,17 +729,20 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
 				"har-schema": "^2.0.0"
@@ -675,12 +751,14 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -690,12 +768,14 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -704,15 +784,8 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -732,12 +805,15 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true,
+			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -747,36 +823,41 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA=="
+			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-			"integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+			"integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+			"dev": true,
 			"requires": {
-				"@babel/generator": "7.0.0-beta.51",
-				"@babel/parser": "7.0.0-beta.51",
-				"@babel/template": "7.0.0-beta.51",
-				"@babel/traverse": "7.0.0-beta.51",
-				"@babel/types": "7.0.0-beta.51",
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"istanbul-lib-coverage": "^2.0.1",
 				"semver": "^5.5.0"
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -786,32 +867,46 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsesc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -830,7 +925,8 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"locate-path": {
 			"version": "3.0.0",
@@ -849,18 +945,19 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
 		},
 		"log4js": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
-			"integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-4.0.1.tgz",
+			"integrity": "sha512-rXta20AbapfmCYVIuSQf4+ET6XSXigflXblfJmCR/wwHnmhs4iKJmEwx2WeNTiuMaiA1+tqKxqQ/wkN5ZSaJmQ==",
 			"requires": {
-				"circular-json": "^0.5.5",
-				"date-format": "^1.2.0",
+				"date-format": "^2.0.0",
 				"debug": "^3.1.0",
+				"flatted": "^2.0.0",
 				"rfdc": "^1.1.2",
-				"streamroller": "0.7.0"
+				"streamroller": "^1.0.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -878,27 +975,20 @@
 				}
 			}
 		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
 			}
 		},
 		"map-age-cleaner": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-			"integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -916,12 +1006,14 @@
 		"mime-db": {
 			"version": "1.36.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.20",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+			"dev": true,
 			"requires": {
 				"mime-db": "~1.36.0"
 			}
@@ -935,6 +1027,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -942,12 +1035,14 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
 		},
 		"minipass": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
 			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -956,7 +1051,8 @@
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+					"dev": true
 				}
 			}
 		},
@@ -964,6 +1060,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -971,14 +1068,16 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
 				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -989,6 +1088,7 @@
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.3.tgz",
 			"integrity": "sha512-gDNxrDWpx07BxYNO/jn1UrGI1vNhDQZrIFphbHMcTCDc5mrrqQBWfQMXPHJ5WSgbFwD1D6bv4HOsqtTrPG03AA==",
+			"dev": true,
 			"requires": {
 				"ejs": "^2.5.2",
 				"tap": "^12.0.1"
@@ -1008,42 +1108,42 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nyc": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
-			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+			"integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
-				"caching-transform": "^1.0.0",
-				"convert-source-map": "^1.5.1",
+				"caching-transform": "^2.0.0",
+				"convert-source-map": "^1.6.0",
 				"debug-log": "^1.0.1",
-				"default-require-extensions": "^1.0.0",
-				"find-cache-dir": "^0.1.1",
-				"find-up": "^2.1.0",
-				"foreground-child": "^1.5.3",
-				"glob": "^7.0.6",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.1.0",
-				"istanbul-lib-instrument": "^2.1.0",
-				"istanbul-lib-report": "^1.1.3",
-				"istanbul-lib-source-maps": "^1.2.5",
-				"istanbul-reports": "^1.4.1",
-				"md5-hex": "^1.2.0",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-hook": "^2.0.1",
+				"istanbul-lib-instrument": "^3.0.0",
+				"istanbul-lib-report": "^2.0.2",
+				"istanbul-lib-source-maps": "^2.0.1",
+				"istanbul-reports": "^2.0.1",
+				"make-dir": "^1.3.0",
 				"merge-source-map": "^1.1.0",
-				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.0",
-				"resolve-from": "^2.0.0",
+				"resolve-from": "^4.0.0",
 				"rimraf": "^2.6.2",
-				"signal-exit": "^3.0.1",
+				"signal-exit": "^3.0.2",
 				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^4.2.0",
+				"test-exclude": "^5.0.0",
+				"uuid": "^3.3.2",
 				"yargs": "11.1.0",
-				"yargs-parser": "^8.0.0"
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -1052,205 +1152,87 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
-					"version": "0.4.0",
+					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"default-require-extensions": "^1.0.0"
+						"default-require-extensions": "^2.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"arr-flatten": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"bundled": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
-				},
-				"assign-symbols": {
-					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
-				},
-				"atob": {
-					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
-				},
-				"base": {
-					"version": "0.11.2",
 					"bundled": true,
-					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
-					}
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
-				"braces": {
-					"version": "2.3.2",
-					"bundled": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
-				},
-				"cache-base": {
-					"version": "1.0.1",
 					"bundled": true,
-					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
-					}
+					"dev": true
 				},
 				"caching-transform": {
-					"version": "1.0.1",
+					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"md5-hex": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"write-file-atomic": "^1.1.4"
+						"make-dir": "^1.0.0",
+						"md5-hex": "^2.0.0",
+						"package-hash": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
 						"lazy-cache": "^1.0.3"
 					}
 				},
-				"class-utils": {
-					"version": "0.3.6",
-					"bundled": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -1261,45 +1243,38 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
-				},
-				"collection-visit": {
-					"version": "1.0.0",
 					"bundled": true,
-					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
-					}
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
-				},
-				"component-emitter": {
-					"version": "1.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
-					"version": "1.5.1",
-					"bundled": true
-				},
-				"copy-descriptor": {
-					"version": "0.1.1",
-					"bundled": true
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -1308,76 +1283,46 @@
 				"debug": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"define-property": {
-					"version": "2.0.2",
-					"bundled": true,
-					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
-					},
-					"dependencies": {
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"error-ex": {
-					"version": "1.3.1",
+					"version": "1.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
+				"es6-error": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -1391,6 +1336,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -1399,189 +1345,52 @@
 						}
 					}
 				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"bundled": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"bundled": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"bundled": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"bundled": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"find-cache-dir": {
-					"version": "0.1.1",
+					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
 					}
 				},
 				"find-up": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "^3.0.0"
 					}
-				},
-				"for-in": {
-					"version": "1.0.2",
-					"bundled": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
 					}
 				},
-				"fragment-cache": {
-					"version": "0.2.1",
-					"bundled": true,
-					"requires": {
-						"map-cache": "^0.2.2"
-					}
-				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
-					"version": "1.0.2",
-					"bundled": true
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
-				},
-				"get-value": {
-					"version": "2.0.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -1593,11 +1402,13 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -1608,49 +1419,32 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
 						}
 					}
 				},
-				"has-value": {
-					"version": "1.0.0",
+				"has-flag": {
+					"version": "3.0.0",
 					"bundled": true,
-					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"has-values": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "4.0.0",
-							"bundled": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+					"dev": true
 				},
 				"hosted-git-info": {
-					"version": "2.6.0",
-					"bundled": true
+					"version": "2.7.1",
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -1658,170 +1452,106 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
 					"bundled": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
 				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"bundled": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"bundled": true,
-					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"bundled": true
-						}
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"bundled": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true
-				},
-				"is-number": {
-					"version": "3.0.0",
 					"bundled": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"is-odd": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"bundled": true
-						}
-					}
-				},
-				"is-plain-object": {
-					"version": "2.0.4",
-					"bundled": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
-				},
-				"is-utf8": {
-					"version": "0.2.1",
-					"bundled": true
-				},
-				"is-windows": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-coverage": {
-					"version": "1.2.0",
-					"bundled": true
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
-					"version": "1.1.0",
+					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"append-transform": "^0.4.0"
+						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "1.1.3",
+					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "^1.1.2",
-						"mkdirp": "^0.5.1",
-						"path-parse": "^1.0.5",
-						"supports-color": "^3.1.2"
-					},
-					"dependencies": {
-						"has-flag": {
-							"version": "1.0.0",
-							"bundled": true
-						},
-						"supports-color": {
-							"version": "3.2.3",
-							"bundled": true,
-							"requires": {
-								"has-flag": "^1.0.0"
-							}
-						}
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "1.2.5",
+					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"istanbul-reports": {
-					"version": "1.4.1",
+					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"handlebars": "^4.0.3"
+						"handlebars": "^4.0.11"
 					}
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -1829,77 +1559,81 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
-					"version": "1.1.0",
+					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
+						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
-					},
-					"dependencies": {
-						"path-exists": {
-							"version": "3.0.0",
-							"bundled": true
-						}
 					}
+				},
+				"lodash.flattendeep": {
+					"version": "4.4.0",
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
 					}
 				},
-				"map-cache": {
-					"version": "0.2.2",
-					"bundled": true
-				},
-				"map-visit": {
-					"version": "1.0.0",
+				"make-dir": {
+					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"object-visit": "^1.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"md5-hex": {
-					"version": "1.3.0",
+					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -1907,111 +1641,60 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true
-						}
-					}
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"bundled": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"mixin-deep": {
-					"version": "1.3.1",
+					"version": "0.0.10",
 					"bundled": true,
-					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"bundled": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
-				},
-				"nanomatch": {
-					"version": "1.2.9",
 					"bundled": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-odd": "^2.0.0",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
-					}
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -2022,53 +1705,20 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"object-copy": {
-					"version": "0.1.0",
 					"bundled": true,
-					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"object-visit": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.pick": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
+					"dev": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2076,6 +1726,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -2083,11 +1734,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -2096,171 +1749,142 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
-					"version": "1.2.0",
+					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
-					"version": "1.0.0",
-					"bundled": true
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"package-hash": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
+					}
 				},
 				"parse-json": {
-					"version": "2.2.0",
+					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
-				},
-				"pascalcase": {
-					"version": "0.1.1",
-					"bundled": true
 				},
 				"path-exists": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
+					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
-				},
-				"path-parse": {
-					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
-					"version": "1.1.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
-					"version": "2.3.0",
-					"bundled": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"bundled": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
+					"version": "3.0.0",
 					"bundled": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
+					"dev": true
 				},
 				"pkg-dir": {
-					"version": "1.0.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"bundled": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						}
+						"find-up": "^3.0.0"
 					}
-				},
-				"posix-character-classes": {
-					"version": "0.1.1",
-					"bundled": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"read-pkg": {
-					"version": "1.1.0",
+					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
+						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
-					"version": "1.0.1",
+					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"bundled": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						}
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
-				"regex-not": {
-					"version": "1.0.2",
+				"release-zalgo": {
+					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
+						"es6-error": "^4.0.1"
 					}
-				},
-				"repeat-element": {
-					"version": "1.1.2",
-					"bundled": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"resolve-url": {
-					"version": "0.2.1",
-					"bundled": true
-				},
-				"ret": {
-					"version": "0.1.15",
-					"bundled": true
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -2269,174 +1893,54 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
 				},
-				"safe-regex": {
-					"version": "1.1.0",
+				"safe-buffer": {
+					"version": "5.1.2",
 					"bundled": true,
-					"requires": {
-						"ret": "~0.1.10"
-					}
+					"dev": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
-				},
-				"set-value": {
-					"version": "2.0.0",
 					"bundled": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
-				},
-				"slide": {
-					"version": "1.1.6",
-					"bundled": true
-				},
-				"snapdragon": {
-					"version": "0.8.2",
 					"bundled": true,
-					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon-node": {
-					"version": "2.1.1",
-					"bundled": true,
-					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
-					}
-				},
-				"snapdragon-util": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"kind-of": "^3.2.0"
-					}
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
-				},
-				"source-map-resolve": {
-					"version": "0.5.2",
 					"bundled": true,
-					"requires": {
-						"atob": "^2.1.1",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
-					}
-				},
-				"source-map-url": {
-					"version": "0.4.0",
-					"bundled": true
+					"dev": true,
+					"optional": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -2449,6 +1953,7 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2456,11 +1961,13 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2468,35 +1975,13 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true
-				},
-				"split-string": {
-					"version": "3.1.0",
 					"bundled": true,
-					"requires": {
-						"extend-shallow": "^3.0.0"
-					}
-				},
-				"static-extend": {
-					"version": "0.1.2",
-					"bundled": true,
-					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -2505,60 +1990,44 @@
 				"strip-ansi": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
+					"dev": true
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				},
 				"test-exclude": {
-					"version": "4.2.1",
+					"version": "5.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
-						"micromatch": "^3.1.8",
-						"object-assign": "^4.1.0",
-						"read-pkg-up": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
 						"require-main-filename": "^1.0.1"
-					}
-				},
-				"to-object-path": {
-					"version": "0.3.0",
-					"bundled": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"to-regex": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"bundled": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
 					}
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -2569,6 +2038,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -2582,89 +2052,18 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
-				"union-value": {
-					"version": "1.0.0",
+				"uuid": {
+					"version": "3.3.2",
 					"bundled": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^0.4.3"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"set-value": {
-							"version": "0.4.3",
-							"bundled": true,
-							"requires": {
-								"extend-shallow": "^2.0.1",
-								"is-extendable": "^0.1.1",
-								"is-plain-object": "^2.0.1",
-								"to-object-path": "^0.3.0"
-							}
-						}
-					}
-				},
-				"unset-value": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
-					},
-					"dependencies": {
-						"has-value": {
-							"version": "0.3.1",
-							"bundled": true,
-							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
-							},
-							"dependencies": {
-								"isobject": {
-									"version": "2.1.0",
-									"bundled": true,
-									"requires": {
-										"isarray": "1.0.0"
-									}
-								}
-							}
-						},
-						"has-values": {
-							"version": "0.1.4",
-							"bundled": true
-						}
-					}
-				},
-				"urix": {
-					"version": "0.1.0",
-					"bundled": true
-				},
-				"use": {
-					"version": "3.1.0",
-					"bundled": true,
-					"requires": {
-						"kind-of": "^6.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true
-						}
-					}
+					"dev": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -2673,26 +2072,31 @@
 				"which": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -2700,11 +2104,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -2712,6 +2118,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -2721,6 +2128,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -2729,28 +2137,33 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "1.3.4",
+					"version": "2.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -2766,38 +2179,68 @@
 						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"bundled": true
-						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
 								"wrap-ansi": "^2.0.0"
 							}
 						},
-						"yargs-parser": {
-							"version": "9.0.2",
+						"find-up": {
+							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
-								"camelcase": "^4.1.0"
+								"locate-path": "^2.0.0"
 							}
+						},
+						"locate-path": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "1.3.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^1.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^1.1.0"
+							}
+						},
+						"p-try": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "8.1.0",
+					"version": "9.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -2806,7 +2249,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
@@ -2819,19 +2263,21 @@
 		"opener": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
+			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-			"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"lcid": "^2.0.0",
 				"mem": "^4.0.0"
 			}
@@ -2839,12 +2285,14 @@
 		"own-or": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw="
+			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+			"dev": true
 		},
 		"own-or-env": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+			"dev": true,
 			"requires": {
 				"own-or": "^1.0.0"
 			}
@@ -2861,13 +2309,13 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-			"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -2893,7 +2341,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -2903,37 +2352,55 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true,
+			"optional": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.29",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -2948,6 +2415,7 @@
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -2990,6 +2458,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -2997,12 +2466,14 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -3062,31 +2533,35 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.5.9",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
 		},
 		"spdx-license-list": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-4.1.0.tgz",
-			"integrity": "sha512-nlyjgQUe1PgBGU0RdXIwo+N1VHI0XV/hxCBms8fhRDV7qottuPdX3gcTB4dpNnnQ/fIC3ymb/oWB6S8T6nQEnw=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-5.0.0.tgz",
+			"integrity": "sha512-N5u9tEFRBUzQDjMKRRt8SHxC/UaqYApPmdF4MMFnICQg3z52onNbnneuro/sWw2rd+eGu9agQOzUbD671Xia7Q=="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3102,17 +2577,19 @@
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
 		},
 		"streamroller": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-			"integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.1.tgz",
+			"integrity": "sha512-FKL2mEB0A+XTIWSOlBHm2DvdsER5cGraqrUufO0lFMfsVY+Gpb3TC29Z+6/l0Urbb7vtm6m9zJOQBVl6fEkZBA==",
 			"requires": {
-				"date-format": "^1.2.0",
+				"async": "^2.6.1",
+				"date-format": "^2.0.0",
 				"debug": "^3.1.0",
-				"mkdirp": "^0.5.1",
-				"readable-stream": "^2.3.0"
+				"fs-extra": "^7.0.0",
+				"lodash": "^4.17.10"
 			},
 			"dependencies": {
 				"debug": {
@@ -3158,6 +2635,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -3172,13 +2651,14 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -3187,6 +2667,7 @@
 			"version": "12.0.1",
 			"resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
 			"integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
+			"dev": true,
 			"requires": {
 				"bind-obj-methods": "^2.0.0",
 				"bluebird": "^3.5.1",
@@ -3223,6 +2704,7 @@
 					"version": "11.9.0",
 					"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 					"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+					"dev": true,
 					"requires": {
 						"archy": "^1.0.0",
 						"arrify": "^1.0.1",
@@ -3256,6 +2738,7 @@
 						"align-text": {
 							"version": "0.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2",
 								"longest": "^1.0.1",
@@ -3264,62 +2747,76 @@
 						},
 						"amdefine": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"ansi-styles": {
 							"version": "2.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"append-transform": {
 							"version": "0.4.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"default-require-extensions": "^1.0.0"
 							}
 						},
 						"archy": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"arr-flatten": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"arr-union": {
 							"version": "3.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"arrify": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"assign-symbols": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"async": {
 							"version": "1.5.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"atob": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"babel-code-frame": {
 							"version": "6.26.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"chalk": "^1.1.3",
 								"esutils": "^2.0.2",
@@ -3329,6 +2826,7 @@
 						"babel-generator": {
 							"version": "6.26.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-messages": "^6.23.0",
 								"babel-runtime": "^6.26.0",
@@ -3343,6 +2841,7 @@
 						"babel-messages": {
 							"version": "6.23.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-runtime": "^6.22.0"
 							}
@@ -3350,6 +2849,7 @@
 						"babel-runtime": {
 							"version": "6.26.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"core-js": "^2.4.0",
 								"regenerator-runtime": "^0.11.0"
@@ -3358,6 +2858,7 @@
 						"babel-template": {
 							"version": "6.26.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-runtime": "^6.26.0",
 								"babel-traverse": "^6.26.0",
@@ -3369,6 +2870,7 @@
 						"babel-traverse": {
 							"version": "6.26.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-code-frame": "^6.26.0",
 								"babel-messages": "^6.23.0",
@@ -3384,6 +2886,7 @@
 						"babel-types": {
 							"version": "6.26.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-runtime": "^6.26.0",
 								"esutils": "^2.0.2",
@@ -3393,15 +2896,18 @@
 						},
 						"babylon": {
 							"version": "6.18.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"base": {
 							"version": "0.11.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"cache-base": "^1.0.1",
 								"class-utils": "^0.3.5",
@@ -3415,6 +2921,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -3422,6 +2929,7 @@
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3429,6 +2937,7 @@
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3436,6 +2945,7 @@
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^1.0.0",
 										"is-data-descriptor": "^1.0.0",
@@ -3444,17 +2954,20 @@
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -3463,6 +2976,7 @@
 						"braces": {
 							"version": "2.3.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -3479,6 +2993,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -3487,11 +3002,13 @@
 						},
 						"builtin-modules": {
 							"version": "1.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cache-base": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"collection-visit": "^1.0.0",
 								"component-emitter": "^1.2.1",
@@ -3506,13 +3023,15 @@
 							"dependencies": {
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"caching-transform": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"md5-hex": "^1.2.0",
 								"mkdirp": "^0.5.1",
@@ -3522,11 +3041,13 @@
 						"camelcase": {
 							"version": "1.2.1",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						},
 						"center-align": {
 							"version": "0.1.3",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"align-text": "^0.1.3",
@@ -3536,6 +3057,7 @@
 						"chalk": {
 							"version": "1.1.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-styles": "^2.2.1",
 								"escape-string-regexp": "^1.0.2",
@@ -3547,6 +3069,7 @@
 						"class-utils": {
 							"version": "0.3.6",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-union": "^3.1.0",
 								"define-property": "^0.2.5",
@@ -3557,19 +3080,22 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"cliui": {
 							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"center-align": "^0.1.1",
@@ -3580,17 +3106,20 @@
 								"wordwrap": {
 									"version": "0.0.2",
 									"bundled": true,
+									"dev": true,
 									"optional": true
 								}
 							}
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"collection-visit": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"map-visit": "^1.0.0",
 								"object-visit": "^1.0.0"
@@ -3598,31 +3127,38 @@
 						},
 						"commondir": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"component-emitter": {
 							"version": "1.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"convert-source-map": {
 							"version": "1.5.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"copy-descriptor": {
 							"version": "0.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"core-js": {
 							"version": "2.5.6",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cross-spawn": {
 							"version": "4.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"which": "^1.2.9"
@@ -3631,25 +3167,30 @@
 						"debug": {
 							"version": "2.6.9",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
 						},
 						"debug-log": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"decamelize": {
 							"version": "1.2.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"decode-uri-component": {
 							"version": "0.2.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"default-require-extensions": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"strip-bom": "^2.0.0"
 							}
@@ -3657,6 +3198,7 @@
 						"define-property": {
 							"version": "2.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.2",
 								"isobject": "^3.0.1"
@@ -3665,6 +3207,7 @@
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3672,6 +3215,7 @@
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3679,6 +3223,7 @@
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^1.0.0",
 										"is-data-descriptor": "^1.0.0",
@@ -3687,17 +3232,20 @@
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"detect-indent": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"repeating": "^2.0.0"
 							}
@@ -3705,21 +3253,25 @@
 						"error-ex": {
 							"version": "1.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-arrayish": "^0.2.1"
 							}
 						},
 						"escape-string-regexp": {
 							"version": "1.0.5",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"esutils": {
 							"version": "2.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"execa": {
 							"version": "0.7.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"cross-spawn": "^5.0.1",
 								"get-stream": "^3.0.0",
@@ -3733,6 +3285,7 @@
 								"cross-spawn": {
 									"version": "5.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"lru-cache": "^4.0.1",
 										"shebang-command": "^1.2.0",
@@ -3744,6 +3297,7 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -3757,6 +3311,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -3764,6 +3319,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -3773,6 +3329,7 @@
 						"extend-shallow": {
 							"version": "3.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"assign-symbols": "^1.0.0",
 								"is-extendable": "^1.0.1"
@@ -3781,6 +3338,7 @@
 								"is-extendable": {
 									"version": "1.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-plain-object": "^2.0.4"
 									}
@@ -3790,6 +3348,7 @@
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -3804,6 +3363,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -3811,6 +3371,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -3818,6 +3379,7 @@
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3825,6 +3387,7 @@
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -3832,6 +3395,7 @@
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^1.0.0",
 										"is-data-descriptor": "^1.0.0",
@@ -3840,13 +3404,15 @@
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -3857,6 +3423,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -3866,6 +3433,7 @@
 						"find-cache-dir": {
 							"version": "0.1.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"commondir": "^1.0.1",
 								"mkdirp": "^0.5.1",
@@ -3875,17 +3443,20 @@
 						"find-up": {
 							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"locate-path": "^2.0.0"
 							}
 						},
 						"for-in": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"foreground-child": {
 							"version": "1.5.6",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"cross-spawn": "^4",
 								"signal-exit": "^3.0.0"
@@ -3894,29 +3465,35 @@
 						"fragment-cache": {
 							"version": "0.2.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"map-cache": "^0.2.2"
 							}
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"get-caller-file": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"get-stream": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"get-value": {
 							"version": "2.0.6",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"glob": {
 							"version": "7.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
 								"inflight": "^1.0.4",
@@ -3928,15 +3505,18 @@
 						},
 						"globals": {
 							"version": "9.18.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"graceful-fs": {
 							"version": "4.1.11",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"handlebars": {
 							"version": "4.0.11",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"async": "^1.4.0",
 								"optimist": "^0.6.1",
@@ -3947,6 +3527,7 @@
 								"source-map": {
 									"version": "0.4.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"amdefine": ">=0.0.4"
 									}
@@ -3956,17 +3537,20 @@
 						"has-ansi": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
 						},
 						"has-flag": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"has-value": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"get-value": "^2.0.6",
 								"has-values": "^1.0.0",
@@ -3975,13 +3559,15 @@
 							"dependencies": {
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"has-values": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-number": "^3.0.0",
 								"kind-of": "^4.0.0"
@@ -3990,6 +3576,7 @@
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -3997,6 +3584,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -4006,6 +3594,7 @@
 								"kind-of": {
 									"version": "4.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -4014,15 +3603,18 @@
 						},
 						"hosted-git-info": {
 							"version": "2.6.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"imurmurhash": {
 							"version": "0.1.4",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"inflight": {
 							"version": "1.0.6",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"once": "^1.3.0",
 								"wrappy": "1"
@@ -4030,37 +3622,44 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"invariant": {
 							"version": "2.2.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"loose-envify": "^1.0.0"
 							}
 						},
 						"invert-kv": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
 						},
 						"is-arrayish": {
 							"version": "0.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-buffer": {
 							"version": "1.1.6",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-builtin-module": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"builtin-modules": "^1.0.0"
 							}
@@ -4068,6 +3667,7 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -4075,6 +3675,7 @@
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -4083,28 +3684,33 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"is-extendable": {
 							"version": "0.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-finite": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -4112,60 +3718,72 @@
 						"is-odd": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-number": "^4.0.0"
 							},
 							"dependencies": {
 								"is-number": {
 									"version": "4.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"is-plain-object": {
 							"version": "2.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"is-stream": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-utf8": {
 							"version": "0.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-windows": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isexe": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"istanbul-lib-coverage": {
 							"version": "1.2.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"istanbul-lib-hook": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"append-transform": "^0.4.0"
 							}
@@ -4173,6 +3791,7 @@
 						"istanbul-lib-instrument": {
 							"version": "1.10.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"babel-generator": "^6.18.0",
 								"babel-template": "^6.16.0",
@@ -4186,6 +3805,7 @@
 						"istanbul-lib-report": {
 							"version": "1.1.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"istanbul-lib-coverage": "^1.1.2",
 								"mkdirp": "^0.5.1",
@@ -4196,6 +3816,7 @@
 								"supports-color": {
 									"version": "3.2.3",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"has-flag": "^1.0.0"
 									}
@@ -4205,6 +3826,7 @@
 						"istanbul-lib-source-maps": {
 							"version": "1.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"debug": "^3.1.0",
 								"istanbul-lib-coverage": "^1.1.2",
@@ -4216,6 +3838,7 @@
 								"debug": {
 									"version": "3.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"ms": "2.0.0"
 									}
@@ -4225,21 +3848,25 @@
 						"istanbul-reports": {
 							"version": "1.4.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"handlebars": "^4.0.3"
 							}
 						},
 						"js-tokens": {
 							"version": "3.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"jsesc": {
 							"version": "1.3.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "3.2.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -4247,11 +3874,13 @@
 						"lazy-cache": {
 							"version": "1.0.4",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						},
 						"lcid": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"invert-kv": "^1.0.0"
 							}
@@ -4259,6 +3888,7 @@
 						"load-json-file": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"parse-json": "^2.2.0",
@@ -4270,6 +3900,7 @@
 						"locate-path": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"p-locate": "^2.0.0",
 								"path-exists": "^3.0.0"
@@ -4277,21 +3908,25 @@
 							"dependencies": {
 								"path-exists": {
 									"version": "3.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"lodash": {
 							"version": "4.17.10",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"longest": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"loose-envify": {
 							"version": "1.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"js-tokens": "^3.0.0"
 							}
@@ -4299,6 +3934,7 @@
 						"lru-cache": {
 							"version": "4.1.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"pseudomap": "^1.0.2",
 								"yallist": "^2.1.2"
@@ -4306,11 +3942,13 @@
 						},
 						"map-cache": {
 							"version": "0.2.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"map-visit": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"object-visit": "^1.0.0"
 							}
@@ -4318,17 +3956,20 @@
 						"md5-hex": {
 							"version": "1.3.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"md5-o-matic": "^0.1.1"
 							}
 						},
 						"md5-o-matic": {
 							"version": "0.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"mem": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"mimic-fn": "^1.0.0"
 							}
@@ -4336,19 +3977,22 @@
 						"merge-source-map": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"source-map": "^0.6.1"
 							},
 							"dependencies": {
 								"source-map": {
 									"version": "0.6.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"micromatch": {
 							"version": "3.1.10",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -4367,28 +4011,33 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"mimic-fn": {
 							"version": "1.2.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"mixin-deep": {
 							"version": "1.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"for-in": "^1.0.2",
 								"is-extendable": "^1.0.1"
@@ -4397,6 +4046,7 @@
 								"is-extendable": {
 									"version": "1.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-plain-object": "^2.0.4"
 									}
@@ -4406,17 +4056,20 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"nanomatch": {
 							"version": "1.2.9",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -4434,21 +4087,25 @@
 							"dependencies": {
 								"arr-diff": {
 									"version": "4.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"array-unique": {
 									"version": "0.3.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"normalize-package-data": {
 							"version": "2.4.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"hosted-git-info": "^2.1.4",
 								"is-builtin-module": "^1.0.0",
@@ -4459,21 +4116,25 @@
 						"npm-run-path": {
 							"version": "2.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-key": "^2.0.0"
 							}
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"object-copy": {
 							"version": "0.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"copy-descriptor": "^0.1.0",
 								"define-property": "^0.2.5",
@@ -4483,6 +4144,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -4492,32 +4154,37 @@
 						"object-visit": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"isobject": "^3.0.0"
 							},
 							"dependencies": {
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"object.pick": {
 							"version": "1.3.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"isobject": "^3.0.1"
 							},
 							"dependencies": {
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4525,6 +4192,7 @@
 						"optimist": {
 							"version": "0.6.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"minimist": "~0.0.1",
 								"wordwrap": "~0.0.2"
@@ -4532,11 +4200,13 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"os-locale": {
 							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"execa": "^0.7.0",
 								"lcid": "^1.0.0",
@@ -4545,11 +4215,13 @@
 						},
 						"p-finally": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"p-limit": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"p-try": "^1.0.0"
 							}
@@ -4557,47 +4229,56 @@
 						"p-locate": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"p-limit": "^1.1.0"
 							}
 						},
 						"p-try": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"parse-json": {
 							"version": "2.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"error-ex": "^1.2.0"
 							}
 						},
 						"pascalcase": {
 							"version": "0.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"path-exists": {
 							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"path-key": {
 							"version": "2.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"path-parse": {
 							"version": "1.0.5",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"path-type": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"pify": "^2.0.0",
@@ -4606,15 +4287,18 @@
 						},
 						"pify": {
 							"version": "2.3.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"pinkie": {
 							"version": "2.0.4",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"pinkie-promise": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"pinkie": "^2.0.0"
 							}
@@ -4622,6 +4306,7 @@
 						"pkg-dir": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"find-up": "^1.0.0"
 							},
@@ -4629,6 +4314,7 @@
 								"find-up": {
 									"version": "1.1.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"path-exists": "^2.0.0",
 										"pinkie-promise": "^2.0.0"
@@ -4638,15 +4324,18 @@
 						},
 						"posix-character-classes": {
 							"version": "0.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"pseudomap": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"read-pkg": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"load-json-file": "^1.0.0",
 								"normalize-package-data": "^2.3.2",
@@ -4656,6 +4345,7 @@
 						"read-pkg-up": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"find-up": "^1.0.0",
 								"read-pkg": "^1.0.0"
@@ -4664,6 +4354,7 @@
 								"find-up": {
 									"version": "1.1.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"path-exists": "^2.0.0",
 										"pinkie-promise": "^2.0.0"
@@ -4673,11 +4364,13 @@
 						},
 						"regenerator-runtime": {
 							"version": "0.11.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"regex-not": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^3.0.2",
 								"safe-regex": "^1.1.0"
@@ -4685,42 +4378,51 @@
 						},
 						"repeat-element": {
 							"version": "1.1.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"repeat-string": {
 							"version": "1.6.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"repeating": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-finite": "^1.0.0"
 							}
 						},
 						"require-directory": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"require-main-filename": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"resolve-from": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"resolve-url": {
 							"version": "0.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"ret": {
 							"version": "0.1.15",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"right-align": {
 							"version": "0.1.3",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"align-text": "^0.1.1"
@@ -4729,6 +4431,7 @@
 						"rimraf": {
 							"version": "2.6.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"glob": "^7.0.5"
 							}
@@ -4736,21 +4439,25 @@
 						"safe-regex": {
 							"version": "1.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ret": "~0.1.10"
 							}
 						},
 						"semver": {
 							"version": "5.5.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"set-value": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -4761,6 +4468,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -4770,25 +4478,30 @@
 						"shebang-command": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"shebang-regex": "^1.0.0"
 							}
 						},
 						"shebang-regex": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"slide": {
 							"version": "1.1.6",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"snapdragon": {
 							"version": "0.8.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"base": "^0.11.1",
 								"debug": "^2.2.0",
@@ -4803,6 +4516,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -4810,6 +4524,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -4819,6 +4534,7 @@
 						"snapdragon-node": {
 							"version": "2.1.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"define-property": "^1.0.0",
 								"isobject": "^3.0.0",
@@ -4828,6 +4544,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -4835,6 +4552,7 @@
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -4842,6 +4560,7 @@
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -4849,6 +4568,7 @@
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^1.0.0",
 										"is-data-descriptor": "^1.0.0",
@@ -4857,28 +4577,33 @@
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"snapdragon-util": {
 							"version": "3.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.2.0"
 							}
 						},
 						"source-map": {
 							"version": "0.5.7",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"source-map-resolve": {
 							"version": "0.5.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"atob": "^2.0.0",
 								"decode-uri-component": "^0.2.0",
@@ -4889,11 +4614,13 @@
 						},
 						"source-map-url": {
 							"version": "0.4.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"spawn-wrap": {
 							"version": "1.4.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"foreground-child": "^1.5.6",
 								"mkdirp": "^0.5.0",
@@ -4906,6 +4633,7 @@
 						"spdx-correct": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"spdx-expression-parse": "^3.0.0",
 								"spdx-license-ids": "^3.0.0"
@@ -4913,11 +4641,13 @@
 						},
 						"spdx-exceptions": {
 							"version": "2.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"spdx-expression-parse": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"spdx-exceptions": "^2.1.0",
 								"spdx-license-ids": "^3.0.0"
@@ -4925,11 +4655,13 @@
 						},
 						"spdx-license-ids": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"split-string": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^3.0.0"
 							}
@@ -4937,6 +4669,7 @@
 						"static-extend": {
 							"version": "0.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"define-property": "^0.2.5",
 								"object-copy": "^0.1.0"
@@ -4945,6 +4678,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -4954,6 +4688,7 @@
 						"string-width": {
 							"version": "2.1.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
 								"strip-ansi": "^4.0.0"
@@ -4961,11 +4696,13 @@
 							"dependencies": {
 								"ansi-regex": {
 									"version": "3.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
 									}
@@ -4975,6 +4712,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4982,21 +4720,25 @@
 						"strip-bom": {
 							"version": "2.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-utf8": "^0.2.0"
 							}
 						},
 						"strip-eof": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"supports-color": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"test-exclude": {
 							"version": "4.2.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arrify": "^1.0.1",
 								"micromatch": "^3.1.8",
@@ -5007,15 +4749,18 @@
 							"dependencies": {
 								"arr-diff": {
 									"version": "4.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"array-unique": {
 									"version": "0.3.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"braces": {
 									"version": "2.3.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"arr-flatten": "^1.1.0",
 										"array-unique": "^0.3.2",
@@ -5032,6 +4777,7 @@
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-extendable": "^0.1.0"
 											}
@@ -5041,6 +4787,7 @@
 								"expand-brackets": {
 									"version": "2.1.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"debug": "^2.3.3",
 										"define-property": "^0.2.5",
@@ -5054,6 +4801,7 @@
 										"define-property": {
 											"version": "0.2.5",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-descriptor": "^0.1.0"
 											}
@@ -5061,6 +4809,7 @@
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-extendable": "^0.1.0"
 											}
@@ -5068,6 +4817,7 @@
 										"is-accessor-descriptor": {
 											"version": "0.1.6",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"kind-of": "^3.0.2"
 											},
@@ -5075,6 +4825,7 @@
 												"kind-of": {
 													"version": "3.2.2",
 													"bundled": true,
+													"dev": true,
 													"requires": {
 														"is-buffer": "^1.1.5"
 													}
@@ -5084,6 +4835,7 @@
 										"is-data-descriptor": {
 											"version": "0.1.4",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"kind-of": "^3.0.2"
 											},
@@ -5091,6 +4843,7 @@
 												"kind-of": {
 													"version": "3.2.2",
 													"bundled": true,
+													"dev": true,
 													"requires": {
 														"is-buffer": "^1.1.5"
 													}
@@ -5100,6 +4853,7 @@
 										"is-descriptor": {
 											"version": "0.1.6",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-accessor-descriptor": "^0.1.6",
 												"is-data-descriptor": "^0.1.4",
@@ -5108,13 +4862,15 @@
 										},
 										"kind-of": {
 											"version": "5.1.0",
-											"bundled": true
+											"bundled": true,
+											"dev": true
 										}
 									}
 								},
 								"extglob": {
 									"version": "2.0.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"array-unique": "^0.3.2",
 										"define-property": "^1.0.0",
@@ -5129,6 +4885,7 @@
 										"define-property": {
 											"version": "1.0.0",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-descriptor": "^1.0.0"
 											}
@@ -5136,6 +4893,7 @@
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-extendable": "^0.1.0"
 											}
@@ -5145,6 +4903,7 @@
 								"fill-range": {
 									"version": "4.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"extend-shallow": "^2.0.1",
 										"is-number": "^3.0.0",
@@ -5155,6 +4914,7 @@
 										"extend-shallow": {
 											"version": "2.0.1",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-extendable": "^0.1.0"
 											}
@@ -5164,6 +4924,7 @@
 								"is-accessor-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -5171,6 +4932,7 @@
 								"is-data-descriptor": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^6.0.0"
 									}
@@ -5178,6 +4940,7 @@
 								"is-descriptor": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^1.0.0",
 										"is-data-descriptor": "^1.0.0",
@@ -5187,6 +4950,7 @@
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -5194,6 +4958,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -5202,15 +4967,18 @@
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"micromatch": {
 									"version": "3.1.10",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"arr-diff": "^4.0.0",
 										"array-unique": "^0.3.2",
@@ -5231,11 +4999,13 @@
 						},
 						"to-fast-properties": {
 							"version": "1.0.3",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"to-object-path": {
 							"version": "0.3.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -5243,6 +5013,7 @@
 						"to-regex": {
 							"version": "3.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"define-property": "^2.0.2",
 								"extend-shallow": "^3.0.2",
@@ -5253,6 +5024,7 @@
 						"to-regex-range": {
 							"version": "2.1.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-number": "^3.0.0",
 								"repeat-string": "^1.6.1"
@@ -5261,6 +5033,7 @@
 								"is-number": {
 									"version": "3.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									}
@@ -5269,11 +5042,13 @@
 						},
 						"trim-right": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"uglify-js": {
 							"version": "2.8.29",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"source-map": "~0.5.1",
@@ -5284,6 +5059,7 @@
 								"yargs": {
 									"version": "3.10.0",
 									"bundled": true,
+									"dev": true,
 									"optional": true,
 									"requires": {
 										"camelcase": "^1.0.2",
@@ -5297,11 +5073,13 @@
 						"uglify-to-browserify": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						},
 						"union-value": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-union": "^3.1.0",
 								"get-value": "^2.0.6",
@@ -5312,6 +5090,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -5319,6 +5098,7 @@
 								"set-value": {
 									"version": "0.4.3",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"extend-shallow": "^2.0.1",
 										"is-extendable": "^0.1.1",
@@ -5331,6 +5111,7 @@
 						"unset-value": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-value": "^0.3.1",
 								"isobject": "^3.0.0"
@@ -5339,6 +5120,7 @@
 								"has-value": {
 									"version": "0.3.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"get-value": "^2.0.3",
 										"has-values": "^0.1.4",
@@ -5348,6 +5130,7 @@
 										"isobject": {
 											"version": "2.1.0",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"isarray": "1.0.0"
 											}
@@ -5356,34 +5139,40 @@
 								},
 								"has-values": {
 									"version": "0.1.4",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"isobject": {
 									"version": "3.0.1",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"urix": {
 							"version": "0.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"use": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "6.0.2",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"validate-npm-package-license": {
 							"version": "3.0.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"spdx-correct": "^3.0.0",
 								"spdx-expression-parse": "^3.0.0"
@@ -5392,26 +5181,31 @@
 						"which": {
 							"version": "1.3.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"isexe": "^2.0.0"
 							}
 						},
 						"which-module": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"window-size": {
 							"version": "0.1.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						},
 						"wordwrap": {
 							"version": "0.0.3",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"wrap-ansi": {
 							"version": "2.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
 								"strip-ansi": "^3.0.1"
@@ -5420,6 +5214,7 @@
 								"is-fullwidth-code-point": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"number-is-nan": "^1.0.0"
 									}
@@ -5427,6 +5222,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
 										"is-fullwidth-code-point": "^1.0.0",
@@ -5437,11 +5233,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"write-file-atomic": {
 							"version": "1.3.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.11",
 								"imurmurhash": "^0.1.4",
@@ -5450,15 +5248,18 @@
 						},
 						"y18n": {
 							"version": "3.2.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"yallist": {
 							"version": "2.1.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"yargs": {
 							"version": "11.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"cliui": "^4.0.0",
 								"decamelize": "^1.1.1",
@@ -5476,15 +5277,18 @@
 							"dependencies": {
 								"ansi-regex": {
 									"version": "3.0.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"camelcase": {
 									"version": "4.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								},
 								"cliui": {
 									"version": "4.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"string-width": "^2.1.1",
 										"strip-ansi": "^4.0.0",
@@ -5494,6 +5298,7 @@
 								"strip-ansi": {
 									"version": "4.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
 									}
@@ -5501,6 +5306,7 @@
 								"yargs-parser": {
 									"version": "9.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"camelcase": "^4.1.0"
 									}
@@ -5510,13 +5316,15 @@
 						"yargs-parser": {
 							"version": "8.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							},
 							"dependencies": {
 								"camelcase": {
 									"version": "4.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						}
@@ -5528,6 +5336,7 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
+			"dev": true,
 			"requires": {
 				"color-support": "^1.1.0",
 				"debug": "^2.1.3",
@@ -5544,6 +5353,7 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 					"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+					"dev": true,
 					"requires": {
 						"events-to-array": "^1.0.1",
 						"js-yaml": "^3.2.7",
@@ -5556,6 +5366,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
 			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+			"dev": true,
 			"requires": {
 				"events-to-array": "^1.0.1",
 				"js-yaml": "^3.2.7",
@@ -5565,17 +5376,20 @@
 		"tmatch": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tmatch/-/tmatch-4.0.0.tgz",
-			"integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg=="
+			"integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg==",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"dev": true,
 			"requires": {
 				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
@@ -5584,22 +5398,26 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"trivial-deferred": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
-			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM="
+			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+			"dev": true
 		},
 		"tsame": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.0.tgz",
-			"integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw=="
+			"integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -5608,36 +5426,47 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"unicode-length": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+			"dev": true,
 			"requires": {
 				"punycode": "^1.3.2",
 				"strip-ansi": "^3.0.1"
 			}
 		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true,
+			"optional": true
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -5659,7 +5488,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -5695,16 +5524,12 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.2"
 			}
-		},
-		"xregexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -5714,20 +5539,22 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yapool": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+			"dev": true
 		},
 		"yargs": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-			"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^2.0.0",
+				"decamelize": "^1.2.0",
 				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^3.0.0",
@@ -5737,15 +5564,16 @@
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^10.1.0"
+				"yargs-parser": "^11.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -27,24 +27,24 @@
         "@types/node": "^8.10.37",
         "@types/nodeunit": "^0.0.30",
         "@types/semver": "^5.5.0",
-        "@types/yargs": "^11.1.2",
+        "@types/yargs": "^12.0.8",
         "clone": "^2.1.2",
         "jsii-build-tools": "^0.7.13",
         "nodeunit": "^0.11.3",
-        "nyc": "^12.0.2"
+        "nyc": "^13.1.0"
     },
     "dependencies": {
-        "case": "^1.5.5",
-        "colors": "^1.3.1",
+        "case": "^1.6.1",
+        "colors": "^1.3.3",
         "deep-equal": "^1.0.1",
-        "fs-extra": "^7.0.0",
+        "fs-extra": "^7.0.1",
         "jsii-spec": "^0.7.13",
-        "log4js": "^3.0.6",
+        "log4js": "^4.0.1",
         "semver": "^5.6.0",
         "sort-json": "^2.0.0",
-        "spdx-license-list": "^4.1.0",
-        "typescript": "^3.2.2",
-        "yargs": "^12.0.2"
+        "spdx-license-list": "^5.0.0",
+        "typescript": "^3.2.4",
+        "yargs": "^12.0.5"
     },
     "nyc": {
         "reporter": [

--- a/packages/oo-ascii-tree/jest.config.js
+++ b/packages/oo-ascii-tree/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/oo-ascii-tree/lib/ascii-tree.ts
+++ b/packages/oo-ascii-tree/lib/ascii-tree.ts
@@ -1,5 +1,3 @@
-import stream = require('stream');
-
 /**
  * A tree of nodes that can be ASCII visualized.
  */
@@ -25,7 +23,7 @@ export class AsciiTree {
   /**
    * Prints the tree to an output stream.
    */
-  public printTree(output: stream.Writable = process.stdout) {
+  public printTree(output: NodeJS.WritableStream = process.stdout) {
     let ancestorsPrefix = '';
 
     for (const parent of this.ancestors) {

--- a/packages/oo-ascii-tree/package-lock.json
+++ b/packages/oo-ascii-tree/package-lock.json
@@ -10,6 +10,90 @@
 				"@babel/highlight": "^7.0.0"
 			}
 		},
+		"@babel/core": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+			"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helpers": "^7.2.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/template": "^7.2.2",
+				"@babel/traverse": "^7.2.2",
+				"@babel/types": "^7.2.2",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.10",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+			"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+			"requires": {
+				"@babel/types": "^7.3.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"requires": {
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.3.0"
+			}
+		},
 		"@babel/highlight": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -18,24 +102,66 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+			"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA=="
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/types": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+			"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@types/jest": {
-			"version": "23.3.10",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.10.tgz",
-			"integrity": "sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ=="
+			"version": "23.3.13",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.13.tgz",
+			"integrity": "sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA=="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "8.10.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
+			"integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA=="
 		},
 		"abab": {
 			"version": "2.0.0",
@@ -57,9 +183,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+					"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 				}
 			}
 		},
@@ -69,9 +195,9 @@
 			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
 		},
 		"ajv": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-			"integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -80,14 +206,14 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+			"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -104,264 +230,14 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
 			}
 		},
 		"append-transform": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "^2.0.0"
 			}
 		},
 		"argparse": {
@@ -373,12 +249,9 @@
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -392,13 +265,13 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -461,211 +334,38 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
 		"babel-jest": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.0.0.tgz",
+			"integrity": "sha512-YGKRbZUjoRmNIAyG7x4wYxUyHvHPFpYXj6Mx1A5cslhaQOUgP/+LF3wtFgMuOQkIpjbVNBufmOnVY0QVwB5v9Q==",
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.2.0"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.0.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz",
+			"integrity": "sha512-CLoXPRSUWiR8yao8bShqZUIC6qLfZVVY3X1wj+QPNXu0wfmrRRfarh1LYy+dYMVI+bDj0ghy3tuqFFRFZmL1Nw==",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.0.0.tgz",
+			"integrity": "sha512-ipefE7YWNyRNVaV/MonUb/I5nef53ZRFR74P9meMGmJxqt8s1BJmfhw11YeIMbcjXN4fxtWUaskZZe8yreXE1Q=="
 		},
 		"babel-preset-jest": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.0.0.tgz",
+			"integrity": "sha512-ECMMOLvNDCmsn3geBa3JkwzylcfpThMpAdfreONQm8EmXcs4tXUpXZDQPxiIMg7nMobTuAC2zDGIKrbrBXW2Vg==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.2.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.0.0"
 			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -719,16 +419,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -750,13 +440,30 @@
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"browser-process-hrtime": {
@@ -812,19 +519,12 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
 			}
 		},
 		"callsites": {
-			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw=="
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -845,9 +545,9 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -855,9 +555,9 @@
 			}
 		},
 		"ci-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -877,11 +577,6 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -893,6 +588,21 @@
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
 				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"co": {
@@ -941,6 +651,11 @@
 			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
 			"optional": true
 		},
+		"compare-versions": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
+		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -964,22 +679,19 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
@@ -1028,11 +740,11 @@
 			}
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -1051,11 +763,11 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-require-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"define-properties": {
@@ -1100,16 +812,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -1118,23 +820,15 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		"diff-sequences": {
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.0.0.tgz",
+			"integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw=="
 		},
 		"domexception": {
 			"version": "1.0.1",
@@ -1153,6 +847,14 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1162,15 +864,16 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
@@ -1237,12 +940,12 @@
 			}
 		},
 		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
@@ -1256,32 +959,60 @@
 			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "^2.1.0"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"expect": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.0.0.tgz",
+			"integrity": "sha512-qDHRU4lGsme0xjg8dXp/RQhvO9XIo9FWqVo7dTHDPBwzy25JGEHAWFsnpmRYErB50tgi/6euo3ir5e/kF9LUTA==",
 			"requires": {
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.6.0",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0"
+				"jest-get-type": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"jest-message-util": "^24.0.0",
+				"jest-regex-util": "^24.0.0"
 			}
 		},
 		"extend": {
@@ -1309,11 +1040,62 @@
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
 			}
 		},
 		"extsprintf": {
@@ -1344,11 +1126,6 @@
 				"bser": "^2.0.0"
 			}
 		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -1359,37 +1136,38 @@
 			}
 		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"requires": {
-				"for-in": "^1.0.1"
-			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -1420,9 +1198,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -1444,7 +1222,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1454,37 +1232,32 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1500,7 +1273,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -1543,7 +1316,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1561,11 +1334,11 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -1587,8 +1360,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1598,7 +1370,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1611,27 +1382,24 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1641,7 +1409,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1652,7 +1419,7 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1662,17 +1429,17 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -1688,12 +1455,12 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -1714,8 +1481,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1725,7 +1491,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1760,11 +1525,11 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -1792,15 +1557,15 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true
 				},
 				"safer-buffer": {
@@ -1814,7 +1579,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -1831,7 +1596,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1859,16 +1623,16 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -1878,11 +1642,11 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -1890,7 +1654,7 @@
 					"bundled": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true
 				}
 			}
@@ -1906,9 +1670,12 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -1936,27 +1703,10 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "^2.0.0"
-			}
-		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
 		},
 		"graceful-fs": {
 			"version": "4.1.15",
@@ -2008,14 +1758,6 @@
 				"function-bind": "^1.1.1"
 			}
 		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2034,13 +1776,6 @@
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
 			}
 		},
 		"has-values": {
@@ -2052,24 +1787,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -2078,15 +1795,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -2121,11 +1829,11 @@
 			}
 		},
 		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"requires": {
-				"pkg-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
 			}
 		},
@@ -2157,9 +1865,9 @@
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -2167,6 +1875,16 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-arrayish": {
@@ -2181,7 +1899,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
@@ -2193,11 +1911,11 @@
 			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"requires": {
-				"ci-info": "^1.5.0"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -2206,6 +1924,16 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-date-object": {
@@ -2230,36 +1958,10 @@
 				}
 			}
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-		},
-		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -2267,24 +1969,26 @@
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-generator-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
-		},
-		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"requires": {
-				"is-extglob": "^1.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g=="
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-plain-object": {
@@ -2293,24 +1997,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -2338,11 +2025,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2359,12 +2041,9 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -2372,324 +2051,319 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.0.tgz",
+			"integrity": "sha512-+Ygg4t1StoiNlBGc6x0f8q/Bv26FbZqP/+jegzfNpU7Q8o+4ZRoJxJPhBkgE/UonpAjtxnE4zCZIyJX+MwLRMQ==",
 			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.1",
-				"istanbul-lib-hook": "^1.2.2",
-				"istanbul-lib-instrument": "^1.10.2",
-				"istanbul-lib-report": "^1.1.5",
-				"istanbul-lib-source-maps": "^1.2.6",
-				"istanbul-reports": "^1.5.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.0",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
 				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw=="
 		},
 		"istanbul-lib-hook": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "^1.0.0"
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.0.tgz",
+			"integrity": "sha512-azQdSX+dtTtkQEfqq20ICxWi6eOHXyHIgMFw1VOOVi8iIPWeCWRgCyFh/CsBKIhcgskMI8ExXmU7rjXTRCIJ+A==",
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "^4.0.11"
 			}
 		},
 		"jest": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.0.0.tgz",
+			"integrity": "sha512-1Z2EblP4BnERbWZGtipGb9zjHDq7nCHgCY7V57F5SYaFRJV4DE1HKoOz+CRC5OrAThN9OVhRlUhTzsTFArg2iQ==",
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^23.6.0"
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.0.0"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
+					"version": "24.0.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.0.0.tgz",
+					"integrity": "sha512-mElnFipLaGxo1SiQ1CLvuaz3eX07MJc4HcyKrApSJf8xSdY1/EwaHurKwu1g2cDiwIgY8uHj7UcF5OYbtiBOWg==",
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.3.1",
-						"istanbul-lib-coverage": "^1.2.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.4.2",
-						"jest-config": "^23.6.0",
-						"jest-environment-jsdom": "^23.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.6.0",
-						"jest-runner": "^23.6.0",
-						"jest-runtime": "^23.6.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"jest-watcher": "^23.4.0",
-						"jest-worker": "^23.2.0",
-						"micromatch": "^2.3.11",
+						"graceful-fs": "^4.1.15",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"istanbul-api": "^2.0.8",
+						"istanbul-lib-coverage": "^2.0.2",
+						"istanbul-lib-instrument": "^3.0.1",
+						"istanbul-lib-source-maps": "^3.0.1",
+						"jest-changed-files": "^24.0.0",
+						"jest-config": "^24.0.0",
+						"jest-environment-jsdom": "^24.0.0",
+						"jest-get-type": "^24.0.0",
+						"jest-haste-map": "^24.0.0",
+						"jest-message-util": "^24.0.0",
+						"jest-regex-util": "^24.0.0",
+						"jest-resolve-dependencies": "^24.0.0",
+						"jest-runner": "^24.0.0",
+						"jest-runtime": "^24.0.0",
+						"jest-snapshot": "^24.0.0",
+						"jest-util": "^24.0.0",
+						"jest-validate": "^24.0.0",
+						"jest-watcher": "^24.0.0",
+						"jest-worker": "^24.0.0",
+						"micromatch": "^3.1.10",
 						"node-notifier": "^5.2.1",
-						"prompts": "^0.1.9",
+						"p-each-series": "^1.0.0",
+						"pirates": "^4.0.0",
+						"prompts": "^2.0.1",
 						"realpath-native": "^1.0.0",
 						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
+						"slash": "^2.0.0",
 						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
+						"strip-ansi": "^5.0.0",
 						"which": "^1.2.12",
-						"yargs": "^11.0.0"
+						"yargs": "^12.0.2"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.0.0.tgz",
+			"integrity": "sha512-nnuU510R9U+UX0WNb5XFEcsrMqriSiRLeO9KWDFgPrpToaQm60prfQYpxsXigdClpvNot5bekDY440x9dNGnsQ==",
 			"requires": {
+				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.0.0.tgz",
+			"integrity": "sha512-9/soqWL5YSq1ZJtgVJ5YYPCL1f9Mi2lVCp5+OXuYBOaN8DHSFRCSWip0rQ6N+mPTOEIAlCvcUH8zaPOwK4hePg==",
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^23.6.0",
+				"@babel/core": "^7.1.0",
+				"babel-jest": "^24.0.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^23.4.0",
-				"jest-environment-node": "^23.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"pretty-format": "^23.6.0"
+				"jest-environment-jsdom": "^24.0.0",
+				"jest-environment-node": "^24.0.0",
+				"jest-get-type": "^24.0.0",
+				"jest-jasmine2": "^24.0.0",
+				"jest-regex-util": "^24.0.0",
+				"jest-resolve": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"jest-validate": "^24.0.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.0.0",
+				"realpath-native": "^1.0.2",
+				"uuid": "^3.3.2"
 			}
 		},
 		"jest-diff": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.0.0.tgz",
+			"integrity": "sha512-XY5wMpRaTsuMoU+1/B2zQSKQ9RdE9gsLkGydx3nvApeyPijLA8GtEvIcPwISRCer+VDf9W1mStTYYq6fPt8ryA==",
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"diff-sequences": "^24.0.0",
+				"jest-get-type": "^24.0.0",
+				"pretty-format": "^24.0.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0.tgz",
+			"integrity": "sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==",
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.0.0.tgz",
+			"integrity": "sha512-gFcbY4Cu55yxExXMkjrnLXov3bWO3dbPAW7HXb31h/DNWdNc/6X8MtxGff8nh3/MjkF9DpVqnj0KsPKuPK0cpA==",
 			"requires": {
 				"chalk": "^2.0.1",
-				"pretty-format": "^23.6.0"
+				"jest-get-type": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"pretty-format": "^24.0.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.0.0.tgz",
+			"integrity": "sha512-1YNp7xtxajTRaxbylDc2pWvFnfDTH5BJJGyVzyGAKNt/lEULohwEV9zFqTgG4bXRcq7xzdd+sGFws+LxThXXOw==",
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0",
+				"jest-mock": "^24.0.0",
+				"jest-util": "^24.0.0",
 				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.0.0.tgz",
+			"integrity": "sha512-62fOFcaEdU0VLaq8JL90TqwI7hLn0cOKOl8vY2n477vRkCJRojiRRtJVRzzCcgFvs6gqU97DNqX5R0BrBP6Rxg==",
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0"
+				"jest-mock": "^24.0.0",
+				"jest-util": "^24.0.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "22.4.3",
-			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
+			"integrity": "sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w=="
 		},
 		"jest-haste-map": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.0.0.tgz",
+			"integrity": "sha512-CcViJyUo41IQqttLxXVdI41YErkzBKbE6cS6dRAploCeutePYfUimWd3C9rQEWhX0YBOQzvNsC0O9nYxK2nnxQ==",
 			"requires": {
 				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
+				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
-				"jest-docblock": "^23.2.0",
-				"jest-serializer": "^23.0.1",
-				"jest-worker": "^23.2.0",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"jest-serializer": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"jest-worker": "^24.0.0",
+				"micromatch": "^3.1.10",
+				"sane": "^3.0.0"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.0.0.tgz",
+			"integrity": "sha512-q1xEV9KHM0bgfBj3yrkrjRF5kxpNDkWPCwVfSPN1DC+pD6J5wrM9/u2BgzhKhALXiaZUUhJ+f/OcEC0Gwpw90A==",
 			"requires": {
-				"babel-traverse": "^6.0.0",
+				"@babel/traverse": "^7.1.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^23.6.0",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.6.0",
-				"jest-each": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"pretty-format": "^23.6.0"
+				"expect": "^24.0.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"jest-message-util": "^24.0.0",
+				"jest-snapshot": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"pretty-format": "^24.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.0.0.tgz",
+			"integrity": "sha512-ZYHJYFeibxfsDSKowjDP332pStuiFT2xfc5R67Rjm/l+HFJWJgNIOCOlQGeXLCtyUn3A23+VVDdiCcnB6dTTrg==",
 			"requires": {
-				"pretty-format": "^23.6.0"
+				"pretty-format": "^24.0.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.0.0.tgz",
+			"integrity": "sha512-LQTDmO+aWRz1Tf9HJg+HlPHhDh1E1c65kVwRFo5mwCVp5aQDzlkz4+vCvXhOKFjitV2f0kMdHxnODrXVoi+rlA==",
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"jest-diff": "^24.0.0",
+				"jest-get-type": "^24.0.0",
+				"pretty-format": "^24.0.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.0.0.tgz",
+			"integrity": "sha512-J9ROJIwz/IeC+eV1XSwnRK4oAwPuhmxEyYx1+K5UI+pIYwFZDSrfZaiWTdq0d2xYFw4Xiu+0KQWsdsQpgJMf3Q==",
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
+				"@babel/code-frame": "^7.0.0",
 				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
 				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-			"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.0.0.tgz",
+			"integrity": "sha512-sQp0Hu5fcf5NZEh1U9eIW2qD0BwJZjb63Yqd98PQJFvf/zzUTBoUAwv/Dc/HFeNHIw1f3hl/48vNn+j3STaI7A=="
 		},
 		"jest-regex-util": {
-			"version": "23.3.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-			"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.0.0.tgz",
+			"integrity": "sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q=="
 		},
 		"jest-resolve": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.0.0.tgz",
+			"integrity": "sha512-uKDGyJqNaBQKox1DJzm27CJobADsIMNgZGusXhtYzl98LKu/fKuokkRsd7EBVgoDA80HKHc3LOPKuYLryMu1vw==",
 			"requires": {
 				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
@@ -2697,119 +2371,97 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.0.0.tgz",
+			"integrity": "sha512-CJGS5ME2g5wL16o3Y22ga9p5ntNT5CUYX40/0lYj9ic9jB5YHm/qMKTgbFt9kowEBiMOFpXy15dWtBTEU54+zg==",
 			"requires": {
-				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.6.0"
+				"jest-regex-util": "^24.0.0",
+				"jest-snapshot": "^24.0.0"
 			}
 		},
 		"jest-runner": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.0.0.tgz",
+			"integrity": "sha512-XefXm2XimKtwdfi2am4364GfCmLD1tOjiRtDexY65diCXt4Rw23rxj2wiW7p9s8Nh9dzJQNmrheqZ5rzvn762g==",
 			"requires": {
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-leak-detector": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-worker": "^23.2.0",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.0.0",
+				"jest-docblock": "^24.0.0",
+				"jest-haste-map": "^24.0.0",
+				"jest-jasmine2": "^24.0.0",
+				"jest-leak-detector": "^24.0.0",
+				"jest-message-util": "^24.0.0",
+				"jest-runtime": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"jest-worker": "^24.0.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				}
 			}
 		},
 		"jest-runtime": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.0.0.tgz",
+			"integrity": "sha512-UeVoTGiij8upcqfyBlJvImws7IGY+ZWtgVpt1h4VmVbyei39tVGia/20VoP3yvodS6FdjTwBj+JzVNuoh/9UTw==",
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.1.6",
+				"@babel/core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"exit": "^0.1.2",
 				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.0.0",
+				"jest-haste-map": "^24.0.0",
+				"jest-message-util": "^24.0.0",
+				"jest-regex-util": "^24.0.0",
+				"jest-resolve": "^24.0.0",
+				"jest-snapshot": "^24.0.0",
+				"jest-util": "^24.0.0",
+				"jest-validate": "^24.0.0",
+				"micromatch": "^3.1.10",
 				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"slash": "^2.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^11.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				}
+				"write-file-atomic": "^2.4.2",
+				"yargs": "^12.0.2"
 			}
 		},
 		"jest-serializer": {
-			"version": "23.0.1",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0.tgz",
+			"integrity": "sha512-9FKxQyrFgHtx3ozU+1a8v938ILBE7S8Ko3uiAVjT8Yfi2o91j/fj81jacCQZ/Ihjiff/VsUCXVgQ+iF1XdImOw=="
 		},
 		"jest-snapshot": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.0.0.tgz",
+			"integrity": "sha512-7OcrckVnfzVYxSGPYl2Sn+HyT30VpDv+FMBFbQxSQ6DV2K9Js6vYT6d4SBPKp6DfDiEL2txNssJBxtlvF+Dymw==",
 			"requires": {
-				"babel-types": "^6.0.0",
+				"@babel/types": "^7.0.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.6.0",
+				"jest-diff": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"jest-message-util": "^24.0.0",
+				"jest-resolve": "^24.0.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.6.0",
+				"pretty-format": "^24.0.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.0.0.tgz",
+			"integrity": "sha512-QxsALc4wguYS7cfjdQSOr5HTkmjzkHgmZvIDkcmPfl1ib8PNV8QUWLwbKefCudWS0PRKioV+VbQ0oCUPC691fQ==",
 			"requires": {
-				"callsites": "^2.0.0",
+				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^23.4.0",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"jest-message-util": "^24.0.0",
 				"mkdirp": "^0.5.1",
-				"slash": "^1.0.0",
+				"slash": "^2.0.0",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
@@ -2821,43 +2473,63 @@
 			}
 		},
 		"jest-validate": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.0.0.tgz",
+			"integrity": "sha512-vMrKrTOP4BBFIeOWsjpsDgVXATxCspC9S1gqvbJ3Tnn/b9ACsJmteYeVx9830UMV28Cob1RX55x96Qq3Tfad4g==",
 			"requires": {
+				"camelcase": "^5.0.0",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
+				"jest-get-type": "^24.0.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^23.6.0"
+				"pretty-format": "^24.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+				}
 			}
 		},
 		"jest-watcher": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.0.0.tgz",
+			"integrity": "sha512-GxkW2QrZ4YxmW1GUWER05McjVDunBlKMFfExu+VsGmXJmpej1saTEKvONdx5RJBlVdpPI5x6E3+EDQSIGgl53g==",
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
+				"jest-util": "^24.0.0",
 				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
+			"integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -2902,9 +2574,14 @@
 			}
 		},
 		"jsesc": {
-			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -2922,9 +2599,19 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -2938,24 +2625,21 @@
 			}
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"kleur": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.1.tgz",
+			"integrity": "sha512-P3kRv+B+Ra070ng2VKQqW4qW7gd/v3iD8sy/zOdcYRsfiD+QBokQNOps/AfP6Hr48cBhIIBFWckB9aO+IZhrWg=="
 		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"left-pad": {
@@ -2978,23 +2662,22 @@
 			}
 		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -3016,13 +2699,12 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pify": "^3.0.0"
 			}
 		},
 		"make-error": {
@@ -3038,6 +2720,14 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -3051,17 +2741,14 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+			"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^1.0.0",
+				"p-is-promise": "^1.1.0"
 			}
 		},
 		"merge": {
@@ -3078,23 +2765,23 @@
 			}
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mime-db": {
@@ -3156,14 +2843,14 @@
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"optional": true
 		},
 		"nanomatch": {
@@ -3182,23 +2869,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
 			}
 		},
 		"natural-compare": {
@@ -3206,10 +2876,20 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
 		},
 		"node-notifier": {
 			"version": "5.3.0",
@@ -3264,11 +2944,6 @@
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3286,6 +2961,14 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
 				}
 			}
 		},
@@ -3300,13 +2983,6 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -3318,28 +2994,12 @@
 				"es-abstract": "^1.5.1"
 			}
 		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
-			}
-		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
 			}
 		},
 		"once": {
@@ -3379,69 +3039,72 @@
 				}
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
 			}
 		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
+		"p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse5": {
@@ -3461,7 +3124,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
@@ -3475,13 +3138,11 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"performance-now": {
@@ -3490,29 +3151,24 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+		"pirates": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+			"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
 			"requires": {
-				"pinkie": "^2.0.0"
+				"node-modules-regexp": "^1.0.0"
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "^3.0.0"
 			}
 		},
 		"pn": {
@@ -3530,31 +3186,14 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-		},
 		"pretty-format": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
+			"integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
 			"requires": {
-				"ansi-regex": "^3.0.0",
+				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				}
 			}
-		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -3562,23 +3201,27 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"prompts": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.1.tgz",
+			"integrity": "sha512-8lnEOSIGQbgbnO47+13S+H204L8ISogGulyi0/NNEFAQ9D1VMNTrJ9SBX2Ra03V4iPn/zt36HQMndRYkaPoWiQ==",
 			"requires": {
-				"kleur": "^2.0.1",
-				"sisteransi": "^0.1.1"
+				"kleur": "^3.0.0",
+				"sisteransi": "^1.0.0"
 			}
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -3590,69 +3233,28 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"requires": {
-				"load-json-file": "^1.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				}
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -3670,19 +3272,6 @@
 			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
 			"requires": {
 				"util.promisify": "^1.0.0"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -3708,14 +3297,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
 		},
 		"request": {
 			"version": "2.88.0",
@@ -3817,11 +3398,11 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"rsvp": {
@@ -3836,7 +3417,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -3848,13 +3429,14 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-3.1.0.tgz",
+			"integrity": "sha512-G5GClRRxT1cELXfdAq7UKtUsv8q/ZC5k8lQGmjEm4HcAl3HzBy68iglyNCmw4+0tiXPCBZntslHlRhbnsSws+Q==",
 			"requires": {
 				"anymatch": "^2.0.0",
 				"capture-exit": "^1.2.0",
 				"exec-sh": "^0.2.0",
+				"execa": "^1.0.0",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^1.2.3",
 				"micromatch": "^3.1.4",
@@ -3863,257 +3445,9 @@
 				"watch": "~0.18.0"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -4178,14 +3512,14 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sisteransi": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -4202,6 +3536,14 @@
 				"use": "^3.1.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -4217,6 +3559,11 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -4263,16 +3610,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -4282,6 +3619,16 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
 				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"source-map": {
@@ -4302,11 +3649,19 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+			"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
 			"requires": {
-				"source-map": "^0.5.6"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"source-map-url": {
@@ -4315,9 +3670,9 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -4338,9 +3693,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -4356,9 +3711,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -4407,6 +3762,21 @@
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string-width": {
@@ -4416,42 +3786,47 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
-			}
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"requires": {
-				"ansi-regex": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
-		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"safe-buffer": "~5.1.0"
 			}
+		},
+		"strip-ansi": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+			"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+			"requires": {
+				"ansi-regex": "^4.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"supports-color": {
@@ -4468,14 +3843,13 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"test-exclude": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
+			"integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
 			"requires": {
 				"arrify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
 				"require-main-filename": "^1.0.1"
 			}
 		},
@@ -4490,9 +3864,9 @@
 			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -4500,6 +3874,16 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
@@ -4520,16 +3904,6 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
 			}
 		},
 		"tough-cookie": {
@@ -4615,9 +3989,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-			"integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"uglify-js": {
 			"version": "3.4.9",
@@ -4702,11 +4076,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -4793,7 +4162,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -4846,13 +4215,18 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -4873,7 +4247,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -4887,9 +4261,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+			"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -4910,40 +4284,43 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yargs": {
-			"version": "11.1.0",
-			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
+				"os-locale": "^3.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+				}
 			}
 		}
 	}

--- a/packages/oo-ascii-tree/package.json
+++ b/packages/oo-ascii-tree/package.json
@@ -11,12 +11,12 @@
     "package": "package-js"
   },
   "devDependencies": {
-    "@types/jest": "^23.3.10",
-    "@types/node": "^10.12.12",
-    "jest": "^23.6.0",
+    "@types/jest": "^23.3.13",
+    "@types/node": "^8.10.37",
+    "jest": "^24.0.0",
     "jsii-build-tools": "^0.7.13",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.2.1"
+    "typescript": "^3.2.4"
   },
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
Notable upgrades include:
- `typescript@3.2.4`
- `yargs@^12.0.5`

In particular, the `yargs` update prompted a couple of code changes to enable
leveraging the new mapped type support that is offered (which in a number of
cases allows writing safer code around the CLI parser).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
