### PR TITLE
fix(java): Stop using Streams to render params

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -987,17 +987,9 @@ class JavaGenerator extends Generator {
 
     private renderMethodCallArguments(method: spec.Method) {
         if (!method.parameters || method.parameters.length === 0) { return ''; }
-        let paramStream: string = '';
-        for (const param of method.parameters) {
-            const paramValue = isNullable(param) ? param.name : `java.util.Objects.requireNonNull(${param.name}, "${param.name} is required")`;
-            const thisParam = `${param.variadic ? 'java.util.Arrays.stream' : 'java.util.stream.Stream.of'}(${paramValue})`;
-            if (paramStream === '') {
-                paramStream = thisParam;
-            } else {
-                paramStream = `java.util.stream.Stream.concat(${paramStream}, ${thisParam})`;
-            }
-        }
-        return `, ${paramStream}.toArray()`;
+        const values = method.parameters.map(param =>
+            isNullable(param) ? param.name : `java.util.Objects.requireNonNull(${param.name}, "${param.name} is required")`);
+        return `, new Object[] { ${values.join(', ')} }`;
     }
 
     private renderMethodCall(cls: spec.TypeReference, method: spec.Method, async: boolean) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -16,7 +16,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
      */
     public Number(final java.lang.Number value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -42,7 +42,7 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
 
         @Override
         public java.lang.String abstractMethod(final java.lang.String name) {
-            return this.jsiiCall("abstractMethod", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(name, "name is required")).toArray());
+            return this.jsiiCall("abstractMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -17,7 +17,7 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      */
     public Add(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(lhs, "lhs is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(rhs, "rhs is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -18,7 +18,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
     }
 
     public void anyIn(@javax.annotation.Nullable final java.lang.Object inp) {
-        this.jsiiCall("anyIn", Void.class, java.util.stream.Stream.of(inp).toArray());
+        this.jsiiCall("anyIn", Void.class, new Object[] { inp });
     }
 
     @javax.annotation.Nullable
@@ -27,7 +27,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
     }
 
     public software.amazon.jsii.tests.calculator.StringEnum enumMethod(final software.amazon.jsii.tests.calculator.StringEnum value) {
-        return this.jsiiCall("enumMethod", software.amazon.jsii.tests.calculator.StringEnum.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        return this.jsiiCall("enumMethod", software.amazon.jsii.tests.calculator.StringEnum.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     public java.lang.Number getEnumPropertyValue() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -12,24 +12,24 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
     }
 
     public void getBar(final java.lang.String _p1, final java.lang.Number _p2) {
-        this.jsiiCall("getBar", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_p1, "_p1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_p2, "_p2 is required"))).toArray());
+        this.jsiiCall("getBar", Void.class, new Object[] { java.util.Objects.requireNonNull(_p1, "_p1 is required"), java.util.Objects.requireNonNull(_p2, "_p2 is required") });
     }
 
     /**
      * getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
      */
     public java.lang.String getFoo(final java.lang.String withParam) {
-        return this.jsiiCall("getFoo", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(withParam, "withParam is required")).toArray());
+        return this.jsiiCall("getFoo", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(withParam, "withParam is required") });
     }
 
     public void setBar(final java.lang.String _x, final java.lang.Number _y, final java.lang.Boolean _z) {
-        this.jsiiCall("setBar", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_x, "_x is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_y, "_y is required"))), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_z, "_z is required"))).toArray());
+        this.jsiiCall("setBar", Void.class, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required"), java.util.Objects.requireNonNull(_z, "_z is required") });
     }
 
     /**
      * setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
      */
     public void setFoo(final java.lang.String _x, final java.lang.Number _y) {
-        this.jsiiCall("setFoo", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_x, "_x is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(_y, "_y is required"))).toArray());
+        this.jsiiCall("setFoo", Void.class, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -38,7 +38,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.Number overrideMe(final java.lang.Number mult) {
-        return this.jsiiAsyncCall("overrideMe", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(mult, "mult is required")).toArray());
+        return this.jsiiAsyncCall("overrideMe", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(mult, "mult is required") });
     }
 
     public java.lang.Number overrideMeToo() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -17,7 +17,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      */
     public BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(lhs, "lhs is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(rhs, "rhs is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -16,7 +16,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      */
     public Calculator(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.CalculatorProps props) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(props).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props });
     }
     /**
      * Creates a Calculator object.
@@ -30,14 +30,14 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * Adds a number to the current value.
      */
     public void add(final java.lang.Number value) {
-        this.jsiiCall("add", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("add", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
      * Multiplies the current value by a number.
      */
     public void mul(final java.lang.Number value) {
-        this.jsiiCall("mul", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("mul", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
@@ -51,7 +51,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * Raises the current value by a power.
      */
     public void pow(final java.lang.Number value) {
-        this.jsiiCall("pow", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("pow", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
@@ -11,7 +11,7 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
     }
 
     public static software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties create(final java.lang.String readOnlyString, final java.lang.String readWriteString) {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, "create", software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(readOnlyString, "readOnlyString is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(readWriteString, "readWriteString is required"))).toArray());
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, "create", software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, new Object[] { java.util.Objects.requireNonNull(readOnlyString, "readOnlyString is required"), java.util.Objects.requireNonNull(readWriteString, "readWriteString is required") });
     }
 
     @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -8,6 +8,6 @@ public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
     }
     public ConstructorPassesThisOut(final software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(consumer, "consumer is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(consumer, "consumer is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -12,11 +12,11 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
     }
 
     public java.lang.String consumeAnotherPublicInterface(final software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
-        return this.jsiiCall("consumeAnotherPublicInterface", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+        return this.jsiiCall("consumeAnotherPublicInterface", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 
     @javax.annotation.Nullable
     public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
-        return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+        return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -8,15 +8,15 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
     }
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)), java.util.stream.Stream.of(arg3)).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 });
     }
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 });
     }
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(arg1).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 });
     }
     public DefaultedConstructorArgument() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -12,7 +12,7 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
     }
 
     public void changePrivatePropertyValue(final java.lang.String newValue) {
-        this.jsiiCall("changePrivatePropertyValue", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(newValue, "newValue is required")).toArray());
+        this.jsiiCall("changePrivatePropertyValue", Void.class, new Object[] { java.util.Objects.requireNonNull(newValue, "newValue is required") });
     }
 
     public java.lang.String privateMethodValue() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -15,14 +15,14 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
     }
 
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny, @javax.annotation.Nullable final java.lang.String _optionalString) {
-        this.jsiiCall("method", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(_requiredAny), java.util.stream.Stream.of(_optionalAny)), java.util.stream.Stream.of(_optionalString)).toArray());
+        this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny, _optionalString });
     }
 
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny) {
-        this.jsiiCall("method", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(_requiredAny), java.util.stream.Stream.of(_optionalAny)).toArray());
+        this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny });
     }
 
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny) {
-        this.jsiiCall("method", Void.class, java.util.stream.Stream.of(_requiredAny).toArray());
+        this.jsiiCall("method", Void.class, new Object[] { _requiredAny });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
@@ -29,7 +29,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * @param greetee The person to be greeted.
      */
     public java.lang.Number greet(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Greetee greetee) {
-        return this.jsiiCall("greet", java.lang.Number.class, java.util.stream.Stream.of(greetee).toArray());
+        return this.jsiiCall("greet", java.lang.Number.class, new Object[] { greetee });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -12,6 +12,6 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
     }
 
     public java.lang.String optionalAndVariadic(@javax.annotation.Nullable final java.lang.String optional, final java.lang.String... things) {
-        return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(optional), java.util.Arrays.stream(java.util.Objects.requireNonNull(things, "things is required"))).toArray());
+        return this.jsiiCall("optionalAndVariadic", java.lang.String.class, new Object[] { optional, java.util.Objects.requireNonNull(things, "things is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -18,7 +18,7 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * are being erased when sending values from native code to JS.
      */
     public static java.lang.Boolean doesKeyExist(final software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions opts, final java.lang.String key) {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "doesKeyExist", java.lang.Boolean.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(opts, "opts is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(key, "key is required"))).toArray());
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "doesKeyExist", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(opts, "opts is required"), java.util.Objects.requireNonNull(key, "key is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -8,7 +8,7 @@ public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
     }
     public ExportedBaseClass(final java.lang.Boolean success) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(success, "success is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(success, "success is required") });
     }
 
     public java.lang.Boolean getSuccess() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -15,21 +15,21 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
      */
     public software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
-        return this.jsiiCall("derivedToFirst", software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(derived, "derived is required")).toArray());
+        return this.jsiiCall("derivedToFirst", software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
     /**
      * Returns the boolean from a DerivedStruct struct.
      */
     public software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
-        return this.jsiiCall("readDerivedNonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(derived, "derived is required")).toArray());
+        return this.jsiiCall("readDerivedNonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
     /**
      * Returns the "anumber" from a MyFirstStruct struct;
      */
     public java.lang.Number readFirstNumber(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {
-        return this.jsiiCall("readFirstNumber", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(first, "first is required")).toArray());
+        return this.jsiiCall("readFirstNumber", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(first, "first is required") });
     }
 
     public software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals getStructLiteral() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -12,6 +12,6 @@ public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.String betterGreeting(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
-        return this.jsiiCall("betterGreeting", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(friendly, "friendly is required")).toArray());
+        return this.jsiiCall("betterGreeting", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -18,12 +18,12 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
 
         @Override
         public void hello(final java.lang.String arg1, @javax.annotation.Nullable final java.lang.Number arg2) {
-            this.jsiiCall("hello", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(arg2)).toArray());
+            this.jsiiCall("hello", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), arg2 });
         }
 
         @Override
         public void hello(final java.lang.String arg1) {
-            this.jsiiCall("hello", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")).toArray());
+            this.jsiiCall("hello", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required") });
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -8,7 +8,7 @@ public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII41
     }
     public JSII417Derived(final java.lang.String property) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(property, "property is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(property, "property is required") });
     }
 
     public void bar() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -17,7 +17,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     public Multiply(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(lhs, "lhs is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(rhs, "rhs is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -11,7 +11,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
     }
     public Negate(final software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(operand, "operand is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -11,15 +11,15 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
     }
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, @javax.annotation.Nullable final java.lang.Object optional) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(_param1, "_param1 is required")), java.util.stream.Stream.of(optional)).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional });
     }
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(_param1, "_param1 is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required") });
     }
 
     public void giveMeUndefined(@javax.annotation.Nullable final java.lang.Object value) {
-        this.jsiiCall("giveMeUndefined", Void.class, java.util.stream.Stream.of(value).toArray());
+        this.jsiiCall("giveMeUndefined", Void.class, new Object[] { value });
     }
 
     public void giveMeUndefined() {
@@ -27,7 +27,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
     }
 
     public void giveMeUndefinedInsideAnObject(final software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData input) {
-        this.jsiiCall("giveMeUndefinedInsideAnObject", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(input, "input is required")).toArray());
+        this.jsiiCall("giveMeUndefinedInsideAnObject", Void.class, new Object[] { java.util.Objects.requireNonNull(input, "input is required") });
     }
 
     public void verifyPropertyIsUndefined() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -11,11 +11,11 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
     }
     public NumberGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(generator, "generator is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(generator, "generator is required") });
     }
 
     public java.lang.Boolean isSameGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {
-        return this.jsiiCall("isSameGenerator", java.lang.Boolean.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(gen, "gen is required")).toArray());
+        return this.jsiiCall("isSameGenerator", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(gen, "gen is required") });
     }
 
     public java.lang.Number nextTimes100() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -18,13 +18,13 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
      * Returns the sum of all values.
      */
     public java.lang.Number sumFromArray(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
-        return this.jsiiCall("sumFromArray", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(values, "values is required")).toArray());
+        return this.jsiiCall("sumFromArray", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }
 
     /**
      * Returns the sum of all values in a map.
      */
     public java.lang.Number sumFromMap(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> values) {
-        return this.jsiiCall("sumFromMap", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(values, "values is required")).toArray());
+        return this.jsiiCall("sumFromMap", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -8,11 +8,11 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
     }
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }
 
     public java.lang.Number getArg1() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -8,7 +8,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
     }
     public OptionalStructConsumer(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(optionalStruct).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct });
     }
     public OptionalStructConsumer() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -12,6 +12,6 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.Number test(final software.amazon.jsii.tests.calculator.IReturnsNumber obj) {
-        return this.jsiiCall("test", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+        return this.jsiiCall("test", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -23,7 +23,7 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
 
         @Override
         public java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev) {
-            return this.jsiiCall("consumePartiallyInitializedThis", java.lang.String.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(dt, "dt is required"))), java.util.stream.Stream.of(java.util.Objects.requireNonNull(ev, "ev is required"))).toArray());
+            return this.jsiiCall("consumePartiallyInitializedThis", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required"), java.util.Objects.requireNonNull(dt, "dt is required"), java.util.Objects.requireNonNull(ev, "ev is required") });
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -12,6 +12,6 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.String sayHello(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
-        return this.jsiiCall("sayHello", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(friendly, "friendly is required")).toArray());
+        return this.jsiiCall("sayHello", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -17,7 +17,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      */
     public Power(final software.amazon.jsii.tests.calculator.lib.Value base, final software.amazon.jsii.tests.calculator.lib.Value pow) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(base, "base is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(pow, "pow is required"))).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(base, "base is required"), java.util.Objects.requireNonNull(pow, "pow is required") });
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -20,7 +20,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
     }
 
     public void saveFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
-        this.jsiiCall("saveFoo", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("saveFoo", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     @javax.annotation.Nullable

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -12,15 +12,15 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
     }
 
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
-        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)), java.util.stream.Stream.of(arg3)).toArray());
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2, arg3 });
     }
 
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
-        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(arg1), java.util.stream.Stream.of(arg2)).toArray());
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2 });
     }
 
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1) {
-        this.jsiiCall("methodWithDefaultedArguments", Void.class, java.util.stream.Stream.of(arg1).toArray());
+        this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1 });
     }
 
     public void methodWithDefaultedArguments() {
@@ -28,7 +28,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
     }
 
     public void methodWithOptionalAnyArgument(@javax.annotation.Nullable final java.lang.Object arg) {
-        this.jsiiCall("methodWithOptionalAnyArgument", Void.class, java.util.stream.Stream.of(arg).toArray());
+        this.jsiiCall("methodWithOptionalAnyArgument", Void.class, new Object[] { arg });
     }
 
     public void methodWithOptionalAnyArgument() {
@@ -39,13 +39,13 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * Used to verify verification of number of method arguments.
      */
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
-        this.jsiiCall("methodWithOptionalArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))), java.util.stream.Stream.of(arg3)).toArray());
+        this.jsiiCall("methodWithOptionalArguments", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
 
     /**
      * Used to verify verification of number of method arguments.
      */
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2) {
-        this.jsiiCall("methodWithOptionalArguments", Void.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg1, "arg1 is required")), java.util.stream.Stream.of(java.util.Objects.requireNonNull(arg2, "arg2 is required"))).toArray());
+        this.jsiiCall("methodWithOptionalArguments", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -14,7 +14,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     }
     public Statics(final java.lang.String value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
@@ -23,7 +23,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * @param name The name of the person to say hello to.
      */
     public static java.lang.String staticMethod(final java.lang.String name) {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Statics.class, "staticMethod", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(name, "name is required")).toArray());
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Statics.class, "staticMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });
     }
 
     public java.lang.String justMethod() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -20,11 +20,11 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     }
 
     public void modifyOtherProperty(final java.lang.String value) {
-        this.jsiiCall("modifyOtherProperty", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("modifyOtherProperty", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     public void modifyValueOfTheProperty(final java.lang.String value) {
-        this.jsiiCall("modifyValueOfTheProperty", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("modifyValueOfTheProperty", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     public java.lang.Number readA() {
@@ -44,11 +44,11 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.Number virtualMethod(final java.lang.Number n) {
-        return this.jsiiCall("virtualMethod", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(n, "n is required")).toArray());
+        return this.jsiiCall("virtualMethod", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(n, "n is required") });
     }
 
     public void writeA(final java.lang.Number value) {
-        this.jsiiCall("writeA", Void.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        this.jsiiCall("writeA", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     public java.lang.String getReadonlyProperty() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -11,7 +11,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
     }
     public UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(operand, "operand is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
     }
 
     public software.amazon.jsii.tests.calculator.lib.Value getOperand() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -8,7 +8,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
     }
     public UsesInterfaceWithProperties(final software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.of(java.util.Objects.requireNonNull(obj, "obj is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 
     public java.lang.String justRead() {
@@ -16,11 +16,11 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
     }
 
     public java.lang.String readStringAndNumber(final software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
-        return this.jsiiCall("readStringAndNumber", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(ext, "ext is required")).toArray());
+        return this.jsiiCall("readStringAndNumber", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(ext, "ext is required") });
     }
 
     public java.lang.String writeAndRead(final java.lang.String value) {
-        return this.jsiiCall("writeAndRead", java.lang.String.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(value, "value is required")).toArray());
+        return this.jsiiCall("writeAndRead", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     public software.amazon.jsii.tests.calculator.IInterfaceWithProperties getObj() {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -11,7 +11,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      */
     public VariadicMethod(final java.lang.Number... prefix) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.stream(java.util.Objects.requireNonNull(prefix, "prefix is required")).toArray());
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(prefix, "prefix is required") });
     }
 
     /**
@@ -19,6 +19,6 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      * @param others other elements to be included in the array.
      */
     public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {
-        return this.jsiiCall("asArray", java.util.List.class, java.util.stream.Stream.concat(java.util.stream.Stream.of(java.util.Objects.requireNonNull(first, "first is required")), java.util.Arrays.stream(java.util.Objects.requireNonNull(others, "others is required"))).toArray());
+        return this.jsiiCall("asArray", java.util.List.class, new Object[] { java.util.Objects.requireNonNull(first, "first is required"), java.util.Objects.requireNonNull(others, "others is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -12,22 +12,22 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
     }
 
     public java.lang.Number overrideMeAsync(final java.lang.Number index) {
-        return this.jsiiAsyncCall("overrideMeAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(index, "index is required")).toArray());
+        return this.jsiiAsyncCall("overrideMeAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
     public java.lang.Number overrideMeSync(final java.lang.Number index) {
-        return this.jsiiCall("overrideMeSync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(index, "index is required")).toArray());
+        return this.jsiiCall("overrideMeSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
     public java.lang.Number parallelSumAsync(final java.lang.Number count) {
-        return this.jsiiAsyncCall("parallelSumAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
+        return this.jsiiAsyncCall("parallelSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
     public java.lang.Number serialSumAsync(final java.lang.Number count) {
-        return this.jsiiAsyncCall("serialSumAsync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
+        return this.jsiiAsyncCall("serialSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
     public java.lang.Number sumSync(final java.lang.Number count) {
-        return this.jsiiCall("sumSync", java.lang.Number.class, java.util.stream.Stream.of(java.util.Objects.requireNonNull(count, "count is required")).toArray());
+        return this.jsiiCall("sumSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 }


### PR DESCRIPTION
The Java cod generated by `jsii-pacmak` used to use `Stream`
concatenations to render parameters into an `Object` array when passing
to the low-level `jsii` engine. In the majority of cases this worked
fine, however in cases where the last argument was an `enum`, this
caused `javac` type inferrence to impose bounds on the `Stream`'s item
type that could not be met by non-`enum` types.

Additionally, as this code demonstrates, the `Stream`-based code was
unnecessarily complicated as it is possible to initialize an array
literal in place, by using less code, which also reads simpler, and
incurs less memory churn. It's a win all over the board 🎉

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
