### PR TITLE
Implement Async Function Support

### DIFF
--- a/packages/jsii-python-runtime/src/jsii/__init__.py
+++ b/packages/jsii-python-runtime/src/jsii/__init__.py
@@ -30,6 +30,7 @@ set = kernel.set
 sget = kernel.sget
 sset = kernel.sset
 invoke = kernel.invoke
+ainvoke = kernel.ainvoke
 sinvoke = kernel.sinvoke
 stats = kernel.stats
 
@@ -56,6 +57,7 @@ __all__ = [
     "sget",
     "sset",
     "invoke",
+    "ainvoke",
     "sinvoke",
     "stats",
 ]

--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/base.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/base.py
@@ -18,6 +18,14 @@ from jsii._kernel.types import (
     StaticGetRequest,
     StaticInvokeRequest,
     StaticSetRequest,
+    BeginRequest,
+    BeginResponse,
+    EndRequest,
+    EndResponse,
+    CallbacksRequest,
+    CallbacksResponse,
+    CompleteRequest,
+    CompleteResponse,
     StatsRequest,
     StatsResponse,
 )
@@ -64,6 +72,22 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def delete(self, request: DeleteRequest) -> DeleteResponse:
+        ...
+
+    @abc.abstractmethod
+    def begin(self, request: BeginRequest) -> BeginResponse:
+        ...
+
+    @abc.abstractmethod
+    def end(self, request: EndRequest) -> EndResponse:
+        ...
+
+    @abc.abstractmethod
+    def callbacks(self, request: CallbacksRequest) -> CallbacksResponse:
+        ...
+
+    @abc.abstractmethod
+    def complete(self, request: CompleteRequest) -> CompleteResponse:
         ...
 
     @abc.abstractmethod

--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
@@ -42,6 +42,14 @@ from jsii._kernel.types import (
     StaticGetRequest,
     StaticInvokeRequest,
     StaticSetRequest,
+    BeginRequest,
+    BeginResponse,
+    EndRequest,
+    EndResponse,
+    CallbacksRequest,
+    CallbacksResponse,
+    CompleteRequest,
+    CompleteResponse,
     StatsRequest,
     StatsResponse,
 )
@@ -182,6 +190,21 @@ class _NodeProcess:
         self._serializer.register_unstructure_hook(
             StaticInvokeRequest,
             _with_api_key("sinvoke", self._serializer.unstructure_attrs_asdict),
+        )
+        self._serializer.register_unstructure_hook(
+            BeginRequest,
+            _with_api_key("begin", self._serializer.unstructure_attrs_asdict),
+        )
+        self._serializer.register_unstructure_hook(
+            EndRequest, _with_api_key("end", self._serializer.unstructure_attrs_asdict)
+        )
+        self._serializer.register_unstructure_hook(
+            CallbacksRequest,
+            _with_api_key("callbacks", self._serializer.unstructure_attrs_asdict),
+        )
+        self._serializer.register_unstructure_hook(
+            CompleteRequest,
+            _with_api_key("complete", self._serializer.unstructure_attrs_asdict),
         )
         self._serializer.register_unstructure_hook(
             StatsRequest,
@@ -336,6 +359,18 @@ class ProcessProvider(BaseProvider):
 
     def delete(self, request: DeleteRequest) -> DeleteResponse:
         return self._process.send(request, DeleteResponse)
+
+    def begin(self, request: BeginRequest) -> BeginResponse:
+        return self._process.send(request, BeginResponse)
+
+    def end(self, request: EndRequest) -> EndResponse:
+        return self._process.send(request, EndResponse)
+
+    def callbacks(self, request: CallbacksRequest) -> CallbacksResponse:
+        return self._process.send(request, CallbacksResponse)
+
+    def complete(self, request: CompleteRequest) -> CompleteResponse:
+        return self._process.send(request, CompleteResponse)
 
     def stats(self, request: Optional[StatsRequest] = None) -> StatsResponse:
         if request is None:

--- a/packages/jsii-python-runtime/src/jsii/_kernel/types.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/types.py
@@ -164,10 +164,10 @@ class EndResponse:
 class Callback:
 
     cbid: str
-    cookie: Optional[str]
-    invoke: Optional[InvokeRequest]
-    get: Optional[GetRequest]
-    set: Optional[SetRequest]
+    cookie: Optional[str] = None
+    invoke: Optional[InvokeRequest] = None
+    get: Optional[GetRequest] = None
+    set: Optional[SetRequest] = None
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)

