### PR TITLE
fix: copy non-hidden bases when erasing hidden interfaces

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1424,3 +1424,55 @@ export class ImplementsPrivateInterface implements IPrivateInterface {
 export interface ExtendsPrivateInterface extends IPrivateInterface {
     moreThings: string[];
 }
+
+//
+// hidden (private/internal) base interface erasure will copy non-hidden bases from
+// hidden to consuming type.
+//
+
+export interface IAnotherPublicInterface {
+    a: string;
+
+}
+
+/** @internal */
+export interface IAnotherInternalInterface extends IAnotherPublicInterface {
+    b: string;
+}
+
+export interface INonInternalInterface extends IAnotherInternalInterface {
+    c: string;
+}
+
+/** @internal */
+export interface IInternalInterfaceThatExtendsTheNonInternalOne extends INonInternalInterface {
+    d: string;
+}
+
+interface IPrivateInterfaceThatExtendsTheNonInternalOne extends INonInternalInterface {
+    e: string;
+}
+
+export class ClassThatImplementsTheInternalInterface implements IInternalInterfaceThatExtendsTheNonInternalOne, INonInternalInterface {
+    public a = 'a';
+    public b = 'b';
+    public c = 'c';
+    public d = 'd';
+}
+
+export class ClassThatImplementsThePrivateInterface implements IPrivateInterfaceThatExtendsTheNonInternalOne {
+    public a = 'a';
+    public b = 'b';
+    public c = 'c';
+    public e = 'e';
+}
+
+export class ConsumersOfThisCrazyTypeSystem {
+    public consumeAnotherPublicInterface(obj: IAnotherPublicInterface) {
+        return obj.a;
+    }
+
+    public consumeNonInternalInterface(obj: INonInternalInterface): any {
+        return { a: obj.a, b: obj.b, c: obj.c };
+    }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1040,6 +1040,98 @@
         }
       ]
     },
+    "jsii-calc.ClassThatImplementsTheInternalInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassThatImplementsTheInternalInterface",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.INonInternalInterface"
+        }
+      ],
+      "kind": "class",
+      "name": "ClassThatImplementsTheInternalInterface",
+      "properties": [
+        {
+          "name": "a",
+          "overrides": {
+            "fqn": "jsii-calc.IAnotherPublicInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "b",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "c",
+          "overrides": {
+            "fqn": "jsii-calc.INonInternalInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "d",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.ClassThatImplementsThePrivateInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassThatImplementsThePrivateInterface",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.INonInternalInterface"
+        }
+      ],
+      "kind": "class",
+      "name": "ClassThatImplementsThePrivateInterface",
+      "properties": [
+        {
+          "name": "a",
+          "overrides": {
+            "fqn": "jsii-calc.IAnotherPublicInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "b",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "c",
+          "overrides": {
+            "fqn": "jsii-calc.INonInternalInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "e",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.ClassWithMutableObjectLiteralProperty": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
@@ -1139,6 +1231,45 @@
         }
       ],
       "name": "Constructors"
+    },
+    "jsii-calc.ConsumersOfThisCrazyTypeSystem": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ConsumersOfThisCrazyTypeSystem",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "consumeAnotherPublicInterface",
+          "parameters": [
+            {
+              "name": "obj",
+              "type": {
+                "fqn": "jsii-calc.IAnotherPublicInterface"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "consumeNonInternalInterface",
+          "parameters": [
+            {
+              "name": "obj",
+              "type": {
+                "fqn": "jsii-calc.INonInternalInterface"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "any"
+          }
+        }
+      ],
+      "name": "ConsumersOfThisCrazyTypeSystem"
     },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
@@ -1611,6 +1742,21 @@
       ],
       "name": "GreetingAugmenter"
     },
+    "jsii-calc.IAnotherPublicInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IAnotherPublicInterface",
+      "kind": "interface",
+      "name": "IAnotherPublicInterface",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "a",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
@@ -1749,6 +1895,26 @@
         }
       ],
       "name": "IInterfaceWithOptionalMethodArguments"
+    },
+    "jsii-calc.INonInternalInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.INonInternalInterface",
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.IAnotherPublicInterface"
+        }
+      ],
+      "kind": "interface",
+      "name": "INonInternalInterface",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "c",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
     },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
