### PR TITLE
fix: Bump version of Jackson because of CVEs

### DIFF
--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -52,14 +52,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
+            <version>[2.9.8,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>[2.9.8,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava-io -->


### PR DESCRIPTION
Versions low than 2.9.8 have a number of CVEs filed against it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
