### PR TITLE
Add support for JSII_RUNTIME

### DIFF
--- a/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/providers/process.py
@@ -262,8 +262,10 @@ class _NodeProcess:
         environ = os.environ.copy()
         environ["JSII_AGENT"] = f"Python/{platform.python_version()}"
 
+        jsii_runtime = environ.get('JSII_RUNTIME', self._jsii_runtime())
+
         self._process = subprocess.Popen(
-            ["node", self._jsii_runtime()],
+            ["node", jsii_runtime],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             env=environ,


### PR DESCRIPTION
Fixes #245 for Python.

This assumes that the `JSII_RUNTIME` will point to the actual `.js` file and that the `js-runtime.js.map` and `mappings.wasm` will be in the same directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