@@ -4083,5 +4249,5 @@
     }
   },
   "version": "0.7.15",
-  "fingerprint": "iMxRj3lsHKNzSiBrjCyBH6Pp7Uvo+1Sxh/jN3hW+3nA="
+  "fingerprint": "y7h6OQBzbQrvU43LHTizXl12OUAEOpXhqD02OJfmhWQ="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1040,6 +1040,98 @@
         }
       ]
     },
+    "jsii-calc.ClassThatImplementsTheInternalInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassThatImplementsTheInternalInterface",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.INonInternalInterface"
+        }
+      ],
+      "kind": "class",
+      "name": "ClassThatImplementsTheInternalInterface",
+      "properties": [
+        {
+          "name": "a",
+          "overrides": {
+            "fqn": "jsii-calc.IAnotherPublicInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "b",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "c",
+          "overrides": {
+            "fqn": "jsii-calc.INonInternalInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "d",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.ClassThatImplementsThePrivateInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ClassThatImplementsThePrivateInterface",
+      "initializer": {
+        "initializer": true
+      },
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.INonInternalInterface"
+        }
+      ],
+      "kind": "class",
+      "name": "ClassThatImplementsThePrivateInterface",
+      "properties": [
+        {
+          "name": "a",
+          "overrides": {
+            "fqn": "jsii-calc.IAnotherPublicInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "b",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "c",
+          "overrides": {
+            "fqn": "jsii-calc.INonInternalInterface"
+          },
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "e",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.ClassWithMutableObjectLiteralProperty": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
@@ -1139,6 +1231,45 @@
         }
       ],
       "name": "Constructors"
+    },
+    "jsii-calc.ConsumersOfThisCrazyTypeSystem": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.ConsumersOfThisCrazyTypeSystem",
+      "initializer": {
+        "initializer": true
+      },
+      "kind": "class",
+      "methods": [
+        {
+          "name": "consumeAnotherPublicInterface",
+          "parameters": [
+            {
+              "name": "obj",
+              "type": {
+                "fqn": "jsii-calc.IAnotherPublicInterface"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "string"
+          }
+        },
+        {
+          "name": "consumeNonInternalInterface",
+          "parameters": [
+            {
+              "name": "obj",
+              "type": {
+                "fqn": "jsii-calc.INonInternalInterface"
+              }
+            }
+          ],
+          "returns": {
+            "primitive": "any"
+          }
+        }
+      ],
+      "name": "ConsumersOfThisCrazyTypeSystem"
     },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
@@ -1611,6 +1742,21 @@
       ],
       "name": "GreetingAugmenter"
     },
+    "jsii-calc.IAnotherPublicInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IAnotherPublicInterface",
+      "kind": "interface",
+      "name": "IAnotherPublicInterface",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "a",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
@@ -1749,6 +1895,26 @@
         }
       ],
       "name": "IInterfaceWithOptionalMethodArguments"
+    },
+    "jsii-calc.INonInternalInterface": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.INonInternalInterface",
+      "interfaces": [
+        {
+          "fqn": "jsii-calc.IAnotherPublicInterface"
+        }
+      ],
+      "kind": "interface",
+      "name": "INonInternalInterface",
+      "properties": [
+        {
+          "abstract": true,
+          "name": "c",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
     },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
@@ -4083,5 +4249,5 @@
     }
   },
   "version": "0.7.15",
