### PR TITLE
feat(kernel): Normalize empty structs to undefined

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1587,7 +1587,7 @@ export class ConsumersOfThisCrazyTypeSystem {
 
 //
 // Ensure the JSII kernel can pass "this" out to JSII remotes from within the constructor (this is dirty, but possible)
-///
+//
 export abstract class PartiallyInitializedThisConsumer {
     public abstract consumePartiallyInitializedThis(obj: ConstructorPassesThisOut, dt: Date, ev: AllTypesEnum): string;
 }
@@ -1599,4 +1599,20 @@ export class ConstructorPassesThisOut {
             throw new Error(`Expected OK but received ${result}`);
         }
     }
+}
+
+//
+// Consumes a possibly empty struct and verifies it is turned to undefined when passed
+//
+export class OptionalStructConsumer {
+    public readonly parameterWasUndefined: boolean;
+    public readonly fieldValue?: string;
+
+    constructor(optionalStruct?: OptionalStruct) {
+        this.parameterWasUndefined = optionalStruct === undefined;
+        this.fieldValue = optionalStruct && optionalStruct.field;
+    }
+}
+export interface OptionalStruct {
+    readonly field?: string;
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1603,6 +1603,7 @@ export class ConstructorPassesThisOut {
 
 //
 // Consumes a possibly empty struct and verifies it is turned to undefined when passed
+// See: https://github.com/awslabs/jsii/issues/411
 //
 export class OptionalStructConsumer {
     public readonly parameterWasUndefined: boolean;

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3343,6 +3343,59 @@
         }
       ]
     },
+    "jsii-calc.OptionalStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "fqn": "jsii-calc.OptionalStruct",
+      "kind": "interface",
+      "name": "OptionalStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "field",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.OptionalStructConsumer": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.OptionalStructConsumer",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "optionalStruct",
+            "type": {
+              "fqn": "jsii-calc.OptionalStruct",
+              "optional": true
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "OptionalStructConsumer",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "parameterWasUndefined",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "fieldValue",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.OverrideReturnsObject",
@@ -4580,5 +4633,5 @@
     }
   },
   "version": "0.8.2",
-  "fingerprint": "72ya8nGgXRz4NmrkTbtbKD06Kk++josvz4i1aenPmvI="
+  "fingerprint": "QQVEfUkkaxXMbXiD6wDVqdim8HdLW5L8CElwn+WdzUA="
 }

--- a/packages/jsii-kernel/lib/serialization.ts
+++ b/packages/jsii-kernel/lib/serialization.ts
@@ -274,6 +274,10 @@ export const SERIALIZERS: {[k: string]: Serializer} = {
       return host.objects.registerObject(value, wireFqn);
     },
     deserialize(value, type, host) {
+      if (typeof value === 'object' && Object.keys(value || {}).length === 0) {
+        // Treat empty structs as `undefined` (see https://github.com/awslabs/jsii/issues/411)
+        value = undefined;
+      }
       if (nullAndOk(value, type)) { return undefined; }
 
       if (typeof value !== 'object' || value == null) {

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -1112,6 +1112,20 @@ defineTest('Object ID does not get re-allocated when the constructor passes "thi
     test.equal(classRef[api.TOKEN_REF], 'jsii-calc.ConstructorPassesThisOut@10001');
 });
 
+defineTest('struct: empty object is turned to undefined by deserialization', async (test, sandbox) => {
+    const object = sandbox.create({ fqn: 'jsii-calc.OptionalStructConsumer', args: [{}] });
+    const result = sandbox.get({ objref: object, property: 'parameterWasUndefined' });
+    test.ok(result.value, 'The parameter was undefined within the constructor');
+});
+
+defineTest('struct: non-empty object deserializes properly', async (test, sandbox) => {
+    const objref = sandbox.create({ fqn: 'jsii-calc.OptionalStructConsumer', args: [{ field: 'foo' }] });
+    const result = sandbox.get({ objref, property: 'parameterWasUndefined' });
+    test.ok(!result.value, 'The parameter was not undefined within the constructor');
+    const field = sandbox.get({ objref, property: 'fieldValue' });
+    test.equal('foo', field.value);
+});
+
 // =================================================================================================
 
 const testNames: { [name: string]: boolean } = { };

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3343,6 +3343,59 @@
         }
       ]
     },