--- a/packages/jsii-python-runtime/src/jsii/_reference_map.py
+++ b/packages/jsii-python-runtime/src/jsii/_reference_map.py
@@ -98,9 +98,13 @@ class _ReferenceMap:
 
         return inst
 
+    def resolve_id(self, id):
+        return self._refs[id]
+
 
 _refs = _ReferenceMap(_types)
 
 
 register_reference = _refs.register
 resolve_reference = _refs.resolve
+resolve_id = _refs.resolve_id

--- a/packages/jsii-python-runtime/tests/test_compliance.py
+++ b/packages/jsii-python-runtime/tests/test_compliance.py
@@ -49,8 +49,7 @@ from scope.jsii_calc_lib import IFriendly, EnumFromScopedModule, Number
 #       Tests as closely as possible to make keeping them in sync easier.
 
 # These map distinct reasons for failures, so we an easily find them.
-xfail_async = pytest.mark.xfail(reason="Implement async methods", strict=True)
-xfail_callbacks = pytest.mark.xfail(reason="Implement callback support", strict=True)
+xfail_callbacks = pytest.mark.skip(reason="Implement callback support")
 
 
 class DerivedFromAllTypes(AllTypes):
@@ -464,39 +463,33 @@ def test_creationOfNativeObjectsFromJavaScriptObjects():
     assert unmarshalled_native_obj.__class__ == MulTen
 
 
-@xfail_async
 def test_asyncOverrides_callAsyncMethod():
     obj = AsyncVirtualMethods()
     assert obj.call_me() == 128
     assert obj.override_me(44) == 528
 
 
-@xfail_async
 def test_asyncOverrides_overrideAsyncMethod():
     obj = OverrideAsyncMethods()
     obj.call_me() == 4452
 
 
-@xfail_async
 def test_asyncOverrides_overrideAsyncMethodByParentClass():
     obj = OverrideAsyncMethodsByBaseClass()
     obj.call_me() == 4452
 
 
-@xfail_async
 def test_asyncOverrides_overrideCallsSuper():
     obj = OverrideCallsSuper()
     assert obj.override_me(12) == 1441
     assert obj.call_me() == 1209
 
 
-@xfail_async
 def test_asyncOverrides_twoOverrides():
     obj = TwoOverrides()
     assert obj.call_me() == 684
 
 
-@xfail_async
 def test_asyncOverrides_overrideThrows():
     class ThrowingAsyncVirtualMethods(AsyncVirtualMethods):
         def override_me(self, mult):
@@ -783,15 +776,14 @@ def test_reservedKeywordsAreSlugifiedInMethodNames():
     obj.return_()
 
 
-@xfail_async
 def test_nodeStandardLibrary():
     obj = NodeStandardLibrary()
 
     assert obj.fs_read_file() == "Hello, resource!"
     assert obj.fs_read_file_sync() == "Hello, resource! SYNC!"
-    assert len(obj.get_os_platform()) > 0
+    assert len(obj.os_platform) > 0
     assert (
-        obj.crypto_sha_256()
+        obj.crypto_sha256()
         == "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
     )
 


### PR DESCRIPTION
Implements async function support, exposing it the same as a sync function in the Python language.

This is basically done, but will need to coordinate with sync callbacks to make sure we're not doing anything drastically different for the bits that are going to be shared.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
