### PR TITLE
fix(dotnet): Correctly handle 'void' callback results

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1663,3 +1663,22 @@ export class StaticContext {
 
     private constructor() { }
 }
+
+/**
+ * This test is used to validate the runtimes can return correctly from a void callback.
+ *
+ * - Implement `overrideMe` (method does not have to do anything).
+ * - Invoke `callMe`
+ * - Verify that `methodWasCalled` is `true`.
+ */
+export abstract class VoidCallback {
+    private _methodWasCalled = false;
+    public get methodWasCalled(): boolean {
+        return this._methodWasCalled;
+    }
+    public callMe(): void {
+        this.overrideMe();
+        this._methodWasCalled = true;
+    }
+    protected abstract overrideMe(): void;
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -6551,6 +6551,53 @@
       ],
       "name": "VirtualMethodPlayground"
     },
+    "jsii-calc.VoidCallback": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "- Implement `overrideMe` (method does not have to do anything).\n- Invoke `callMe`\n- Verify that `methodWasCalled` is `true`.",
+        "summary": "This test is used to validate the runtimes can return correctly from a void callback."
+      },
+      "fqn": "jsii-calc.VoidCallback",
+      "initializer": {},
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1674
+      },
+      "methods": [
+        {
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1679
+          },
+          "name": "callMe"
+        },
+        {
+          "abstract": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1683
+          },
+          "name": "overrideMe",
+          "protected": true
+        }
+      ],
+      "name": "VoidCallback",
+      "properties": [
+        {
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1676
+          },
+          "name": "methodWasCalled",
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
     "jsii-calc.composition.CompositeOperation": {
       "abstract": true,
       "assembly": "jsii-calc",
@@ -6697,5 +6744,5 @@
     }
   },
   "version": "0.10.1",
-  "fingerprint": "xAP41ArR/7KF9tmWHGtBlronNIVBQ/oDKKrhPoZ8otA="
+  "fingerprint": "975zFxt3ZCRvNKhp/Yh0HUwj9Gqz6I7YcagcGWY7UIY="
 }

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -905,7 +905,24 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             Assert.NotNull(obj);
         }
+        
+        [Fact(DisplayName = Prefix + nameof(CorrectlyReturnsFromVoidCallback))]
+        public void CorrectlyReturnsFromVoidCallback()
+        {
+            var voidCallback = new VoidCallbackImpl();
+            voidCallback.CallMe();
+            
+            Assert.True(voidCallback.MethodWasCalled);
+        }
 
+        class VoidCallbackImpl : VoidCallback
+        {
+            protected override void OverrideMe()
+            {
+                // Do nothing!
+            }
+        }
+        
         class PartiallyInitializedThisConsumerImpl : PartiallyInitializedThisConsumer
         {
             public override String ConsumePartiallyInitializedThis(ConstructorPassesThisOut obj, DateTime dt, AllTypesEnum ev)
@@ -959,10 +976,6 @@ namespace Amazon.JSII.Runtime.IntegrationTests
                 : base(new Number(value), new Number(10))
             {
             }
-        }
-
-        class DerivedFromAllTypes : AllTypes
-        {
         }
 
         class OverrideAsyncMethods : AsyncVirtualMethods

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/CallbackExtensions.cs
@@ -77,10 +77,8 @@ namespace Amazon.JSII.Runtime
             }
 
             JsiiMethodAttribute attribute = methodInfo.GetCustomAttribute<JsiiMethodAttribute>();
