### PR TITLE
Abstract proxy classes need to inherent from parent's proxies

### DIFF
--- a/packages/jsii-python-runtime/src/jsii/__init__.py
+++ b/packages/jsii-python-runtime/src/jsii/__init__.py
@@ -10,6 +10,7 @@ from ._runtime import (
     implements,
     member,
     kernel,
+    proxy_for,
 )
 
 
@@ -44,6 +45,7 @@ __all__ = [
     "implements",
     "member",
     "kernel",
+    "proxy_for",
     "load",
     "create",
     "delete",

--- a/packages/jsii-python-runtime/src/jsii/_runtime.py
+++ b/packages/jsii-python-runtime/src/jsii/_runtime.py
@@ -107,3 +107,10 @@ def implements(*interfaces):
         return cls
 
     return deco
+
+
+def proxy_for(abstract_class):
+    if not hasattr(abstract_class, "__jsii_proxy_class__"):
+        raise TypeError(f"{abstract_class} is not a JSII Abstract class.")
+
+    return abstract_class.__jsii_proxy_class__()

--- a/packages/jsii-python-runtime/tests/test_compliance.py
+++ b/packages/jsii-python-runtime/tests/test_compliance.py
@@ -807,7 +807,6 @@ def test_nodeStandardLibrary():
     )
 
 
-@xfail_abstract_class
 def test_returnAbstract():
     obj = AbstractClassReturner()
     obj2 = obj.give_me_abstract()


### PR DESCRIPTION
In the JSII, we generate a proxy class for any Abstract classes. This proxy class inherits from the abstract class, and does nothing but provide implementations of any abstract methods/properties that just call into the JSII. However, this only worked for abstract methods defined on this specific abstract class, not any parent abstract classes.

This PR resolves that issue, by building up a list of all abstract classes in an abstract class's inheritance tree, and then has the proxy depend on it. 

Because the actual name of the abstract class is not part of a module's public interface, this PR adds a ``jsii.proxy_for`` function, which takes an abstract class and returns the proxy class for it. 

#### Before:

```python
class Value(scope.jsii_calc_base.Base, metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-lib.Value"):
    @staticmethod
    def __jsii_proxy_class__():
        return _ValueProxy

    @property
    @jsii.member(jsii_name="value")
    @abc.abstractmethod
    def value(self) -> jsii.Number:
        ...

    ...


class _ValueProxy(Value):
    @property
    @jsii.member(jsii_name="value")
    def value(self) -> jsii.Number:
        return jsii.get(self, "value")
```

#### After:

```python
class Value(scope.jsii_calc_base.Base, metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-lib.Value"):
    @staticmethod
    def __jsii_proxy_class__():
        return _ValueProxy

    @property
    @jsii.member(jsii_name="value")
    @abc.abstractmethod
    def value(self) -> jsii.Number:
        ...

    ...


class _ValueProxy(Value, jsii.proxy_for(scope.jsii_calc_base.Base)):
    @property
    @jsii.member(jsii_name="value")
    def value(self) -> jsii.Number:
        return jsii.get(self, "value")
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
