### PR TITLE
fix(jsii): merge all "implements" declarations

### DIFF
--- a/packages/jsii-calc/lib/erasures.ts
+++ b/packages/jsii-calc/lib/erasures.ts
@@ -44,5 +44,6 @@ export interface IJSII417Derived extends IJSII417PrivateBase {
 //
 // tslint:disable-next-line:no-empty-interface
 export interface IJsii487External { }
+export interface IJsii487External2 { }
 class Jsii487Internal implements IJsii487External { }
-export class Jsii487Derived extends Jsii487Internal { }
+export class Jsii487Derived extends Jsii487Internal implements IJsii487External2 { }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3045,6 +3045,16 @@
       },
       "name": "IJsii487External"
     },
+    "jsii-calc.IJsii487External2": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii487External2",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 47
+      },
+      "name": "IJsii487External2"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4053,12 +4063,13 @@
       "fqn": "jsii-calc.Jsii487Derived",
       "initializer": {},
       "interfaces": [
+        "jsii-calc.IJsii487External2",
         "jsii-calc.IJsii487External"
       ],
       "kind": "class",
       "locationInModule": {
         "filename": "lib/erasures.ts",
-        "line": 48
+        "line": 49
       },
       "name": "Jsii487Derived"
     },
@@ -6768,5 +6779,5 @@
     }
   },
   "version": "0.10.4",
-  "fingerprint": "JCVRuScD6uk2V+RQ+YfHSg6DG1z9qNmSY+Aug5NeTLY="
+  "fingerprint": "BTA5ERZWebBpBrjU3gv4/cr//8oiD3VyWbzqcJTNz7c="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3045,6 +3045,16 @@
       },
       "name": "IJsii487External"
     },
+    "jsii-calc.IJsii487External2": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii487External2",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 47
+      },
+      "name": "IJsii487External2"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4053,12 +4063,13 @@
       "fqn": "jsii-calc.Jsii487Derived",
       "initializer": {},
       "interfaces": [
+        "jsii-calc.IJsii487External2",
         "jsii-calc.IJsii487External"
       ],
       "kind": "class",
       "locationInModule": {
         "filename": "lib/erasures.ts",
-        "line": 48
+        "line": 49
       },
       "name": "Jsii487Derived"
     },
@@ -6768,5 +6779,5 @@
     }
   },
   "version": "0.10.4",