-            return new CallbackResult(
-                attribute?.Returns,
-                methodInfo.Invoke(deputy, request.Arguments.Select(arg => FromKernel(arg, referenceMap)).ToArray())
-            );
+            var returnValue = methodInfo.Invoke(deputy, request.Arguments.Select(arg => FromKernel(arg, referenceMap)).ToArray());
+            return attribute?.Returns != null ? new CallbackResult(attribute?.Returns, returnValue) : null;
         }
 
         static CallbackResult InvokeGetter(GetRequest request, IReferenceMap referenceMap)

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
@@ -63,7 +63,7 @@ namespace Amazon.JSII.Runtime.Deputy
 
             IEnumerable<Override> GetMethodOverrides()
             {
-                foreach (MethodInfo method in type.GetMethods())
+                foreach (MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
                 {
                     JsiiMethodAttribute inheritedAttribute = method.GetCustomAttribute<JsiiMethodAttribute>(true);
                     JsiiMethodAttribute uninheritedAttribute = method.GetCustomAttribute<JsiiMethodAttribute>(false);
@@ -77,7 +77,7 @@ namespace Amazon.JSII.Runtime.Deputy
 
             IEnumerable<Override> GetPropertyOverrides()
             {
-                foreach (PropertyInfo property in type.GetProperties())
+                foreach (PropertyInfo property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
                 {
                     JsiiPropertyAttribute inheritedAttribute = property.GetCustomAttribute<JsiiPropertyAttribute>(true);
                     JsiiPropertyAttribute uninheritedAttribute = property.GetCustomAttribute<JsiiPropertyAttribute>(false);

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/ReflectionUtils.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/ReflectionUtils.cs
@@ -26,7 +26,7 @@ namespace Amazon.JSII.Runtime
 
         public static MethodInfo GetNativeMethod(Type classType, string name)
         {
-            MethodInfo methodInfo = classType.GetMethods().FirstOrDefault(method =>
+            MethodInfo methodInfo = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(method =>
             {
                 JsiiMethodAttribute attribute = method.GetCustomAttribute<JsiiMethodAttribute>();
 
@@ -44,7 +44,7 @@ namespace Amazon.JSII.Runtime
 
         public static PropertyInfo GetNativeProperty(Type classType, string name)
         {
-            PropertyInfo propertyInfo = classType.GetProperties().FirstOrDefault(property =>
+            PropertyInfo propertyInfo = classType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(property =>
             {
                 JsiiPropertyAttribute attribute = property.GetCustomAttribute<JsiiPropertyAttribute>();
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -6551,6 +6551,53 @@
       ],
       "name": "VirtualMethodPlayground"
     },
+    "jsii-calc.VoidCallback": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "- Implement `overrideMe` (method does not have to do anything).\n- Invoke `callMe`\n- Verify that `methodWasCalled` is `true`.",
+        "summary": "This test is used to validate the runtimes can return correctly from a void callback."
+      },
+      "fqn": "jsii-calc.VoidCallback",
+      "initializer": {},
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1674
+      },
+      "methods": [
+        {
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1679
+          },
+          "name": "callMe"
+        },
+        {
+          "abstract": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1683
+          },
+          "name": "overrideMe",
+          "protected": true
+        }
+      ],
+      "name": "VoidCallback",
+      "properties": [
+        {
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1676
+          },
+          "name": "methodWasCalled",
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
     "jsii-calc.composition.CompositeOperation": {
       "abstract": true,
       "assembly": "jsii-calc",
@@ -6697,5 +6744,5 @@
     }
   },
   "version": "0.10.1",
-  "fingerprint": "xAP41ArR/7KF9tmWHGtBlronNIVBQ/oDKKrhPoZ8otA="
+  "fingerprint": "975zFxt3ZCRvNKhp/Yh0HUwj9Gqz6I7YcagcGWY7UIY="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallback.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallback.cs
@@ -1,0 +1,41 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This test is used to validate the runtimes can return correctly from a void callback.</summary>
+    /// <remarks>
+    /// - Implement `overrideMe` (method does not have to do anything).
+    /// - Invoke `callMe`
+    /// - Verify that `methodWasCalled` is `true`.
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
+    public abstract class VoidCallback : DeputyBase
+    {
+        protected VoidCallback(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected VoidCallback(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected VoidCallback(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty(name: "methodWasCalled", typeJson: "{\"primitive\":\"boolean\"}")]
+        public virtual bool MethodWasCalled
+        {
+            get => GetInstanceProperty<bool>();
+        }
+
+        [JsiiMethod(name: "callMe")]
+        public virtual void CallMe()
+        {
+            InvokeInstanceVoidMethod(new object[]{});
+        }
+
+        [JsiiMethod(name: "overrideMe")]
+        protected abstract void OverrideMe();
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
@@ -1,0 +1,24 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This test is used to validate the runtimes can return correctly from a void callback.</summary>
+    /// <remarks>
+    /// - Implement `overrideMe` (method does not have to do anything).
+    /// - Invoke `callMe`
+    /// - Verify that `methodWasCalled` is `true`.
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
+    internal sealed class VoidCallbackProxy : VoidCallback
+    {
+        private VoidCallbackProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        [JsiiMethod(name: "overrideMe")]
+        protected override void OverrideMe()
+        {
+            InvokeInstanceVoidMethod(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -126,6 +126,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.UsesInterfaceWithProperties": return software.amazon.jsii.tests.calculator.UsesInterfaceWithProperties.class;
             case "jsii-calc.VariadicMethod": return software.amazon.jsii.tests.calculator.VariadicMethod.class;
             case "jsii-calc.VirtualMethodPlayground": return software.amazon.jsii.tests.calculator.VirtualMethodPlayground.class;
+            case "jsii-calc.VoidCallback": return software.amazon.jsii.tests.calculator.VoidCallback.class;
             case "jsii-calc.composition.CompositeOperation": return software.amazon.jsii.tests.calculator.composition.CompositeOperation.class;
             case "jsii-calc.composition.CompositeOperation.CompositionStringStyle": return software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle.class;
             default: throw new ClassNotFoundException("Unknown JSII type: " + fqn);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
@@ -1,0 +1,44 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * This test is used to validate the runtimes can return correctly from a void callback.
+ * 
+ * - Implement `overrideMe` (method does not have to do anything).
+ * - Invoke `callMe`
+ * - Verify that `methodWasCalled` is `true`.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VoidCallback")
+public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
+    protected VoidCallback(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public VoidCallback() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    public void callMe() {
+        this.jsiiCall("callMe", Void.class);
+    }
+
+    protected abstract void overrideMe();
+
+    public java.lang.Boolean getMethodWasCalled() {
+        return this.jsiiGet("methodWasCalled", java.lang.Boolean.class);
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.VoidCallback {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+
+        @Override
+        protected void overrideMe() {
+            this.jsiiCall("overrideMe", Void.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -2450,6 +2450,35 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         return jsii.invoke(self, "sumSync", [count])
 
 
+class VoidCallback(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.VoidCallback"):
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _VoidCallbackProxy
+
+    def __init__(self) -> None:
+        jsii.create(VoidCallback, self, [])
+
+    @jsii.member(jsii_name="callMe")
+    def call_me(self) -> None:
+        return jsii.invoke(self, "callMe", [])
+
+    @jsii.member(jsii_name="overrideMe")
+    @abc.abstractmethod
+    def _override_me(self) -> None:
+        ...
+
+    @property
+    @jsii.member(jsii_name="methodWasCalled")
+    def method_was_called(self) -> bool:
+        return jsii.get(self, "methodWasCalled")
+
+
+class _VoidCallbackProxy(VoidCallback):
+    @jsii.member(jsii_name="overrideMe")
+    def _override_me(self) -> None:
+        return jsii.invoke(self, "overrideMe", [])
+
+
 class composition:
     class CompositeOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.composition.CompositeOperation"):
         @staticmethod
@@ -2629,6 +2658,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -6152,6 +6152,63 @@ VirtualMethodPlayground
       :rtype: number
 
 
+VoidCallback
+^^^^^^^^^^^^
+
+.. py:class:: VoidCallback()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.VoidCallback;
+
+      .. code-tab:: javascript
+
+         const { VoidCallback } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { VoidCallback } from 'jsii-calc';
+
+
+
+   This test is used to validate the runtimes can return correctly from a void callback.
+
+   
+
+   - Implement `overrideMe` (method does not have to do anything).
+
+   - Invoke `callMe`
+
+   - Verify that `methodWasCalled` is `true`.
+
+
+
+   :abstract: Yes
+
+   .. py:method:: callMe()
+
+
+
+   .. py:method:: overrideMe()
+
+      *Protected method*
+
+      :abstract: Yes
+
+
+   .. py:attribute:: methodWasCalled
+
+      :type: boolean *(readonly)*
+
+
 
 composition
 ^^^^^^^^^^^

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -78,3 +78,4 @@ Value
 VariadicMethod
 Very
 VirtualMethodPlayground
+VoidCallback

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -1154,6 +1154,18 @@ assemblies
  │   │     │ └─┬ count
  │   │     │   └── type: number
  │   │     └── returns: number
+ │   ├─┬ class VoidCallback
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   ├─┬ callMe() method
+ │   │   │ └── returns: void
+ │   │   ├─┬ overrideMe() method
+ │   │   │ ├── abstract
+ │   │   │ ├── protected
+ │   │   │ └── returns: void
+ │   │   └─┬ methodWasCalled property
+ │   │     ├── immutable
+ │   │     └── type: boolean
  │   ├─┬ class CompositeOperation
  │   │ ├── base: Operation
  │   │ └─┬ members

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -98,6 +98,7 @@ assemblies
  │   ├── class UsesInterfaceWithProperties
  │   ├── class VariadicMethod
  │   ├── class VirtualMethodPlayground
+ │   ├── class VoidCallback
  │   ├─┬ class CompositeOperation
  │   │ └── base: Operation
  │   ├── interface CalculatorProps

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -512,6 +512,12 @@ assemblies
  │   │   ├── parallelSumAsync(count) method
  │   │   ├── serialSumAsync(count) method
  │   │   └── sumSync(count) method
+ │   ├─┬ class VoidCallback
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   ├── callMe() method
+ │   │   ├── overrideMe() method
+ │   │   └── methodWasCalled property
  │   ├─┬ class CompositeOperation
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -75,6 +75,7 @@ assemblies
  │   ├── class UsesInterfaceWithProperties
  │   ├── class VariadicMethod
  │   ├── class VirtualMethodPlayground
+ │   ├── class VoidCallback
  │   ├── class CompositeOperation
  │   ├── interface CalculatorProps
  │   ├── interface DerivedStruct


### PR DESCRIPTION
Previously, it attempted to generate an OptionalValue instance with no
`Type`, which is illegal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