-  "fingerprint": "iMxRj3lsHKNzSiBrjCyBH6Pp7Uvo+1Sxh/jN3hW+3nA="
+  "fingerprint": "y7h6OQBzbQrvU43LHTizXl12OUAEOpXhqD02OJfmhWQ="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
@@ -1,0 +1,48 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(ClassThatImplementsTheInternalInterface), "jsii-calc.ClassThatImplementsTheInternalInterface", "[]")]
+    public class ClassThatImplementsTheInternalInterface : DeputyBase, IINonInternalInterface
+    {
+        public ClassThatImplementsTheInternalInterface(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected ClassThatImplementsTheInternalInterface(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected ClassThatImplementsTheInternalInterface(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("a", "{\"primitive\":\"string\"}")]
+        public virtual string A
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("b", "{\"primitive\":\"string\"}")]
+        public virtual string B
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("c", "{\"primitive\":\"string\"}")]
+        public virtual string C
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("d", "{\"primitive\":\"string\"}")]
+        public virtual string D
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
@@ -1,0 +1,48 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(ClassThatImplementsThePrivateInterface), "jsii-calc.ClassThatImplementsThePrivateInterface", "[]")]
+    public class ClassThatImplementsThePrivateInterface : DeputyBase, IINonInternalInterface
+    {
+        public ClassThatImplementsThePrivateInterface(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected ClassThatImplementsThePrivateInterface(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected ClassThatImplementsThePrivateInterface(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("a", "{\"primitive\":\"string\"}")]
+        public virtual string A
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("b", "{\"primitive\":\"string\"}")]
+        public virtual string B
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("c", "{\"primitive\":\"string\"}")]
+        public virtual string C
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("e", "{\"primitive\":\"string\"}")]
+        public virtual string E
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
@@ -1,0 +1,32 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(ConsumersOfThisCrazyTypeSystem), "jsii-calc.ConsumersOfThisCrazyTypeSystem", "[]")]
+    public class ConsumersOfThisCrazyTypeSystem : DeputyBase
+    {
+        public ConsumersOfThisCrazyTypeSystem(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected ConsumersOfThisCrazyTypeSystem(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected ConsumersOfThisCrazyTypeSystem(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod("consumeAnotherPublicInterface", "{\"primitive\":\"string\"}", "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IAnotherPublicInterface\"}}]")]
+        public virtual string ConsumeAnotherPublicInterface(IIAnotherPublicInterface obj)
+        {
+            return InvokeInstanceMethod<string>(new object[]{obj});
+        }
+
+        [JsiiMethod("consumeNonInternalInterface", "{\"primitive\":\"any\"}", "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.INonInternalInterface\"}}]")]
+        public virtual object ConsumeNonInternalInterface(IINonInternalInterface obj)
+        {
+            return InvokeInstanceMethod<object>(new object[]{obj});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
@@ -1,0 +1,19 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(typeof(IIAnotherPublicInterface), "jsii-calc.IAnotherPublicInterface")]
+    internal sealed class IAnotherPublicInterfaceProxy : DeputyBase, IIAnotherPublicInterface
+    {
+        private IAnotherPublicInterfaceProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("a", "{\"primitive\":\"string\"}")]
+        public string A
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIAnotherPublicInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIAnotherPublicInterface.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(typeof(IIAnotherPublicInterface), "jsii-calc.IAnotherPublicInterface")]
+    public interface IIAnotherPublicInterface
+    {
+        [JsiiProperty("a", "{\"primitive\":\"string\"}")]
+        string A
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(typeof(IINonInternalInterface), "jsii-calc.INonInternalInterface")]
+    public interface IINonInternalInterface : IIAnotherPublicInterface
+    {
+        [JsiiProperty("c", "{\"primitive\":\"string\"}")]
+        string C
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
@@ -1,0 +1,26 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(typeof(IINonInternalInterface), "jsii-calc.INonInternalInterface")]
+    internal sealed class INonInternalInterfaceProxy : DeputyBase, IINonInternalInterface
+    {
+        private INonInternalInterfaceProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("c", "{\"primitive\":\"string\"}")]
+        public string C
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+
+        [JsiiProperty("a", "{\"primitive\":\"string\"}")]
+        public string A
+        {
+            get => GetInstanceProperty<string>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -30,9 +30,12 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.BinaryOperation": return software.amazon.jsii.tests.calculator.BinaryOperation.class;
             case "jsii-calc.Calculator": return software.amazon.jsii.tests.calculator.Calculator.class;
             case "jsii-calc.CalculatorProps": return software.amazon.jsii.tests.calculator.CalculatorProps.class;
+            case "jsii-calc.ClassThatImplementsTheInternalInterface": return software.amazon.jsii.tests.calculator.ClassThatImplementsTheInternalInterface.class;
+            case "jsii-calc.ClassThatImplementsThePrivateInterface": return software.amazon.jsii.tests.calculator.ClassThatImplementsThePrivateInterface.class;
             case "jsii-calc.ClassWithMutableObjectLiteralProperty": return software.amazon.jsii.tests.calculator.ClassWithMutableObjectLiteralProperty.class;
             case "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties": return software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class;
             case "jsii-calc.Constructors": return software.amazon.jsii.tests.calculator.Constructors.class;
+            case "jsii-calc.ConsumersOfThisCrazyTypeSystem": return software.amazon.jsii.tests.calculator.ConsumersOfThisCrazyTypeSystem.class;
             case "jsii-calc.DefaultedConstructorArgument": return software.amazon.jsii.tests.calculator.DefaultedConstructorArgument.class;
             case "jsii-calc.DerivedClassHasNoProperties.Base": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base.class;
             case "jsii-calc.DerivedClassHasNoProperties.Derived": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived.class;
@@ -46,12 +49,14 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.ExtendsPrivateInterface": return software.amazon.jsii.tests.calculator.ExtendsPrivateInterface.class;
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
             case "jsii-calc.GreetingAugmenter": return software.amazon.jsii.tests.calculator.GreetingAugmenter.class;
+            case "jsii-calc.IAnotherPublicInterface": return software.amazon.jsii.tests.calculator.IAnotherPublicInterface.class;
             case "jsii-calc.IFriendlier": return software.amazon.jsii.tests.calculator.IFriendlier.class;
             case "jsii-calc.IFriendlyRandomGenerator": return software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class;
             case "jsii-calc.IInterfaceThatShouldNotBeADataType": return software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType.class;
             case "jsii-calc.IInterfaceWithInternal": return software.amazon.jsii.tests.calculator.IInterfaceWithInternal.class;
             case "jsii-calc.IInterfaceWithMethods": return software.amazon.jsii.tests.calculator.IInterfaceWithMethods.class;
             case "jsii-calc.IInterfaceWithOptionalMethodArguments": return software.amazon.jsii.tests.calculator.IInterfaceWithOptionalMethodArguments.class;
+            case "jsii-calc.INonInternalInterface": return software.amazon.jsii.tests.calculator.INonInternalInterface.class;
             case "jsii-calc.IPrivatelyImplemented": return software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class;
             case "jsii-calc.IPublicInterface": return software.amazon.jsii.tests.calculator.IPublicInterface.class;
             case "jsii-calc.IRandomNumberGenerator": return software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
@@ -1,0 +1,49 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsTheInternalInterface")
+public class ClassThatImplementsTheInternalInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
+    protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public ClassThatImplementsTheInternalInterface() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    @Override
+    public java.lang.String getA() {
+        return this.jsiiGet("a", java.lang.String.class);
+    }
+
+    @Override
+    public void setA(final java.lang.String value) {
+        this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
+    }
+
+    public java.lang.String getB() {
+        return this.jsiiGet("b", java.lang.String.class);
+    }
+
+    public void setB(final java.lang.String value) {
+        this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
+    }
+
+    @Override
+    public java.lang.String getC() {
+        return this.jsiiGet("c", java.lang.String.class);
+    }
+
+    @Override
+    public void setC(final java.lang.String value) {
+        this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
+    }
+
+    public java.lang.String getD() {
+        return this.jsiiGet("d", java.lang.String.class);
+    }
+
+    public void setD(final java.lang.String value) {
+        this.jsiiSet("d", java.util.Objects.requireNonNull(value, "d is required"));
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
@@ -1,0 +1,49 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsThePrivateInterface")
+public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
+    protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public ClassThatImplementsThePrivateInterface() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    @Override
+    public java.lang.String getA() {
+        return this.jsiiGet("a", java.lang.String.class);
+    }
+
+    @Override
+    public void setA(final java.lang.String value) {
+        this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
+    }
+
+    public java.lang.String getB() {
+        return this.jsiiGet("b", java.lang.String.class);
+    }
+
+    public void setB(final java.lang.String value) {
+        this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
+    }
+
+    @Override
+    public java.lang.String getC() {
+        return this.jsiiGet("c", java.lang.String.class);
+    }
+
+    @Override
+    public void setC(final java.lang.String value) {
+        this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
+    }
+
+    public java.lang.String getE() {
+        return this.jsiiGet("e", java.lang.String.class);
+    }
+
+    public void setE(final java.lang.String value) {
+        this.jsiiSet("e", java.util.Objects.requireNonNull(value, "e is required"));
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -1,0 +1,21 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ConsumersOfThisCrazyTypeSystem")
+public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObject {
+    protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public ConsumersOfThisCrazyTypeSystem() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public java.lang.String consumeAnotherPublicInterface(final software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
+        return this.jsiiCall("consumeAnotherPublicInterface", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+    }
+
+    public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
+        return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -1,0 +1,26 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerializable {
+    java.lang.String getA();
+    void setA(final java.lang.String value);
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IAnotherPublicInterface {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getA() {
+            return this.jsiiGet("a", java.lang.String.class);
+        }
+
+        @Override
+        public void setA(final java.lang.String value) {
+            this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -1,0 +1,36 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IAnotherPublicInterface {
+    java.lang.String getC();
+    void setC(final java.lang.String value);
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public java.lang.String getC() {
+            return this.jsiiGet("c", java.lang.String.class);
+        }
+
+        @Override
+        public void setC(final java.lang.String value) {
+            this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
+        }
+
+        @Override
+        public java.lang.String getA() {
+            return this.jsiiGet("a", java.lang.String.class);
+        }
+
+        @Override
+        public void setA(final java.lang.String value) {
+            this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1052,6 +1052,112 @@ CalculatorProps (interface)
       :type: number *(optional)*
 
 
+ClassThatImplementsTheInternalInterface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: ClassThatImplementsTheInternalInterface()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.ClassThatImplementsTheInternalInterface;
+
+      .. code-tab:: javascript
+
+         const { ClassThatImplementsTheInternalInterface } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { ClassThatImplementsTheInternalInterface } from 'jsii-calc';
+
+
+
+   :implements: :py:class:`~jsii-calc.INonInternalInterface`\ 
+
+   .. py:attribute:: a
+
+      *Implements* :py:meth:`jsii-calc.IAnotherPublicInterface.a`
+
+      :type: string
+
+
+   .. py:attribute:: b
+
+      :type: string
+
+
+   .. py:attribute:: c
+
+      *Implements* :py:meth:`jsii-calc.INonInternalInterface.c`
+
+      :type: string
+
+
+   .. py:attribute:: d
+
+      :type: string
+
+
+ClassThatImplementsThePrivateInterface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: ClassThatImplementsThePrivateInterface()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.ClassThatImplementsThePrivateInterface;
+
+      .. code-tab:: javascript
+
+         const { ClassThatImplementsThePrivateInterface } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { ClassThatImplementsThePrivateInterface } from 'jsii-calc';
+
+
+
+   :implements: :py:class:`~jsii-calc.INonInternalInterface`\ 
+
+   .. py:attribute:: a
+
+      *Implements* :py:meth:`jsii-calc.IAnotherPublicInterface.a`
+
+      :type: string
+
+
+   .. py:attribute:: b
+
+      :type: string
+
+
+   .. py:attribute:: c
+
+      *Implements* :py:meth:`jsii-calc.INonInternalInterface.c`
+
+      :type: string
+
+
+   .. py:attribute:: e
+
+      :type: string
+
+
 ClassWithMutableObjectLiteralProperty
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1177,6 +1283,48 @@ Constructors
    .. py:staticmethod:: makeInterface() -> jsii-calc.IPublicInterface
 
       :rtype: :py:class:`~jsii-calc.IPublicInterface`\ 
+
+
+ConsumersOfThisCrazyTypeSystem
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: ConsumersOfThisCrazyTypeSystem()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.ConsumersOfThisCrazyTypeSystem;
+
+      .. code-tab:: javascript
+
+         const { ConsumersOfThisCrazyTypeSystem } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { ConsumersOfThisCrazyTypeSystem } from 'jsii-calc';
+
+
+
+
+   .. py:method:: consumeAnotherPublicInterface(obj) -> string
+
+      :param obj: 
+      :type obj: :py:class:`~jsii-calc.IAnotherPublicInterface`\ 
+      :rtype: string
+
+
+   .. py:method:: consumeNonInternalInterface(obj) -> any
+
+      :param obj: 
+      :type obj: :py:class:`~jsii-calc.INonInternalInterface`\ 
+      :rtype: any
 
 
 DefaultedConstructorArgument
@@ -1784,6 +1932,40 @@ GreetingAugmenter
       :rtype: string
 
 
+IAnotherPublicInterface (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IAnotherPublicInterface
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IAnotherPublicInterface;
+
+      .. code-tab:: javascript
+
+         // IAnotherPublicInterface is an interface
+
+      .. code-tab:: typescript
+
+         import { IAnotherPublicInterface } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: a
+
+      :type: string
+
+
 IFriendlier (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2077,6 +2259,48 @@ IInterfaceWithOptionalMethodArguments (interface)
       :param arg2: 
       :type arg2: number *(optional)*
       :abstract: Yes
+
+
+INonInternalInterface (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: INonInternalInterface
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.INonInternalInterface;
+
+      .. code-tab:: javascript
+
+         // INonInternalInterface is an interface
+
+      .. code-tab:: typescript
+
+         import { INonInternalInterface } from 'jsii-calc';
+
+
+
+   :extends: :py:class:`~jsii-calc.IAnotherPublicInterface`\ 
+
+
+   .. py:attribute:: c
+
+      :type: string
+
+
+   .. py:attribute:: a
+
+      *Inherited from* :py:attr:`jsii-calc.IAnotherPublicInterface <jsii-calc.IAnotherPublicInterface.a>`
+
+      :type: string
 
 
 IPrivatelyImplemented (interface)

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -10,10 +10,13 @@ Base
 Base
 BinaryOperation
 Calculator
+ClassThatImplementsTheInternalInterface
+ClassThatImplementsThePrivateInterface
 ClassWithMutableObjectLiteralProperty
 ClassWithPrivateConstructorAndAutomaticProperties
 CompositeOperation
 Constructors
+ConsumersOfThisCrazyTypeSystem
 DefaultedConstructorArgument
 Derived
 DoNotOverridePrivates

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -223,6 +223,32 @@ assemblies
  │   │   │ └── type: primitive:number (optional)
  │   │   └─┬ unionProperty property
  │   │     └── type: class:jsii-calc.Add | class:jsii-calc.Multiply | class:jsii-calc.Power
+ │   ├─┬ class ClassThatImplementsTheInternalInterface
+ │   │ ├── interfaces: INonInternalInterface
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>() method
+ │   │   │ └── returns: void
+ │   │   ├─┬ a property
+ │   │   │ └── type: primitive:string
+ │   │   ├─┬ b property
+ │   │   │ └── type: primitive:string
+ │   │   ├─┬ c property
+ │   │   │ └── type: primitive:string
+ │   │   └─┬ d property
+ │   │     └── type: primitive:string
+ │   ├─┬ class ClassThatImplementsThePrivateInterface
+ │   │ ├── interfaces: INonInternalInterface
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>() method
+ │   │   │ └── returns: void
+ │   │   ├─┬ a property
+ │   │   │ └── type: primitive:string
+ │   │   ├─┬ b property
+ │   │   │ └── type: primitive:string
+ │   │   ├─┬ c property
+ │   │   │ └── type: primitive:string
+ │   │   └─┬ e property
+ │   │     └── type: primitive:string
  │   ├─┬ class ClassWithMutableObjectLiteralProperty
  │   │ └─┬ members
  │   │   ├─┬ <initializer>() method
@@ -255,6 +281,20 @@ assemblies
  │   │   └─┬ makeInterface() method
  │   │     ├── static
  │   │     └── returns: interface:jsii-calc.IPublicInterface
+ │   ├─┬ class ConsumersOfThisCrazyTypeSystem
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>() method
+ │   │   │ └── returns: void
+ │   │   ├─┬ consumeAnotherPublicInterface(obj) method
+ │   │   │ ├─┬ parameters
+ │   │   │ │ └─┬ obj
+ │   │   │ │   └── type: interface:jsii-calc.IAnotherPublicInterface
+ │   │   │ └── returns: primitive:string
+ │   │   └─┬ consumeNonInternalInterface(obj) method
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ obj
+ │   │     │   └── type: interface:jsii-calc.INonInternalInterface
+ │   │     └── returns: primitive:any
  │   ├─┬ class DefaultedConstructorArgument
  │   │ └─┬ members
  │   │   ├─┬ <initializer>(arg1,arg2,arg3) method
@@ -1103,6 +1143,11 @@ assemblies
  │   │   └─┬ moreThings property
  │   │     ├── abstract
  │   │     └── type: Array<primitive:string>
+ │   ├─┬ interface IAnotherPublicInterface
+ │   │ └─┬ members
+ │   │   └─┬ a property
+ │   │     ├── abstract
+ │   │     └── type: primitive:string
  │   ├─┬ interface IFriendlier
  │   │ ├─┬ interfaces
  │   │ │ └── IFriendly
@@ -1150,6 +1195,13 @@ assemblies
  │   │     │ └─┬ arg2
  │   │     │   └── type: primitive:number (optional)
  │   │     └── returns: void
+ │   ├─┬ interface INonInternalInterface
+ │   │ ├─┬ interfaces
+ │   │ │ └── IAnotherPublicInterface
+ │   │ └─┬ members
+ │   │   └─┬ c property
+ │   │     ├── abstract
+ │   │     └── type: primitive:string
  │   ├─┬ interface IPrivatelyImplemented
  │   │ └─┬ members
  │   │   └─┬ success property

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -17,10 +17,15 @@ assemblies
  │   │ └── interfaces: IFriendly
  │   ├─┬ class Calculator
  │   │ └── base: CompositeOperation
+ │   ├─┬ class ClassThatImplementsTheInternalInterface
+ │   │ └── interfaces: INonInternalInterface
+ │   ├─┬ class ClassThatImplementsThePrivateInterface
+ │   │ └── interfaces: INonInternalInterface
  │   ├── class ClassWithMutableObjectLiteralProperty
  │   ├─┬ class ClassWithPrivateConstructorAndAutomaticProperties
  │   │ └── interfaces: InterfaceWithProperties
  │   ├── class Constructors
+ │   ├── class ConsumersOfThisCrazyTypeSystem
  │   ├── class DefaultedConstructorArgument
  │   ├── class Base
  │   ├─┬ class Derived
@@ -88,6 +93,7 @@ assemblies
  │   │   └── MyFirstStruct
  │   ├── interface ExtendsInternalInterface
  │   ├── interface ExtendsPrivateInterface
+ │   ├── interface IAnotherPublicInterface
  │   ├─┬ interface IFriendlier
  │   │ └─┬ interfaces
  │   │   └── IFriendly
@@ -101,6 +107,9 @@ assemblies
  │   ├── interface IInterfaceWithInternal
  │   ├── interface IInterfaceWithMethods
  │   ├── interface IInterfaceWithOptionalMethodArguments
+ │   ├─┬ interface INonInternalInterface
+ │   │ └─┬ interfaces
+ │   │   └── IAnotherPublicInterface
  │   ├── interface IPrivatelyImplemented
  │   ├── interface IPublicInterface
  │   ├── interface IRandomNumberGenerator

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -86,6 +86,20 @@ assemblies
  │   │   ├── curr property
  │   │   ├── maxValue property
  │   │   └── unionProperty property
+ │   ├─┬ class ClassThatImplementsTheInternalInterface
+ │   │ └─┬ members
+ │   │   ├── <initializer>() method
+ │   │   ├── a property
+ │   │   ├── b property
+ │   │   ├── c property
+ │   │   └── d property
+ │   ├─┬ class ClassThatImplementsThePrivateInterface
+ │   │ └─┬ members
+ │   │   ├── <initializer>() method
+ │   │   ├── a property
+ │   │   ├── b property
+ │   │   ├── c property
+ │   │   └── e property
  │   ├─┬ class ClassWithMutableObjectLiteralProperty
  │   │ └─┬ members
  │   │   ├── <initializer>() method
@@ -100,6 +114,11 @@ assemblies
  │   │   ├── <initializer>() method
  │   │   ├── makeClass() method
  │   │   └── makeInterface() method
+ │   ├─┬ class ConsumersOfThisCrazyTypeSystem
+ │   │ └─┬ members
+ │   │   ├── <initializer>() method
+ │   │   ├── consumeAnotherPublicInterface(obj) method
+ │   │   └── consumeNonInternalInterface(obj) method
  │   ├─┬ class DefaultedConstructorArgument
  │   │ └─┬ members
  │   │   ├── <initializer>(arg1,arg2,arg3) method
@@ -461,6 +480,9 @@ assemblies
  │   ├─┬ interface ExtendsPrivateInterface
  │   │ └─┬ members
  │   │   └── moreThings property
+ │   ├─┬ interface IAnotherPublicInterface
+ │   │ └─┬ members
+ │   │   └── a property
  │   ├─┬ interface IFriendlier
  │   │ └─┬ members
  │   │   ├── farewell() method
@@ -480,6 +502,9 @@ assemblies
  │   ├─┬ interface IInterfaceWithOptionalMethodArguments
  │   │ └─┬ members
  │   │   └── hello(arg1,arg2) method
+ │   ├─┬ interface INonInternalInterface
+ │   │ └─┬ members
+ │   │   └── c property
  │   ├─┬ interface IPrivatelyImplemented
  │   │ └─┬ members
  │   │   └── success property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -11,9 +11,12 @@ assemblies
  │   ├── class AugmentableClass
  │   ├── class BinaryOperation
  │   ├── class Calculator
+ │   ├── class ClassThatImplementsTheInternalInterface
+ │   ├── class ClassThatImplementsThePrivateInterface
  │   ├── class ClassWithMutableObjectLiteralProperty
  │   ├── class ClassWithPrivateConstructorAndAutomaticProperties
  │   ├── class Constructors
+ │   ├── class ConsumersOfThisCrazyTypeSystem
  │   ├── class DefaultedConstructorArgument
  │   ├── class Base
  │   ├── class Derived
@@ -66,12 +69,14 @@ assemblies
  │   ├── interface DerivedStruct
  │   ├── interface ExtendsInternalInterface
  │   ├── interface ExtendsPrivateInterface
+ │   ├── interface IAnotherPublicInterface
  │   ├── interface IFriendlier
  │   ├── interface IFriendlyRandomGenerator
  │   ├── interface IInterfaceThatShouldNotBeADataType
  │   ├── interface IInterfaceWithInternal
  │   ├── interface IInterfaceWithMethods
  │   ├── interface IInterfaceWithOptionalMethodArguments
+ │   ├── interface INonInternalInterface
  │   ├── interface IPrivatelyImplemented
  │   ├── interface IPublicInterface
  │   ├── interface IRandomNumberGenerator

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -381,7 +381,7 @@ export class Assembler implements Emitter {
                 if (!spec.isInterfaceType(deref)) {
                     this._diagnostic(decl,
                                     ts.DiagnosticCategory.Error,
-                                    `Inheritence clause of ${fqn} uses ${spec.describeTypeReference(typeRef)} as an interface`);
+                                    `Inheritance clause of ${fqn} uses ${spec.describeTypeReference(typeRef)} as an interface`);
                 }
             });
 

--- a/packages/jsii/test/negatives/neg.deref-error.ts
+++ b/packages/jsii/test/negatives/neg.deref-error.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Unable to resolve referenced type 'Base'. Missing export?
+///!MATCH_ERROR: Unable to resolve referenced type 'Base'. Type may be @internal or unexported
 
 class Base {
 

--- a/packages/jsii/test/negatives/neg.implements-class.ts
+++ b/packages/jsii/test/negatives/neg.implements-class.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Inheritence clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
+///!MATCH_ERROR: Inheritance clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
 
 export class NotAnInterface {
     public meaningOfTheUniverse() {

--- a/packages/jsii/test/negatives/neg.implements-class.ts
+++ b/packages/jsii/test/negatives/neg.implements-class.ts
@@ -1,4 +1,4 @@
-///!MATCH_ERROR: Implements clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
+///!MATCH_ERROR: Inheritence clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
 
 export class NotAnInterface {
     public meaningOfTheUniverse() {

--- a/packages/jsii/test/negatives/neg.internal-base-class.ts
+++ b/packages/jsii/test/negatives/neg.internal-base-class.ts
@@ -1,0 +1,10 @@
+///!MATCH_ERROR: Unable to resolve referenced type 'jsii.InternalBaseClass'. Type may be @internal or unexported
+
+/** @internal */
+export class InternalBaseClass {
+
+}
+
+export class MyClass extends InternalBaseClass {
+
+}


### PR DESCRIPTION
When a type inherits (extends/implements) from a hidden (private/internal)
interface, and that interface extends a non-hidden interface, we need to 
copy the non-hidden interface to the consuming type so that it can be polymorphically
used.

Follow up on #390

Co-authored-by: RomainMuller <rmuller@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