-  "fingerprint": "JCVRuScD6uk2V+RQ+YfHSg6DG1z9qNmSY+Aug5NeTLY="
+  "fingerprint": "BTA5ERZWebBpBrjU3gv4/cr//8oiD3VyWbzqcJTNz7c="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External2.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External2.cs
@@ -1,0 +1,9 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(nativeType: typeof(IIJsii487External2), fullyQualifiedName: "jsii-calc.IJsii487External2")]
+    public interface IIJsii487External2
+    {
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
@@ -1,0 +1,12 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(nativeType: typeof(IIJsii487External2), fullyQualifiedName: "jsii-calc.IJsii487External2")]
+    internal sealed class IJsii487External2Proxy : DeputyBase, IIJsii487External2
+    {
+        private IJsii487External2Proxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
@@ -3,7 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     [JsiiClass(nativeType: typeof(Jsii487Derived), fullyQualifiedName: "jsii-calc.Jsii487Derived")]
-    public class Jsii487Derived : DeputyBase, IIJsii487External
+    public class Jsii487Derived : DeputyBase, IIJsii487External2, IIJsii487External
     {
         public Jsii487Derived(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -68,6 +68,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.IJSII417Derived": return software.amazon.jsii.tests.calculator.IJSII417Derived.class;
             case "jsii-calc.IJSII417PublicBaseOfBase": return software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase.class;
             case "jsii-calc.IJsii487External": return software.amazon.jsii.tests.calculator.IJsii487External.class;
+            case "jsii-calc.IJsii487External2": return software.amazon.jsii.tests.calculator.IJsii487External2.class;
             case "jsii-calc.IMutableObjectLiteral": return software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class;
             case "jsii-calc.INonInternalInterface": return software.amazon.jsii.tests.calculator.INonInternalInterface.class;
             case "jsii-calc.IPrivatelyImplemented": return software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
@@ -1,0 +1,14 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IJsii487External2 extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External2 {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
@@ -2,7 +2,7 @@ package software.amazon.jsii.tests.calculator;
 
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii487Derived")
-public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External {
+public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External2,software.amazon.jsii.tests.calculator.IJsii487External {
     protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1286,6 +1286,18 @@ class _IJsii487ExternalProxy():
     __jsii_type__ = "jsii-calc.IJsii487External"
     pass
 
+@jsii.interface(jsii_type="jsii-calc.IJsii487External2")
+class IJsii487External2(jsii.compat.Protocol):
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _IJsii487External2Proxy
+
+    pass
+
+class _IJsii487External2Proxy():
+    __jsii_type__ = "jsii-calc.IJsii487External2"
+    pass
+
 @jsii.interface(jsii_type="jsii-calc.IMutableObjectLiteral")
 class IMutableObjectLiteral(jsii.compat.Protocol):
     @staticmethod
@@ -1967,7 +1979,7 @@ class JavaReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JavaReserv
         return jsii.set(self, "while", value)
 
 
-@jsii.implements(IJsii487External)
+@jsii.implements(IJsii487External2, IJsii487External)
 class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
     def __init__(self) -> None:
         jsii.create(Jsii487Derived, self, [])
@@ -3290,6 +3302,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -2848,6 +2848,35 @@ IJsii487External (interface)
 
 
 
+IJsii487External2 (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IJsii487External2
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IJsii487External2;
+
+      .. code-tab:: javascript
+
+         // IJsii487External2 is an interface
+
+      .. code-tab:: typescript
+
+         import { IJsii487External2 } from 'jsii-calc';
+
+
+
+
+
 IMutableObjectLiteral (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3940,6 +3969,7 @@ Jsii487Derived
 
 
 
+   :implements: :py:class:`~jsii-calc.IJsii487External2`\ 
    :implements: :py:class:`~jsii-calc.IJsii487External`\ 
 
 JsiiAgent

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -636,7 +636,7 @@ assemblies
  │   │   └─┬ while property
  │   │     └── type: string
  │   ├─┬ class Jsii487Derived
- │   │ ├── interfaces: IJsii487External
+ │   │ ├── interfaces: IJsii487External2,IJsii487External
  │   │ └─┬ members
  │   │   └── <initializer>() initializer
  │   ├─┬ class JsiiAgent
@@ -1360,6 +1360,8 @@ assemblies
  │   │     ├── immutable
  │   │     └── type: boolean
  │   ├─┬ interface IJsii487External
+ │   │ └── members
+ │   ├─┬ interface IJsii487External2
  │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -60,7 +60,7 @@ assemblies
  │   ├── class JSObjectLiteralToNativeClass
  │   ├── class JavaReservedWords
  │   ├─┬ class Jsii487Derived
- │   │ └── interfaces: IJsii487External
+ │   │ └── interfaces: IJsii487External2,IJsii487External
  │   ├── class JsiiAgent
  │   ├─┬ class Multiply
  │   │ ├── base: BinaryOperation
@@ -135,6 +135,7 @@ assemblies
  │   │   └── IJSII417PublicBaseOfBase
  │   ├── interface IJSII417PublicBaseOfBase
  │   ├── interface IJsii487External
+ │   ├── interface IJsii487External2
  │   ├── interface IMutableObjectLiteral
  │   ├─┬ interface INonInternalInterface
  │   │ └─┬ interfaces

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -600,6 +600,8 @@ assemblies
  │   │   └── hasRoot property
  │   ├─┬ interface IJsii487External
  │   │ └── members
+ │   ├─┬ interface IJsii487External2
+ │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members
  │   │   └── value property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -97,6 +97,7 @@ assemblies
  │   ├── interface IJSII417Derived
  │   ├── interface IJSII417PublicBaseOfBase
  │   ├── interface IJsii487External
+ │   ├── interface IJsii487External2
  │   ├── interface IMutableObjectLiteral
  │   ├── interface INonInternalInterface
  │   ├── interface IPrivatelyImplemented

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -505,9 +505,10 @@ export class Assembler implements Emitter {
     }
 
     // process all "implements" clauses
+    jsiiType.interfaces = jsiiType.interfaces || [];
     for (const clause of implementsClauses) {
       const { interfaces } = await this._processBaseInterfaces(fqn, clause.types.map(t => this._typeChecker.getTypeFromTypeNode(t)));
-      jsiiType.interfaces = apply(interfaces, arr => arr.map(i => i.fqn));
+      jsiiType.interfaces.push(...(interfaces || []).map(i => i.fqn));
       if (interfaces) {
         this._deferUntilTypesAvailable(jsiiType.fqn, interfaces, type.symbol.valueDeclaration, (...ifaces) => {
           for (const iface of ifaces) {
@@ -519,6 +520,10 @@ export class Assembler implements Emitter {
           }
         });
       }
+    }
+
+    if (jsiiType.interfaces.length === 0) {
+      delete jsiiType.interfaces;
     }
 
     if (!type.isClass()) {


### PR DESCRIPTION
When processing the merged set if "implements" declarations,
do not override the "interfaces" section when there are multiple
declaration sites (as in when a base class is erased).

Fixes #493

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
