### PR TITLE
fix(jsii-pacmack): default to target directory mode

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -51,7 +51,7 @@ import { VERSION_DESC } from '../lib/version';
         .option('force-subdirectory', {
             type: 'boolean',
             desc: 'force generation into a target-named subdirectory, even in single-target mode',
-            default: false
+            default: true,
         })
         .option('recurse', {
             alias: 'R',

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -61,7 +61,7 @@ export default class Dotnet extends Target {
 
         await this.copyFiles(
             path.join(sourceDir, packageId, 'bin', 'Release'),
-            path.join(outDir, this.targetName));
+            outDir);
         await fs.remove(path.join(outDir, 'netstandard2.0'));
     }
 


### PR DESCRIPTION
Always generate to `$root/dist/TARGET`, even when only
generating one target. This behavior works better
for selectively building targets in a larger build that
expects certain naming conventions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
