### PR TITLE
fix: remove use of private API

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -325,6 +325,8 @@ function nodeJsCompatibleSearchPaths(dir: string): string[] {
 }
 
 function parseConfigHostFromCompilerHost(host: ts.CompilerHost): ts.ParseConfigHost {
+    // Copied from upstream
+    // https://github.com/Microsoft/TypeScript/blob/9e05abcfd3f8bb3d6775144ede807daceab2e321/src/compiler/program.ts#L3105
     return {
         fileExists: f => host.fileExists(f),
         readDirectory(root, extensions, excludes, includes, depth) {

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -259,7 +259,7 @@ export class Compiler implements Emitter {
         if (files.length > 0) {
             ret.push(...files);
         } else {
-            const parseConfigHost = (ts as any /* private API */).parseConfigHostFromCompilerHost(this.compilerHost);
+            const parseConfigHost = parseConfigHostFromCompilerHost(this.compilerHost);
             const parsed = ts.parseJsonConfigFileContent(this.typescriptConfig, parseConfigHost, this.options.projectInfo.projectRoot);
             ret.push(...parsed.fileNames);
         }
@@ -322,4 +322,19 @@ function nodeJsCompatibleSearchPaths(dir: string): string[] {
     } while (dir !== lastDir); // path.dirname('/') === '/', also works on Windows
 
     return ret;
+}
+
+function parseConfigHostFromCompilerHost(host: ts.CompilerHost): ts.ParseConfigHost {
+    return {
+        fileExists: f => host.fileExists(f),
+        readDirectory(root, extensions, excludes, includes, depth) {
+            if (host.readDirectory === undefined) {
+                throw new Error("'CompilerHost.readDirectory' must be implemented to correctly process 'projectReferences'");
+            }
+            return host.readDirectory!(root, extensions, excludes, includes, depth);
+        },
+        readFile: f => host.readFile(f),
+        useCaseSensitiveFileNames: host.useCaseSensitiveFileNames(),
+        trace: host.trace ? (s) => host.trace!(s) : undefined
+    };
 }

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -43,7 +43,7 @@
         "semver": "^5.6.0",
         "sort-json": "^2.0.0",
         "spdx-license-list": "^5.0.0",
-        "typescript": "3.2.4",
+        "typescript": "^3.2.4",
         "yargs": "^12.0.5"
     },
     "nyc": {

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -43,7 +43,7 @@
         "semver": "^5.6.0",
         "sort-json": "^2.0.0",
         "spdx-license-list": "^5.0.0",
-        "typescript": "^3.2.4",
+        "typescript": "3.2.4",
         "yargs": "^12.0.5"
     },
     "nyc": {


### PR DESCRIPTION
Don't use the upstream private API function to turn a `CompilerHost` into a
`ParseConfigHost` anymore; instead, I copied the implementation, which is
simple enough.

Fixes #350.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
