### PR TITLE
fix: exit with non-zero exit code if there are compilation errors

### DIFF
--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -43,7 +43,7 @@ import { VERSION } from '../lib/version';
     for (const diagnostic of emitResult.diagnostics) {
         utils.logDiagnostic(diagnostic, projectRoot);
     }
-    if (emitResult.emitSkipped) {
+    if (emitResult.hasErrors) {
         process.exit(1);
     }
 }).catch(e => {

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -149,12 +149,12 @@ export class Compiler implements Emitter {
         // jsii warnings will appear.
         const assembler = new Assembler(this.options.projectInfo, program, stdlib);
         const assmEmit = await assembler.emit();
-        if (assmEmit.emitSkipped) {
+        if (assmEmit.hasErrors) {
             LOG.error('Type model errors prevented the JSII assembly from being created');
         }
 
         return {
-            emitSkipped: assmEmit.emitSkipped,
+            hasErrors: emit.emitSkipped || assmEmit.hasErrors,
             diagnostics: [...emit.diagnostics, ...assmEmit.diagnostics]
         };
     }

--- a/packages/jsii/lib/emitter.ts
+++ b/packages/jsii/lib/emitter.ts
@@ -17,7 +17,7 @@ export interface Emitter {
  */
 export interface EmitResult {
     /** Whether the emit was skipped as a result of errors (found in ``diagnostics``) */
-    emitSkipped: boolean;
+    hasErrors: boolean;
 
     /** Diagnostic information created when trying to emit stuff */
     diagnostics: ReadonlyArray<ts.Diagnostic | Diagnostic>;

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -26,7 +26,7 @@ export class Validator implements Emitter {
         try {
             return {
                 diagnostics: this._diagnostics,
-                emitSkipped: this._diagnostics.find(diag => diag.category === ts.DiagnosticCategory.Error) != null
+                hasErrors: this._diagnostics.find(diag => diag.category === ts.DiagnosticCategory.Error) != null
             };
         } finally {
             // Clearing ``this._diagnostics`` to allow contents to be garbage-collected.

--- a/packages/jsii/test/negatives/neg.compilation-error.ts
+++ b/packages/jsii/test/negatives/neg.compilation-error.ts
@@ -1,0 +1,4 @@
+///!MATCH_ERROR: Cannot find name 'boom'.
+///!MATCH_ERROR: Cannot find name 'CompilerErrorIsHere'.
+
+boom! >CompilerErrorIsHere

--- a/packages/jsii/test/test.negatives.ts
+++ b/packages/jsii/test/test.negatives.ts
@@ -17,7 +17,7 @@ for (const source of fs.readdirSync(SOURCE_DIR)) {
         test.ok(expectations.length > 0, `Expected error messages should be specified using ${MATCH_ERROR_MARKER}`);
         const compiler = new Compiler({ projectInfo: _makeProjectInfo(source), watch: false });
         const emitResult = await compiler.emit(path.join(SOURCE_DIR, source));
-        test.equal(emitResult.emitSkipped, true, `emitSkipped should be true`);
+        test.equal(emitResult.hasErrors, true, `hasErrors should be true`);
         const errors = emitResult.diagnostics.filter(diag => diag.category === ts.DiagnosticCategory.Error);
         for (const expectation of expectations) {
             test.notEqual(errors.find(e => _messageText(e).indexOf(expectation) !== -1),


### PR DESCRIPTION
In #383 we modified the compiler to continue jsii validation despite
compilation errors but did not propagate the fact that there were
compilation errors.

This resulted in "jsii" exiting with a 0 exit code even in case
of errors.

Fixes #441

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
