### PR TITLE
fix(jsii): prohibit exported const enums

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -482,6 +482,15 @@ export class Assembler implements Emitter {
             LOG.trace(`Processing enum: ${colors.gray(namespace.join('.'))}.${colors.cyan(type.symbol.name)}`);
         }
 
+        const decl = type.symbol.valueDeclaration;
+        const flags = ts.getCombinedModifierFlags(decl);
+        // tslint:disable-next-line:no-bitwise
+        if (flags & ts.ModifierFlags.Const) {
+            this._diagnostic(decl,
+                             ts.DiagnosticCategory.Error,
+                            `Exported enum cannot be declared 'const'`);
+        }
+
         const jsiiType: spec.EnumType = {
             assembly: this.projectInfo.name,
             fqn: `${[this.projectInfo.name, ...namespace].join('.')}.${type.symbol.name}`,

--- a/packages/jsii/test/negatives/neg.const-enum.ts
+++ b/packages/jsii/test/negatives/neg.const-enum.ts
@@ -1,0 +1,8 @@
+///!MATCH_ERROR: Exported enum cannot be declared 'const'
+
+export const enum NotAllowed {
+  ThisEnum,
+  GetsInlined,
+  AndSoItGetsLost,
+  ForJsii
+}


### PR DESCRIPTION
'const enums' are inlined at the usage site by TypeScript and so the
generated type will not be in the JavaScript source code in the
assembly, even though the declaration will be there.

This leads to "symbol not found" errors upon trying to load it.

https://www.typescriptlang.org/docs/handbook/enums.html#const-enums

Fixes awslabs/aws-cdk#1969

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
