### PR TITLE
fix(dotnet): Correctly generate "optional" markers

### DIFF
--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/MethodExtensionsTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/MethodExtensionsTests.cs
@@ -136,6 +136,38 @@ namespace Amazon.JSII.Generator.UnitTests
 
                 Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
             }
+
+            [Fact(DisplayName = _Prefix + nameof(PreservesOptionality))]
+            public void PreservesOptionality()
+            {
+                Method method = new Method
+                (
+                    isProtected: false,
+                    isAbstract: false,
+                    name: "myMethod",
+                    parameters: new[]
+                    {
+                        new Parameter
+                        (
+                            name: "myParam1",
+                            type: new TypeReference("myParamTypeFqn1")
+                        ),
+                        new Parameter
+                        (
+                            name: "myParam2",
+                            type: new TypeReference("myParamTypeFqn2"),
+                            isOptional: true
+                        )
+                    }
+                );
+
+                SyntaxToken token = method.GetParametersJsonSyntaxToken();
+
+                string actual = token.ToString();
+                string expected = @"""[{\""name\"":\""myParam1\"",\""type\"":{\""fqn\"":\""myParamTypeFqn1\""}},{\""name\"":\""myParam2\"",\""type\"":{\""fqn\"":\""myParamTypeFqn2\""},\""optional\"":true}]""";
+
+                Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+            }
         }
     }
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/CallableExtensions.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/CallableExtensions.cs
@@ -51,7 +51,7 @@ namespace Amazon.JSII.Generator
         {
             // Strip docs before serializing.
             Parameter[] parameters = (callable?.Parameters ?? Enumerable.Empty<Parameter>())
-                .Select(p => new Parameter(p.Name, p.Type))
+                .Select(p => new Parameter(name: p.Name, type: p.Type, isOptional: p.IsOptional, isVariadic: p.IsVariadic))
                 .ToArray();
 
             return SF.Literal(JsonConvert.SerializeObject(parameters, SerializerSettings));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A calculator which maintains a current value and allows adding operations.</summary>
-    [JsiiClass(nativeType: typeof(Calculator), fullyQualifiedName: "jsii-calc.Calculator", parametersJson: "[{\"name\":\"props\",\"type\":{\"fqn\":\"jsii-calc.CalculatorProps\"}}]")]
+    [JsiiClass(nativeType: typeof(Calculator), fullyQualifiedName: "jsii-calc.Calculator", parametersJson: "[{\"name\":\"props\",\"type\":{\"fqn\":\"jsii-calc.CalculatorProps\"},\"optional\":true}]")]
     public class Calculator : CompositeOperation_
     {
         public Calculator(ICalculatorProps props): base(new DeputyProps(new object[]{props}))

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiClass(nativeType: typeof(DefaultedConstructorArgument), fullyQualifiedName: "jsii-calc.DefaultedConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"}}]")]
+    [JsiiClass(nativeType: typeof(DefaultedConstructorArgument), fullyQualifiedName: "jsii-calc.DefaultedConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"},\"optional\":true},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
     public class DefaultedConstructorArgument : DeputyBase
     {
         public DefaultedConstructorArgument(double? arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotRecognizeAnyAsOptional.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotRecognizeAnyAsOptional.cs
@@ -18,7 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod(name: "method", parametersJson: "[{\"name\":\"_requiredAny\",\"type\":{\"primitive\":\"any\"}},{\"name\":\"_optionalAny\",\"type\":{\"primitive\":\"any\"}},{\"name\":\"_optionalString\",\"type\":{\"primitive\":\"string\"}}]")]
+        [JsiiMethod(name: "method", parametersJson: "[{\"name\":\"_requiredAny\",\"type\":{\"primitive\":\"any\"}},{\"name\":\"_optionalAny\",\"type\":{\"primitive\":\"any\"},\"optional\":true},{\"name\":\"_optionalString\",\"type\":{\"primitive\":\"string\"},\"optional\":true}]")]
         public virtual void Method(object _requiredAny, object _optionalAny, string _optionalString)
         {
             InvokeInstanceVoidMethod(new object[]{_requiredAny, _optionalAny, _optionalString});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
@@ -32,7 +32,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// This will print out a friendly greeting intended for
         /// the indicated person.
         /// </remarks>
-        [JsiiMethod(name: "greet", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"greetee\",\"type\":{\"fqn\":\"jsii-calc.Greetee\"}}]")]
+        [JsiiMethod(name: "greet", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"greetee\",\"type\":{\"fqn\":\"jsii-calc.Greetee\"},\"optional\":true}]")]
         public virtual double Greet(IGreetee greetee)
         {
             return InvokeInstanceMethod<double>(new object[]{greetee});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
@@ -17,7 +17,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod(name: "optionalAndVariadic", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"optional\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"things\",\"type\":{\"primitive\":\"string\"}}]")]
+        [JsiiMethod(name: "optionalAndVariadic", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"optional\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"things\",\"variadic\":true,\"type\":{\"primitive\":\"string\"}}]")]
         public virtual string OptionalAndVariadic(string optional, string things)
         {
             return InvokeInstanceMethod<string>(new object[]{optional, things});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithOptionalMethodArguments.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithOptionalMethodArguments.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiInterface(nativeType: typeof(IIInterfaceWithOptionalMethodArguments), fullyQualifiedName: "jsii-calc.IInterfaceWithOptionalMethodArguments")]
     public interface IIInterfaceWithOptionalMethodArguments
     {
-        [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"}}]")]
+        [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"},\"optional\":true}]")]
         void Hello(string arg1, double? arg2);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"}}]")]
