### PR TITLE
Rename BaseKernel/ProcessKernel to Provider to make it more distinct

### DIFF
--- a/packages/jsii-python-runtime/src/jsii/_kernel/__init__.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/__init__.py
@@ -10,7 +10,7 @@ import attr
 
 from jsii import _reference_map
 from jsii._utils import Singleton
-from jsii._kernel.providers import BaseKernel, ProcessKernel
+from jsii._kernel.providers import BaseProvider, ProcessProvider
 from jsii._kernel.types import JSClass, Referenceable
 from jsii._kernel.types import (
     EnumRef,
@@ -128,7 +128,7 @@ class Kernel(metaclass=Singleton):
     #       them at this layer to translate it to something more Pythonic, depending
     #       on what the provider layer looks like.
 
-    def __init__(self, provider_class: Type[BaseKernel] = ProcessKernel) -> None:
+    def __init__(self, provider_class: Type[BaseProvider] = ProcessProvider) -> None:
         self.provider = provider_class()
 
     # TODO: Do we want to return anything from this method? Is the return value useful

--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/__init__.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/__init__.py
@@ -1,5 +1,5 @@
-from jsii._kernel.providers.base import BaseKernel
-from jsii._kernel.providers.process import ProcessKernel
+from jsii._kernel.providers.base import BaseProvider
+from jsii._kernel.providers.process import ProcessProvider
 
 
-__all__ = ["BaseKernel", "ProcessKernel"]
+__all__ = ["BaseProvider", "ProcessProvider"]

--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/base.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/base.py
@@ -23,11 +23,11 @@ from jsii._kernel.types import (
 )
 
 
-class BaseKernel(metaclass=abc.ABCMeta):
+class BaseProvider(metaclass=abc.ABCMeta):
 
-    # The API provided by this Kernel is not very pythonic, however it is done to map
+    # The API provided by this Provider is not very pythonic, however it is done to map
     # this API as closely to the JSII runtime as possible. Higher level abstractions
-    # that layer ontop of the Kernel will provide a translation layer that make this
+    # that layer ontop of the Provider will provide a translation layer that make this
     # much more Pythonic.
 
     @abc.abstractmethod

--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
@@ -20,7 +20,7 @@ import jsii._embedded.jsii
 from jsii.__meta__ import __jsii_runtime_version__
 from jsii._compat import importlib_resources
 from jsii._utils import memoized_property
-from jsii._kernel.providers.base import BaseKernel
+from jsii._kernel.providers.base import BaseProvider
 from jsii._kernel.types import (
     ObjRef,
     EnumRef,
@@ -302,7 +302,7 @@ class _NodeProcess:
             raise JSIIError(resp.error) from JavaScriptError(resp.stack)
 
 
-class ProcessKernel(BaseKernel):
+class ProcessProvider(BaseProvider):
     @memoized_property
     def _process(self) -> _NodeProcess:
         process = _NodeProcess()


### PR DESCRIPTION
This provides distinction from just ``Kernel``, which acts as a wrapper over a ``Provider`` that implements most of the logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
