### PR TITLE
fix(jsii): consider interfaces from erased base classes

### DIFF
--- a/packages/jsii-calc/lib/erasures.ts
+++ b/packages/jsii-calc/lib/erasures.ts
@@ -37,3 +37,12 @@ interface IJSII417PrivateBase extends IJSII417PublicBaseOfBase {
 export interface IJSII417Derived extends IJSII417PrivateBase {
   baz(): void;
 }
+
+//
+// Interfaces should be copied from erased classes to public classes
+// https://github.com/awslabs/jsii/issues/487
+//
+// tslint:disable-next-line:no-empty-interface
+export interface IJsii487External { }
+class Jsii487Internal implements IJsii487External { }
+export class Jsii487Derived extends Jsii487Internal { }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3035,6 +3035,16 @@
         }
       ]
     },
+    "jsii-calc.IJsii487External": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii487External",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 46
+      },
+      "name": "IJsii487External"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4037,6 +4047,20 @@
           }
         }
       ]
+    },
+    "jsii-calc.Jsii487Derived": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.Jsii487Derived",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IJsii487External"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 48
+      },
+      "name": "Jsii487Derived"
     },
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
@@ -6744,5 +6768,5 @@
     }
   },
   "version": "0.10.3",
-  "fingerprint": "HkyspjelXmNd6gQibMCkuk+WfsM6Q9e3uZLl2ee3kbY="
+  "fingerprint": "CSE0eCLDxK7s+qnmR58ZJo0mcEROi4f8Sxlx2pHaBDs="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3035,6 +3035,16 @@
         }
       ]
     },
+    "jsii-calc.IJsii487External": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii487External",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 46
+      },
+      "name": "IJsii487External"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4037,6 +4047,20 @@
           }
         }
       ]
+    },
+    "jsii-calc.Jsii487Derived": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.Jsii487Derived",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IJsii487External"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 48
+      },
+      "name": "Jsii487Derived"
     },
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
@@ -6744,5 +6768,5 @@
     }
   },
   "version": "0.10.3",
