### PR TITLE
fix(jsii): detect double interface member declarations

### DIFF
--- a/packages/jsii/test/negatives/neg.double-interface-members-deeper.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members-deeper.ts
@@ -1,0 +1,15 @@
+///!MATCH_ERROR: Interface declares same member as inherited interface: foo
+
+export interface IA {
+  foo(): void;
+}
+
+export interface IB extends IA {
+    bar(): void;
+}
+
+export interface IC extends IB {
+  foo(): void;
+}
+
+

--- a/packages/jsii/test/negatives/neg.double-interface-members-method.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members-method.ts
@@ -1,0 +1,9 @@
+///!MATCH_ERROR: Interface declares same member as inherited interface: foo
+
+export interface IA {
+  foo(): void;
+}
+export interface IB extends IA {
+  foo(): void;
+}
+

--- a/packages/jsii/test/negatives/neg.double-interface-members.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members.ts
@@ -1,0 +1,8 @@
+///!MATCH_ERROR: Interface declares same member as inherited interface: foo
+
+export interface A {
+  foo: number;
+}
+export interface B extends A {
+  foo: number;
+}

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.2.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.2.ts
@@ -9,6 +9,8 @@ export interface ISomething {
     returnSomething(): Superclass;
 }
 
-export interface ISomethingElse extends ISomething {
-    returnSomething(): Subclass;
+export class ISomethingElse implements ISomething {
+    public returnSomething(): Subclass {
+        return new Subclass();
+    }
 }


### PR DESCRIPTION
In C# it's prohibited to declare an interface member
that also exists in an inherited interface. Have jsii
detect this illegal pattern.

Strictly speaking, this only true if we don't overload,
but since we don't support overloading anyway we just
check on the member names, not the types.

Fixes #340.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
