### PR TITLE
fix(jsii-reflect): don't load same assembly multiple times

### DIFF
--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -91,7 +91,7 @@ async function loadFromFilesystem(name: string) {
   if (stat.isDirectory()) {
     return await ts.loadModule(name);
   } else {
-    return await ts.loadFile(name, true);
+    return await ts.loadFile(name);
   }
 }
 

--- a/packages/jsii-pacmak/lib/timer.ts
+++ b/packages/jsii-pacmak/lib/timer.ts
@@ -1,0 +1,82 @@
+/**
+ * A single timer
+ */
+export class Timer {
+  public timeMs?: number;
+  private startTime: number;
+
+  constructor(public readonly label: string) {
+    this.startTime = Date.now();
+  }
+
+  public start() {
+    this.startTime = Date.now();
+  }
+
+  public end() {
+    this.timeMs = (Date.now() - this.startTime) / 1000;
+  }
+
+  public isSet() {
+    return this.timeMs !== undefined;
+  }
+
+  public humanTime() {
+    if (!this.timeMs) { return '???'; }
+
+    const parts = [];
+
+    let time = this.timeMs;
+    if (time > 60) {
+      const mins = Math.floor(time / 60);
+      parts.push(mins + 'm');
+      time -= mins * 60;
+    }
+    parts.push(time.toFixed(1) + 's');
+
+    return parts.join('');
+  }
+}
+
+/**
+ * A collection of Timers
+ */
+export class Timers {
+  private readonly timers: Timer[] = [];
+
+  public record<T>(label: string, operation: () => T): T {
+    const timer = this.start(label);
+    try {
+      const x = operation();
+      timer.end();
+      return x;
+    } catch (e) {
+      timer.end();
+      throw e;
+    }
+  }
+
+  public async recordAsync<T>(label: string, operation: () => Promise<T>) {
+    const timer = this.start(label);
+    try {
+      const x = await operation();
+      timer.end();
+      return x;
+    } catch (e) {
+      timer.end();
+      throw e;
+    }
+  }
+
+  public start(label: string) {
+    const timer = new Timer(label);
+    this.timers.push(timer);
+    return timer;
+  }
+
+  public display(): string {
+    const timers = this.timers.filter(t => t.isSet());
+    timers.sort((a: Timer, b: Timer) => b.timeMs! - a.timeMs!);
+    return timers.map(t => `${t.label} (${t.humanTime()})`).join(' | ');
+  }
+}

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -17,7 +17,8 @@ export function resolveDependencyDirectory(packageDir: string, dependencyName: s
 
 export function shell(cmd: string, args: string[], options: SpawnOptions): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-        const child = spawn(cmd, args, { ...options, shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
+        logging.debug(cmd, args.join(' '), JSON.stringify(options));
+        const child = spawn(cmd, args, { ...options, shell: true, env: { ...process.env, ...options.env || {} }, stdio: ['ignore', 'pipe', 'pipe'] });
         const stdout = new Array<Buffer>();
         const stderr = new Array<Buffer>();
         child.stdout.on('data', chunk => {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
@@ -103,6 +103,8 @@
         <configuration>
           <failOnError>false</failOnError>
           <show>protected</show>
+          <additionalJOption>-J-XX:+TieredCompilation&lt;/additionalJOption</additionalJOption>
+          <additionalJOption>-J-XX:TieredStopAtLevel=1&lt;/additionalJOption</additionalJOption>
         </configuration>
       </plugin>
     </plugins>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
@@ -103,6 +103,8 @@
         <configuration>
           <failOnError>false</failOnError>
           <show>protected</show>
+          <additionalJOption>-J-XX:+TieredCompilation&lt;/additionalJOption</additionalJOption>
+          <additionalJOption>-J-XX:TieredStopAtLevel=1&lt;/additionalJOption</additionalJOption>
         </configuration>
       </plugin>
     </plugins>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
@@ -134,6 +134,8 @@
         <configuration>
           <failOnError>false</failOnError>
           <show>protected</show>
+          <additionalJOption>-J-XX:+TieredCompilation&lt;/additionalJOption</additionalJOption>
+          <additionalJOption>-J-XX:TieredStopAtLevel=1&lt;/additionalJOption</additionalJOption>
         </configuration>
       </plugin>
     </plugins>

--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -154,6 +154,16 @@ export class Assembly {
     return this._types[fqn];
   }
 
+  /**
+   * Validate an assembly after loading
+   *
+   * If the assembly was loaded without validation, call this to validate
+   * it after all. Throws an exception if validation fails.
+   */
+  public validate() {
+    jsii.validateAssembly(this.spec);
+  }
+
   private get _dependencies() {
     if (!this._dependencyCache) {
       this._dependencyCache = { };

--- a/packages/jsii-reflect/lib/index.ts
+++ b/packages/jsii-reflect/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './assembly';
 export * from './class';
+export * from './callable';
 export * from './dependency';
 export * from './docs';
 export * from './enum';

--- a/packages/jsii-reflect/lib/initializer.ts
+++ b/packages/jsii-reflect/lib/initializer.ts
@@ -5,6 +5,10 @@ import { SourceLocatable } from './source';
 import { MemberKind, TypeMember } from './type-member';
 
 export class Initializer extends Callable implements Documentable, Overridable, TypeMember, SourceLocatable {
+  public static isInitializer(x: Callable): x is Initializer {
+    return x instanceof Initializer;
+  }
+
   public readonly kind = MemberKind.Initializer;
   public readonly name = '<initializer>';
   public readonly abstract = false;

--- a/packages/jsii-reflect/lib/method.ts
+++ b/packages/jsii-reflect/lib/method.ts
@@ -15,6 +15,10 @@ import { TypeSystem } from './type-system';
 export const INITIALIZER_NAME = '<initializer>';
 
 export class Method extends Callable implements Documentable, Overridable, TypeMember, SourceLocatable {
+  public static isMethod(x: Callable): x is Method {
+    return x instanceof Method;
+  }
+
   public readonly kind = MemberKind.Method;
 
   constructor(


### PR DESCRIPTION
deCDK tests were calling `loadModule()` for every package.
`loadModule()` did have some recursion avoidance INSIDE one call,
but not across multiple load calls on the same type system.

This brings down the deCDK tests from 80s to 10s.

Add an option to disable validation, which would bring the full CDK
typesystem loading down from 10s to 600ms (validation is enabled
by default).

Some more type exposure updates so that we can update awslint
and friends in the CDK repository to take advantage of the new
jsii model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