-  "fingerprint": "HkyspjelXmNd6gQibMCkuk+WfsM6Q9e3uZLl2ee3kbY="
+  "fingerprint": "CSE0eCLDxK7s+qnmR58ZJo0mcEROi4f8Sxlx2pHaBDs="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External.cs
@@ -1,0 +1,9 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(nativeType: typeof(IIJsii487External), fullyQualifiedName: "jsii-calc.IJsii487External")]
+    public interface IIJsii487External
+    {
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
@@ -1,0 +1,12 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(nativeType: typeof(IIJsii487External), fullyQualifiedName: "jsii-calc.IJsii487External")]
+    internal sealed class IJsii487ExternalProxy : DeputyBase, IIJsii487External
+    {
+        private IJsii487ExternalProxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(nativeType: typeof(Jsii487Derived), fullyQualifiedName: "jsii-calc.Jsii487Derived")]
+    public class Jsii487Derived : DeputyBase, IIJsii487External
+    {
+        public Jsii487Derived(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected Jsii487Derived(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected Jsii487Derived(DeputyProps props): base(props)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -67,6 +67,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.IInterfaceWithPropertiesExtension": return software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension.class;
             case "jsii-calc.IJSII417Derived": return software.amazon.jsii.tests.calculator.IJSII417Derived.class;
             case "jsii-calc.IJSII417PublicBaseOfBase": return software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase.class;
+            case "jsii-calc.IJsii487External": return software.amazon.jsii.tests.calculator.IJsii487External.class;
             case "jsii-calc.IMutableObjectLiteral": return software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class;
             case "jsii-calc.INonInternalInterface": return software.amazon.jsii.tests.calculator.INonInternalInterface.class;
             case "jsii-calc.IPrivatelyImplemented": return software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class;
@@ -89,6 +90,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.JSObjectLiteralToNative": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNative.class;
             case "jsii-calc.JSObjectLiteralToNativeClass": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class;
             case "jsii-calc.JavaReservedWords": return software.amazon.jsii.tests.calculator.JavaReservedWords.class;
+            case "jsii-calc.Jsii487Derived": return software.amazon.jsii.tests.calculator.Jsii487Derived.class;
             case "jsii-calc.JsiiAgent": return software.amazon.jsii.tests.calculator.JsiiAgent.class;
             case "jsii-calc.LoadBalancedFargateServiceProps": return software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps.class;
             case "jsii-calc.Multiply": return software.amazon.jsii.tests.calculator.Multiply.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
@@ -1,0 +1,14 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IJsii487External extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
@@ -1,0 +1,13 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii487Derived")
+public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External {
+    protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public Jsii487Derived() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1274,6 +1274,18 @@ class _IJSII417DerivedProxy(jsii.proxy_for(IJSII417PublicBaseOfBase)):
         return jsii.invoke(self, "baz", [])
 
 
+@jsii.interface(jsii_type="jsii-calc.IJsii487External")
+class IJsii487External(jsii.compat.Protocol):
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _IJsii487ExternalProxy
+
+    pass
+
+class _IJsii487ExternalProxy():
+    __jsii_type__ = "jsii-calc.IJsii487External"
+    pass
+
 @jsii.interface(jsii_type="jsii-calc.IMutableObjectLiteral")
 class IMutableObjectLiteral(jsii.compat.Protocol):
     @staticmethod
@@ -1953,6 +1965,12 @@ class JavaReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JavaReserv
     @while_.setter
     def while_(self, value: str):
         return jsii.set(self, "while", value)
+
+
+@jsii.implements(IJsii487External)
+class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
+    def __init__(self) -> None:
+        jsii.create(Jsii487Derived, self, [])
 
 
 class JsiiAgent(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsiiAgent"):
@@ -3272,6 +3290,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -2819,6 +2819,35 @@ IJSII417PublicBaseOfBase (interface)
       :abstract: Yes
 
 
+IJsii487External (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IJsii487External
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IJsii487External;
+
+      .. code-tab:: javascript
+
+         // IJsii487External is an interface
+
+      .. code-tab:: typescript
+
+         import { IJsii487External } from 'jsii-calc';
+
+
+
+
+
 IMutableObjectLiteral (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3883,6 +3912,35 @@ JavaReservedWords
 
       :type: string
 
+
+Jsii487Derived
+^^^^^^^^^^^^^^
+
+.. py:class:: Jsii487Derived()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.Jsii487Derived;
+
+      .. code-tab:: javascript
+
+         const { Jsii487Derived } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { Jsii487Derived } from 'jsii-calc';
+
+
+
+   :implements: :py:class:`~jsii-calc.IJsii487External`\ 
 
 JsiiAgent
 ^^^^^^^^^

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -42,6 +42,7 @@ JSObjectLiteralForInterface
 JSObjectLiteralToNative
 JSObjectLiteralToNativeClass
 JavaReservedWords
+Jsii487Derived
 JsiiAgent
 Multiply
 Negate

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -635,6 +635,10 @@ assemblies
  │   │   │ └── returns: void
  │   │   └─┬ while property
  │   │     └── type: string
+ │   ├─┬ class Jsii487Derived
+ │   │ ├── interfaces: IJsii487External
+ │   │ └─┬ members
+ │   │   └── <initializer>() initializer
  │   ├─┬ class JsiiAgent
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -1355,6 +1359,8 @@ assemblies
  │   │     ├── abstract
  │   │     ├── immutable
  │   │     └── type: boolean
+ │   ├─┬ interface IJsii487External
+ │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members
  │   │   └─┬ value property

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -59,6 +59,8 @@ assemblies
  │   ├── class JSObjectLiteralToNative
  │   ├── class JSObjectLiteralToNativeClass
  │   ├── class JavaReservedWords
+ │   ├─┬ class Jsii487Derived
+ │   │ └── interfaces: IJsii487External
  │   ├── class JsiiAgent
  │   ├─┬ class Multiply
  │   │ ├── base: BinaryOperation
@@ -132,6 +134,7 @@ assemblies
  │   │ └─┬ interfaces
  │   │   └── IJSII417PublicBaseOfBase
  │   ├── interface IJSII417PublicBaseOfBase
+ │   ├── interface IJsii487External
  │   ├── interface IMutableObjectLiteral
  │   ├─┬ interface INonInternalInterface
  │   │ └─┬ interfaces

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -295,6 +295,9 @@ assemblies
  │   │   ├── void() method
  │   │   ├── volatile() method
  │   │   └── while property
+ │   ├─┬ class Jsii487Derived
+ │   │ └─┬ members
+ │   │   └── <initializer>() initializer
  │   ├─┬ class JsiiAgent
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -595,6 +598,8 @@ assemblies
  │   │ └─┬ members
  │   │   ├── foo() method
  │   │   └── hasRoot property
+ │   ├─┬ interface IJsii487External
+ │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members
  │   │   └── value property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -43,6 +43,7 @@ assemblies
  │   ├── class JSObjectLiteralToNative
  │   ├── class JSObjectLiteralToNativeClass
  │   ├── class JavaReservedWords
+ │   ├── class Jsii487Derived
  │   ├── class JsiiAgent
  │   ├── class Multiply
  │   ├── class Negate
@@ -95,6 +96,7 @@ assemblies
  │   ├── interface IInterfaceWithPropertiesExtension
  │   ├── interface IJSII417Derived
  │   ├── interface IJSII417PublicBaseOfBase
+ │   ├── interface IJsii487External
  │   ├── interface IMutableObjectLiteral
  │   ├── interface INonInternalInterface
  │   ├── interface IPrivatelyImplemented


### PR DESCRIPTION
When a base class is erased, we now treat it's "implementation" clauses
as if they were part of the original class (similar to how we merge declarations
for methods/properties).

Fixes #487

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
