### PR TITLE
Add instructions for building superchain docker image to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,25 @@ also be used locally as follows:
 eval $(aws ecr get-login --no-include-email)
 IMAGE=260708760616.dkr.ecr.us-east-1.amazonaws.com/superchain:latest
 docker pull ${IMAGE}
+```
+
+Or if you don't have access to that ECS registry/image you can build the image
+yourself as follows (note that this may take quite some time):
+
+```shell
+$ git clone git@github.com:awslabs/aws-delivlib.git
+$ cd aws-delivlib/superchain
+$ docker build -t superchain .
+$ IMAGE=superchain
+```
+
+This will get you into an interactive docker shell.
+
+```shell
 docker run --net=host -it -v $PWD:$PWD -w $PWD ${IMAGE}
 ```
 
-This will get you into an interactive docker shell. You can then run
-./install.sh and ./build.sh as described below.
+You can then run ./install.sh and ./build.sh as described below.
 
 ### Bootstrapping
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,30 +15,22 @@ __jsii__, it relies on the following toolchains:
  - [Python 3.6.5](https://www.python.org/downloads/release/python-365/)
  - [Ruby 2.5.1](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/)
 
-When building on CodeBuild, these toolchains are all included in the
-[superchain](https://github.com/awslabs/superchain) docker image. This image can
-also be used locally as follows:
+Our CI/CD uses the "superchain" image from [aws-delivlib](https://github.com/awslabs/aws-delivlib). 
 
-```shell
-eval $(aws ecr get-login --no-include-email)
-IMAGE=260708760616.dkr.ecr.us-east-1.amazonaws.com/superchain:latest
-docker pull ${IMAGE}
-```
+This image can also be used locally like this (note that initial build may take quite some time):
 
-Or if you don't have access to that ECS registry/image you can build the image
-yourself as follows (note that this may take quite some time):
-
-```shell
+```console
 $ git clone git@github.com:awslabs/aws-delivlib.git
 $ cd aws-delivlib/superchain
 $ docker build -t superchain .
 $ IMAGE=superchain
 ```
 
-This will get you into an interactive docker shell.
+This will get you into an interactive docker shell:
 
-```shell
-docker run --net=host -it -v $PWD:$PWD -w $PWD ${IMAGE}
+```console
+$ cd jsii # go to the root of the jsii repo
+$ docker run --net=host -it -v $PWD:$PWD -w $PWD ${IMAGE}
 ```
 
 You can then run `./build.sh` as described below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,10 @@ All modules within this repository have the following scripts:
 * `build` - builds the module (usually runs the TypeScript compiler).
 * `watch` - runs `tsc -w` which picks up changes and builds them progressively.
 * `test` - uses `nodeunit test/test.*.js` to run all unit tests.
-* `package` - emits publishable artifacts to `dist/xxx` (where "xxx" is the language)
+* `package` - emits publishable artifacts to `dist/<lang>`
 
 Each one of these scripts can be executed either from the root of the repo using
-`lerna run xxx --scope <package>` or from individual modules using `npm run xxx`.
+`lerna run <script> --scope <package>` or from individual modules using `npm run <script>`.
 
 ### Bump
 
@@ -98,7 +98,7 @@ jsii language bindings consist of two main components:
 ### Runtime Client Library
 
 The runtime client library should be implemented as a module under
-`packages/jsii-xxx-runtime` (where `xxx` is the language).
+`packages/jsii-<lang>-runtime`.
 
 The jsii runtime client library usually includes the following components:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ All modules within this repository have the following scripts:
 * `package` - emits publishable artifacts to `dist/<lang>`
 
 Each one of these scripts can be executed either from the root of the repo using
-`lerna run <script> --scope <package>` or from individual modules using `npm run <script>`.
+`npx lerna run <script> --scope <package>` or from individual modules using
+`npm run <script>`.
 
 ### Bump
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ This will get you into an interactive docker shell.
 docker run --net=host -it -v $PWD:$PWD -w $PWD ${IMAGE}
 ```
 
-You can then run ./install.sh and ./build.sh as described below.
+You can then run `./build.sh` as described below.
 
 ### Bootstrapping
 


### PR DESCRIPTION
As the title suggests this PR is mostly about adding an explanation of how to build the `superchain` docker image if you don't have access to the relevant registry/image. However, I've also made a few other tweaks to the contribution guide which I hope are correct and useful.

Ref: #354

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