+    "jsii-calc.OptionalStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "fqn": "jsii-calc.OptionalStruct",
+      "kind": "interface",
+      "name": "OptionalStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "immutable": true,
+          "name": "field",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.OptionalStructConsumer": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.OptionalStructConsumer",
+      "initializer": {
+        "initializer": true,
+        "parameters": [
+          {
+            "name": "optionalStruct",
+            "type": {
+              "fqn": "jsii-calc.OptionalStruct",
+              "optional": true
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "name": "OptionalStructConsumer",
+      "properties": [
+        {
+          "immutable": true,
+          "name": "parameterWasUndefined",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "immutable": true,
+          "name": "fieldValue",
+          "type": {
+            "optional": true,
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.OverrideReturnsObject",
@@ -4580,5 +4633,5 @@
     }
   },
   "version": "0.8.2",
-  "fingerprint": "72ya8nGgXRz4NmrkTbtbKD06Kk++josvz4i1aenPmvI="
+  "fingerprint": "QQVEfUkkaxXMbXiD6wDVqdim8HdLW5L8CElwn+WdzUA="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalStruct.cs
@@ -1,0 +1,14 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(typeof(IOptionalStruct), "jsii-calc.OptionalStruct")]
+    public interface IOptionalStruct
+    {
+        [JsiiProperty("field", "{\"primitive\":\"string\",\"optional\":true}")]
+        string Field
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiByValue]
+    public class OptionalStruct : IOptionalStruct
+    {
+        [JsiiProperty("field", "{\"primitive\":\"string\",\"optional\":true}", true)]
+        public string Field
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
@@ -1,0 +1,32 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(typeof(OptionalStructConsumer), "jsii-calc.OptionalStructConsumer", "[{\"name\":\"optionalStruct\",\"type\":{\"fqn\":\"jsii-calc.OptionalStruct\",\"optional\":true}}]")]
+    public class OptionalStructConsumer : DeputyBase
+    {
+        public OptionalStructConsumer(IOptionalStruct optionalStruct): base(new DeputyProps(new object[]{optionalStruct}))
+        {
+        }
+
+        protected OptionalStructConsumer(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected OptionalStructConsumer(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty("parameterWasUndefined", "{\"primitive\":\"boolean\"}")]
+        public virtual bool ParameterWasUndefined
+        {
+            get => GetInstanceProperty<bool>();
+        }
+
+        [JsiiProperty("fieldValue", "{\"primitive\":\"string\",\"optional\":true}")]
+        public virtual string FieldValue
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
@@ -1,0 +1,18 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(typeof(IOptionalStruct), "jsii-calc.OptionalStruct")]
+    internal sealed class OptionalStructProxy : DeputyBase, IOptionalStruct
+    {
+        private OptionalStructProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiProperty("field", "{\"primitive\":\"string\",\"optional\":true}")]
+        public string Field
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -92,6 +92,8 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.NumberGenerator": return software.amazon.jsii.tests.calculator.NumberGenerator.class;
             case "jsii-calc.ObjectRefsInCollections": return software.amazon.jsii.tests.calculator.ObjectRefsInCollections.class;
             case "jsii-calc.OptionalConstructorArgument": return software.amazon.jsii.tests.calculator.OptionalConstructorArgument.class;
+            case "jsii-calc.OptionalStruct": return software.amazon.jsii.tests.calculator.OptionalStruct.class;
+            case "jsii-calc.OptionalStructConsumer": return software.amazon.jsii.tests.calculator.OptionalStructConsumer.class;
             case "jsii-calc.OverrideReturnsObject": return software.amazon.jsii.tests.calculator.OverrideReturnsObject.class;
             case "jsii-calc.PartiallyInitializedThisConsumer": return software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer.class;
             case "jsii-calc.Polymorphism": return software.amazon.jsii.tests.calculator.Polymorphism.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -1,0 +1,71 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
+    java.lang.String getField();
+
+    /**
+     * @return a {@link Builder} of {@link OptionalStruct}
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link OptionalStruct}
+     */
+    final class Builder {
+        @javax.annotation.Nullable
+        private java.lang.String _field;
+
+        /**
+         * Sets the value of Field
+         * @param value the value to be set
+         * @return {@code this}
+         */
+        public Builder withField(@javax.annotation.Nullable final java.lang.String value) {
+            this._field = value;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link OptionalStruct}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        public OptionalStruct build() {
+            return new OptionalStruct() {
+                @javax.annotation.Nullable
+                private final java.lang.String $field = _field;
+
+                @Override
+                public java.lang.String getField() {
+                    return this.$field;
+                }
+
+                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                    obj.set("field", om.valueToTree(this.getField()));
+                    return obj;
+                }
+
+            };
+        }
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.OptionalStruct {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        @javax.annotation.Nullable
+        public java.lang.String getField() {
+            return this.jsiiGet("field", java.lang.String.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -1,0 +1,26 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalStructConsumer")
+public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
+    protected OptionalStructConsumer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public OptionalStructConsumer(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(optionalStruct).toArray());
+    }
+    public OptionalStructConsumer() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public java.lang.Boolean getParameterWasUndefined() {
+        return this.jsiiGet("parameterWasUndefined", java.lang.Boolean.class);
+    }
+
+    @javax.annotation.Nullable
+    public java.lang.String getFieldValue() {
+        return this.jsiiGet("fieldValue", java.lang.String.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1646,6 +1646,30 @@ class OptionalConstructorArgument(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.
         return jsii.get(self, "arg3")
 
 
+@jsii.data_type(jsii_type="jsii-calc.OptionalStruct")
+class OptionalStruct(jsii.compat.TypedDict, total=False):
+    field: str
+
+class OptionalStructConsumer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.OptionalStructConsumer"):
+    def __init__(self, *, field: typing.Optional[str]=None) -> None:
+        optional_struct: OptionalStruct = {}
+
+        if field is not None:
+            optional_struct["field"] = field
+
+        jsii.create(OptionalStructConsumer, self, [optional_struct])
+
+    @property
+    @jsii.member(jsii_name="parameterWasUndefined")
+    def parameter_was_undefined(self) -> bool:
+        return jsii.get(self, "parameterWasUndefined")
+
+    @property
+    @jsii.member(jsii_name="fieldValue")
+    def field_value(self) -> typing.Optional[str]:
+        return jsii.get(self, "fieldValue")
+
+
 class OverrideReturnsObject(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.OverrideReturnsObject"):
     def __init__(self) -> None:
         jsii.create(OverrideReturnsObject, self, [])
@@ -2383,6 +2407,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "ExtendsPrivateInterface", "GiveMeStructs", "GreetingAugmenter", "IAnotherPublicInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceImplementedByAbstractClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "OptionalConstructorArgument", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "ExtendsPrivateInterface", "GiveMeStructs", "GreetingAugmenter", "IAnotherPublicInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceImplementedByAbstractClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -4248,6 +4248,80 @@ OptionalConstructorArgument
       :type: date *(optional)* *(readonly)*
 
 
+OptionalStruct (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: OptionalStruct
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.OptionalStruct;
+
+      .. code-tab:: javascript
+
+         // OptionalStruct is an interface
+
+      .. code-tab:: typescript
+
+         import { OptionalStruct } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: field
+
+      :type: string *(optional)* *(readonly)*
+
+
+OptionalStructConsumer
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: OptionalStructConsumer([optionalStruct])
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.OptionalStructConsumer;
+
+      .. code-tab:: javascript
+
+         const { OptionalStructConsumer } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { OptionalStructConsumer } from 'jsii-calc';
+
+
+
+   :param optionalStruct: 
+   :type optionalStruct: :py:class:`~jsii-calc.OptionalStruct`\  *(optional)*
+
+   .. py:attribute:: parameterWasUndefined
+
+      :type: boolean *(readonly)*
+
+
+   .. py:attribute:: fieldValue
+
+      :type: string *(optional)* *(readonly)*
+
+
 OverrideReturnsObject
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -48,6 +48,7 @@ NumberGenerator
 ObjectRefsInCollections
 Operation
 OptionalConstructorArgument
+OptionalStructConsumer
 OverrideReturnsObject
 PartiallyInitializedThisConsumer
 Polymorphism

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -769,6 +769,19 @@ assemblies
  │   │   └─┬ arg3 property
  │   │     ├── immutable
  │   │     └── type: primitive:date (optional)
+ │   ├─┬ class OptionalStructConsumer
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>(optionalStruct) method
+ │   │   │ ├─┬ parameters
+ │   │   │ │ └─┬ optionalStruct
+ │   │   │ │   └── type: interface:jsii-calc.OptionalStruct (optional)
+ │   │   │ └── returns: void
+ │   │   ├─┬ parameterWasUndefined property
+ │   │   │ ├── immutable
+ │   │   │ └── type: primitive:boolean
+ │   │   └─┬ fieldValue property
+ │   │     ├── immutable
+ │   │     └── type: primitive:string (optional)
  │   ├─┬ class OverrideReturnsObject
  │   │ └─┬ members
  │   │   ├─┬ <initializer>() method
@@ -1404,6 +1417,12 @@ assemblies
  │   │     ├── abstract
  │   │     ├── immutable
  │   │     └── type: primitive:any (optional)
+ │   ├─┬ interface OptionalStruct
+ │   │ └─┬ members
+ │   │   └─┬ field property
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: primitive:string (optional)
  │   ├─┬ interface UnionProperties
  │   │ └─┬ members
  │   │   ├─┬ bar property

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -66,6 +66,7 @@ assemblies
  │   ├── class NumberGenerator
  │   ├── class ObjectRefsInCollections
  │   ├── class OptionalConstructorArgument
+ │   ├── class OptionalStructConsumer
  │   ├── class OverrideReturnsObject
  │   ├── class PartiallyInitializedThisConsumer
  │   ├── class Polymorphism
@@ -134,6 +135,7 @@ assemblies
  │   ├── interface Hello
  │   ├── interface LoadBalancedFargateServiceProps
  │   ├── interface NullShouldBeTreatedAsUndefinedData
+ │   ├── interface OptionalStruct
  │   ├── interface UnionProperties
  │   ├── enum AllTypesEnum
  │   ├── enum StringEnum

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -326,6 +326,11 @@ assemblies
  │   │   ├── arg1 property
  │   │   ├── arg2 property
  │   │   └── arg3 property
+ │   ├─┬ class OptionalStructConsumer
+ │   │ └─┬ members
+ │   │   ├── <initializer>(optionalStruct) method
+ │   │   ├── parameterWasUndefined property
+ │   │   └── fieldValue property
  │   ├─┬ class OverrideReturnsObject
  │   │ └─┬ members
  │   │   ├── <initializer>() method
@@ -584,6 +589,9 @@ assemblies
  │   │ └─┬ members
  │   │   ├── arrayWithThreeElementsAndUndefinedAsSecondArgument property
  │   │   └── thisShouldBeUndefined property
+ │   ├─┬ interface OptionalStruct
+ │   │ └─┬ members
+ │   │   └── field property
  │   ├─┬ interface UnionProperties
  │   │ └─┬ members
  │   │   ├── bar property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -47,6 +47,7 @@ assemblies
  │   ├── class NumberGenerator
  │   ├── class ObjectRefsInCollections
  │   ├── class OptionalConstructorArgument
+ │   ├── class OptionalStructConsumer
  │   ├── class OverrideReturnsObject
  │   ├── class PartiallyInitializedThisConsumer
  │   ├── class Polymorphism
@@ -96,6 +97,7 @@ assemblies
  │   ├── interface Hello
  │   ├── interface LoadBalancedFargateServiceProps
  │   ├── interface NullShouldBeTreatedAsUndefinedData
+ │   ├── interface OptionalStruct
  │   ├── interface UnionProperties
  │   ├── enum AllTypesEnum
  │   ├── enum StringEnum


### PR DESCRIPTION
Upon deserializing objects from a "native" front-end (Java, .NET, ...),
the kernel now interprets an empty value for a struct type (aka data
type) as `undefined`, since front-ends that perform keyword lifting such
as Python will not be able to distinguish between "no argument passed"
and "an empty argument passed".

Fixes #411

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