+        [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"},\"optional\":true}]")]
         public void Hello(string arg1, double? arg2)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
@@ -3,7 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#282, aws-cdk#157: null should be treated as "undefined".</summary>
-    [JsiiClass(nativeType: typeof(NullShouldBeTreatedAsUndefined), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefined", parametersJson: "[{\"name\":\"_param1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"optional\",\"type\":{\"primitive\":\"any\"}}]")]
+    [JsiiClass(nativeType: typeof(NullShouldBeTreatedAsUndefined), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefined", parametersJson: "[{\"name\":\"_param1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"optional\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
     public class NullShouldBeTreatedAsUndefined : DeputyBase
     {
         public NullShouldBeTreatedAsUndefined(string _param1, object optional): base(new DeputyProps(new object[]{_param1, optional}))
@@ -25,7 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
-        [JsiiMethod(name: "giveMeUndefined", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"any\"}}]")]
+        [JsiiMethod(name: "giveMeUndefined", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
         public virtual void GiveMeUndefined(object value)
         {
             InvokeInstanceVoidMethod(new object[]{value});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiClass(nativeType: typeof(OptionalConstructorArgument), fullyQualifiedName: "jsii-calc.OptionalConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"}}]")]
+    [JsiiClass(nativeType: typeof(OptionalConstructorArgument), fullyQualifiedName: "jsii-calc.OptionalConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
     public class OptionalConstructorArgument : DeputyBase
     {
         public OptionalConstructorArgument(double arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
@@ -2,7 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiClass(nativeType: typeof(OptionalStructConsumer), fullyQualifiedName: "jsii-calc.OptionalStructConsumer", parametersJson: "[{\"name\":\"optionalStruct\",\"type\":{\"fqn\":\"jsii-calc.OptionalStruct\"}}]")]
+    [JsiiClass(nativeType: typeof(OptionalStructConsumer), fullyQualifiedName: "jsii-calc.OptionalStructConsumer", parametersJson: "[{\"name\":\"optionalStruct\",\"type\":{\"fqn\":\"jsii-calc.OptionalStruct\"},\"optional\":true}]")]
     public class OptionalStructConsumer : DeputyBase
     {
         public OptionalStructConsumer(IOptionalStruct optionalStruct): base(new DeputyProps(new object[]{optionalStruct}))

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
@@ -18,20 +18,20 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        [JsiiMethod(name: "methodWithDefaultedArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"}}]")]
+        [JsiiMethod(name: "methodWithDefaultedArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"},\"optional\":true},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
         public virtual void MethodWithDefaultedArguments(double? arg1, string arg2, DateTime? arg3)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});
         }
 
-        [JsiiMethod(name: "methodWithOptionalAnyArgument", parametersJson: "[{\"name\":\"arg\",\"type\":{\"primitive\":\"any\"}}]")]
+        [JsiiMethod(name: "methodWithOptionalAnyArgument", parametersJson: "[{\"name\":\"arg\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
         public virtual void MethodWithOptionalAnyArgument(object arg)
         {
             InvokeInstanceVoidMethod(new object[]{arg});
         }
 
         /// <summary>Used to verify verification of number of method arguments.</summary>
-        [JsiiMethod(name: "methodWithOptionalArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"}}]")]
+        [JsiiMethod(name: "methodWithOptionalArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
         public virtual void MethodWithOptionalArguments(double arg1, string arg2, DateTime? arg3)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicMethod.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicMethod.cs
@@ -2,7 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    [JsiiClass(nativeType: typeof(VariadicMethod), fullyQualifiedName: "jsii-calc.VariadicMethod", parametersJson: "[{\"name\":\"prefix\",\"type\":{\"primitive\":\"number\"}}]")]
+    [JsiiClass(nativeType: typeof(VariadicMethod), fullyQualifiedName: "jsii-calc.VariadicMethod", parametersJson: "[{\"name\":\"prefix\",\"variadic\":true,\"type\":{\"primitive\":\"number\"}}]")]
     public class VariadicMethod : DeputyBase
     {
         public VariadicMethod(double prefix): base(new DeputyProps(new object[]{prefix}))
@@ -19,7 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <param name = "first">the first element of the array to be returned (after the `prefix` provided at construction time).</param>
         /// <param name = "others">other elements to be included in the array.</param>
-        [JsiiMethod(name: "asArray", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"number\"}}}}", parametersJson: "[{\"name\":\"first\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"others\",\"type\":{\"primitive\":\"number\"}}]")]
+        [JsiiMethod(name: "asArray", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"number\"}}}}", parametersJson: "[{\"name\":\"first\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"others\",\"variadic\":true,\"type\":{\"primitive\":\"number\"}}]")]
         public virtual double[] AsArray(double first, double others)
         {
             return InvokeInstanceMethod<double[]>(new object[]{first, others});


### PR DESCRIPTION
Method parameters were missing the "optional" marker due to the logic
that was initially intended to prune only documentation from the JSON
data attached to the method attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
