### PR TITLE
fix(jsii): show jsii diagnostics in watch mode and support $tsc problem matcher

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -6,6 +6,7 @@ import spec = require('jsii-spec');
 import log4js = require('log4js');
 import path = require('path');
 import ts = require('typescript');
+import { JSII_DIAGNOSTICS_CODE } from './compiler';
 import { Diagnostic, Emitter } from './emitter';
 import literate = require('./literate');
 import { ProjectInfo } from './project-info';
@@ -223,8 +224,9 @@ export class Assembler implements Emitter {
     private _diagnostic(node: ts.Node | null, category: ts.DiagnosticCategory, messageText: string) {
         this._diagnostics.push({
             domain: 'JSII',
-            category, code: 0,
-            messageText,
+            category,
+            code: JSII_DIAGNOSTICS_CODE,
+            messageText: `JSII: ${messageText}`,
             file: node != null ? node.getSourceFile() : undefined,
             start: node != null ? node.getStart() : undefined,
             length: node != null ? node.getEnd() - node.getStart() : undefined

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -36,10 +36,6 @@ export function logDiagnostic(diagnostic: ts.Diagnostic, projectRoot: string) {
     const message = diagnostic.file
                 ? ts.formatDiagnosticsWithColorAndContext([diagnostic], formatDiagnosticsHost)
                 : ts.formatDiagnostics([diagnostic], formatDiagnosticsHost);
-    // if (hasDomain(diagnostic)) {
-    //     // Make sure error codes don't render as ``TS123``, instead e.g: ``JSII123``.
-    //     message = message.replace(/([^\w])TS(\d+)([^\w])/, `$1${diagnostic.domain}$2$3`);
-    // }
     const logFunc = diagnosticsLogger(log4js.getLogger(DIAGNOSTICS), diagnostic);
     if (!logFunc) { return; }
     logFunc(message.trim());

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -1,7 +1,6 @@
 import log4js = require('log4js');
 import ts = require('typescript');
 import { DIAGNOSTICS } from './compiler';
-// import { hasDomain } from './emitter';
 
 /**
  * Obtains the relevant logger to be used for a given diagnostic message.


### PR DESCRIPTION
Emit jsii diagnostics error when in watch mode, and also format the errors with a
"TS9999" error code so that VSCode's $tsc problem matcher will show them as
"Problems". Prefix "JSII" in the message to distinguish that these are jsii errors.

Fixes #382

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
