### PR TITLE
fix(java): Correctly pass variadic arguments

### DIFF
--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -50,6 +50,7 @@ import software.amazon.jsii.tests.calculator.Sum;
 import software.amazon.jsii.tests.calculator.SyncVirtualMethods;
 import software.amazon.jsii.tests.calculator.UnionProperties;
 import software.amazon.jsii.tests.calculator.UsesInterfaceWithProperties;
+import software.amazon.jsii.tests.calculator.VariadicMethod;
 import software.amazon.jsii.tests.calculator.composition.CompositeOperation;
 import software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule;
 import software.amazon.jsii.tests.calculator.lib.IFriendly;
@@ -1027,6 +1028,13 @@ public class ComplianceTest {
         final ConstructorPassesThisOut object = new ConstructorPassesThisOut(reflector);
 
         assertTrue(object != null);
+    }
+
+    @Test
+    public void variadicMethodCanBeInvoked() {
+        final VariadicMethod variadicMethod = new VariadicMethod(1);
+        final List<java.lang.Number> result = variadicMethod.asArray(3, 4, 5, 6);
+        assertEquals(Arrays.asList(1, 3, 4, 5, 6), result);
     }
 
     static class PartiallyInitializedThisConsumerImpl extends PartiallyInitializedThisConsumer {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -12,6 +12,6 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
     }
 
     public java.lang.String optionalAndVariadic(@javax.annotation.Nullable final java.lang.String optional, final java.lang.String... things) {
-        return this.jsiiCall("optionalAndVariadic", java.lang.String.class, new Object[] { optional, java.util.Objects.requireNonNull(things, "things is required") });
+        return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { optional }), java.util.Arrays.<Object>stream(things)).toArray(Object[]::new));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -11,7 +11,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      */
     public VariadicMethod(final java.lang.Number... prefix) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(prefix, "prefix is required") });
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(prefix).toArray(Object[]::new));
     }
 
     /**
@@ -19,6 +19,6 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      * @param others other elements to be included in the array.
      */
     public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {
-        return this.jsiiCall("asArray", java.util.List.class, new Object[] { java.util.Objects.requireNonNull(first, "first is required"), java.util.Objects.requireNonNull(others, "others is required") });
+        return this.jsiiCall("asArray", java.util.List.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(first, "first is required") }), java.util.Arrays.<Object>stream(others)).toArray(Object[]::new));
     }
 }


### PR DESCRIPTION
The previous iteration was incorrectly forwarding variadic methods'
"rest" argument to the JSII runtime, causing a runtime failure at the
deserialization site.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
