### PR TITLE
fix(jsii): deduplicate interfaces

### DIFF
--- a/packages/jsii-calc/lib/erasures.ts
+++ b/packages/jsii-calc/lib/erasures.ts
@@ -48,3 +48,11 @@ export interface IJsii487External { }
 export interface IJsii487External2 { }
 class Jsii487Internal implements IJsii487External { }
 export class Jsii487Derived extends Jsii487Internal implements IJsii487External2 { }
+
+//
+// Deduplicate interfaces that come from different declaration sites
+// https://github.com/awslabs/jsii/issues/496
+//
+export interface IJsii496 { }
+class Jsii496Base implements IJsii496 { }
+export class Jsii496Derived extends Jsii496Base implements IJsii496 { }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -3055,6 +3055,16 @@
       },
       "name": "IJsii487External2"
     },
+    "jsii-calc.IJsii496": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii496",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 56
+      },
+      "name": "IJsii496"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4072,6 +4082,20 @@
         "line": 50
       },
       "name": "Jsii487Derived"
+    },
+    "jsii-calc.Jsii496Derived": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.Jsii496Derived",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IJsii496"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 58
+      },
+      "name": "Jsii496Derived"
     },
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
@@ -6779,5 +6803,5 @@
     }
   },
   "version": "0.10.5",
-  "fingerprint": "yLgYMXLhffrmN5U4ftTmlWijmxvKaKHA4QXx9+adYe0="
+  "fingerprint": "Zn881YRFrX198/TaBpApis646FTCp/XbGmU7cWaw/cs="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -3055,6 +3055,16 @@
       },
       "name": "IJsii487External2"
     },
+    "jsii-calc.IJsii496": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.IJsii496",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 56
+      },
+      "name": "IJsii496"
+    },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
       "fqn": "jsii-calc.IMutableObjectLiteral",
@@ -4072,6 +4082,20 @@
         "line": 50
       },
       "name": "Jsii487Derived"
+    },
+    "jsii-calc.Jsii496Derived": {
+      "assembly": "jsii-calc",
+      "fqn": "jsii-calc.Jsii496Derived",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IJsii496"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/erasures.ts",
+        "line": 58
+      },
+      "name": "Jsii496Derived"
     },
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
@@ -6779,5 +6803,5 @@
     }
   },
   "version": "0.10.5",
-  "fingerprint": "yLgYMXLhffrmN5U4ftTmlWijmxvKaKHA4QXx9+adYe0="
+  "fingerprint": "Zn881YRFrX198/TaBpApis646FTCp/XbGmU7cWaw/cs="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii496.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii496.cs
@@ -1,0 +1,9 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiInterface(nativeType: typeof(IIJsii496), fullyQualifiedName: "jsii-calc.IJsii496")]
+    public interface IIJsii496
+    {
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
@@ -1,0 +1,12 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiTypeProxy(nativeType: typeof(IIJsii496), fullyQualifiedName: "jsii-calc.IJsii496")]
+    internal sealed class IJsii496Proxy : DeputyBase, IIJsii496
+    {
+        private IJsii496Proxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(nativeType: typeof(Jsii496Derived), fullyQualifiedName: "jsii-calc.Jsii496Derived")]
+    public class Jsii496Derived : DeputyBase, IIJsii496
+    {
+        public Jsii496Derived(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected Jsii496Derived(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected Jsii496Derived(DeputyProps props): base(props)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -69,6 +69,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.IJSII417PublicBaseOfBase": return software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase.class;
             case "jsii-calc.IJsii487External": return software.amazon.jsii.tests.calculator.IJsii487External.class;
             case "jsii-calc.IJsii487External2": return software.amazon.jsii.tests.calculator.IJsii487External2.class;
+            case "jsii-calc.IJsii496": return software.amazon.jsii.tests.calculator.IJsii496.class;
             case "jsii-calc.IMutableObjectLiteral": return software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class;
             case "jsii-calc.INonInternalInterface": return software.amazon.jsii.tests.calculator.INonInternalInterface.class;
             case "jsii-calc.IPrivatelyImplemented": return software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class;
@@ -92,6 +93,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.JSObjectLiteralToNativeClass": return software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class;
             case "jsii-calc.JavaReservedWords": return software.amazon.jsii.tests.calculator.JavaReservedWords.class;
             case "jsii-calc.Jsii487Derived": return software.amazon.jsii.tests.calculator.Jsii487Derived.class;
+            case "jsii-calc.Jsii496Derived": return software.amazon.jsii.tests.calculator.Jsii496Derived.class;
             case "jsii-calc.JsiiAgent": return software.amazon.jsii.tests.calculator.JsiiAgent.class;
             case "jsii-calc.LoadBalancedFargateServiceProps": return software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps.class;
             case "jsii-calc.Multiply": return software.amazon.jsii.tests.calculator.Multiply.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
@@ -1,0 +1,14 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+public interface IJsii496 extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii496 {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+            super(mode);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
@@ -1,0 +1,13 @@
+package software.amazon.jsii.tests.calculator;
+
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii496Derived")
+public class Jsii496Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii496 {
+    protected Jsii496Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+    public Jsii496Derived() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1298,6 +1298,18 @@ class _IJsii487External2Proxy():
     __jsii_type__ = "jsii-calc.IJsii487External2"
     pass
 
+@jsii.interface(jsii_type="jsii-calc.IJsii496")
+class IJsii496(jsii.compat.Protocol):
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _IJsii496Proxy
+
+    pass
+
+class _IJsii496Proxy():
+    __jsii_type__ = "jsii-calc.IJsii496"
+    pass
+
 @jsii.interface(jsii_type="jsii-calc.IMutableObjectLiteral")
 class IMutableObjectLiteral(jsii.compat.Protocol):
     @staticmethod
@@ -1983,6 +1995,12 @@ class JavaReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JavaReserv
 class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
     def __init__(self) -> None:
         jsii.create(Jsii487Derived, self, [])
+
+
+@jsii.implements(IJsii496)
+class Jsii496Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii496Derived"):
+    def __init__(self) -> None:
+        jsii.create(Jsii496Derived, self, [])
 
 
 class JsiiAgent(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsiiAgent"):
@@ -3302,6 +3320,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -2877,6 +2877,35 @@ IJsii487External2 (interface)
 
 
 
+IJsii496 (interface)
+^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IJsii496
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IJsii496;
+
+      .. code-tab:: javascript
+
+         // IJsii496 is an interface
+
+      .. code-tab:: typescript
+
+         import { IJsii496 } from 'jsii-calc';
+
+
+
+
+
 IMutableObjectLiteral (interface)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3971,6 +4000,35 @@ Jsii487Derived
 
    :implements: :py:class:`~jsii-calc.IJsii487External2`\ 
    :implements: :py:class:`~jsii-calc.IJsii487External`\ 
+
+Jsii496Derived
+^^^^^^^^^^^^^^
+
+.. py:class:: Jsii496Derived()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.Jsii496Derived;
+
+      .. code-tab:: javascript
+
+         const { Jsii496Derived } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { Jsii496Derived } from 'jsii-calc';
+
+
+
+   :implements: :py:class:`~jsii-calc.IJsii496`\ 
 
 JsiiAgent
 ^^^^^^^^^

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -43,6 +43,7 @@ JSObjectLiteralToNative
 JSObjectLiteralToNativeClass
 JavaReservedWords
 Jsii487Derived
+Jsii496Derived
 JsiiAgent
 Multiply
 Negate

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -639,6 +639,10 @@ assemblies
  │   │ ├── interfaces: IJsii487External2,IJsii487External
  │   │ └─┬ members
  │   │   └── <initializer>() initializer
+ │   ├─┬ class Jsii496Derived
+ │   │ ├── interfaces: IJsii496
+ │   │ └─┬ members
+ │   │   └── <initializer>() initializer
  │   ├─┬ class JsiiAgent
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -1362,6 +1366,8 @@ assemblies
  │   ├─┬ interface IJsii487External
  │   │ └── members
  │   ├─┬ interface IJsii487External2
+ │   │ └── members
+ │   ├─┬ interface IJsii496
  │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -61,6 +61,8 @@ assemblies
  │   ├── class JavaReservedWords
  │   ├─┬ class Jsii487Derived
  │   │ └── interfaces: IJsii487External2,IJsii487External
+ │   ├─┬ class Jsii496Derived
+ │   │ └── interfaces: IJsii496
  │   ├── class JsiiAgent
  │   ├─┬ class Multiply
  │   │ ├── base: BinaryOperation
@@ -136,6 +138,7 @@ assemblies
  │   ├── interface IJSII417PublicBaseOfBase
  │   ├── interface IJsii487External
  │   ├── interface IJsii487External2
+ │   ├── interface IJsii496
  │   ├── interface IMutableObjectLiteral
  │   ├─┬ interface INonInternalInterface
  │   │ └─┬ interfaces

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -298,6 +298,9 @@ assemblies
  │   ├─┬ class Jsii487Derived
  │   │ └─┬ members
  │   │   └── <initializer>() initializer
+ │   ├─┬ class Jsii496Derived
+ │   │ └─┬ members
+ │   │   └── <initializer>() initializer
  │   ├─┬ class JsiiAgent
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -601,6 +604,8 @@ assemblies
  │   ├─┬ interface IJsii487External
  │   │ └── members
  │   ├─┬ interface IJsii487External2
+ │   │ └── members
+ │   ├─┬ interface IJsii496
  │   │ └── members
  │   ├─┬ interface IMutableObjectLiteral
  │   │ └─┬ members

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -44,6 +44,7 @@ assemblies
  │   ├── class JSObjectLiteralToNativeClass
  │   ├── class JavaReservedWords
  │   ├── class Jsii487Derived
+ │   ├── class Jsii496Derived
  │   ├── class JsiiAgent
  │   ├── class Multiply
  │   ├── class Negate
@@ -98,6 +99,7 @@ assemblies
  │   ├── interface IJSII417PublicBaseOfBase
  │   ├── interface IJsii487External
  │   ├── interface IJsii487External2
+ │   ├── interface IJsii496
  │   ├── interface IMutableObjectLiteral
  │   ├── interface INonInternalInterface
  │   ├── interface IPrivatelyImplemented

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -505,10 +505,12 @@ export class Assembler implements Emitter {
     }
 
     // process all "implements" clauses
-    jsiiType.interfaces = jsiiType.interfaces || [];
+    const allInterfaces = new Set<string>();
     for (const clause of implementsClauses) {
       const { interfaces } = await this._processBaseInterfaces(fqn, clause.types.map(t => this._typeChecker.getTypeFromTypeNode(t)));
-      jsiiType.interfaces.push(...(interfaces || []).map(i => i.fqn));
+      for (const ifc of (interfaces || [])) {
+        allInterfaces.add(ifc.fqn);
+      }
       if (interfaces) {
         this._deferUntilTypesAvailable(jsiiType.fqn, interfaces, type.symbol.valueDeclaration, (...ifaces) => {
           for (const iface of ifaces) {
@@ -522,8 +524,8 @@ export class Assembler implements Emitter {
       }
     }
 
-    if (jsiiType.interfaces.length === 0) {
-      delete jsiiType.interfaces;
+    if (allInterfaces.size > 0) {
+      jsiiType.interfaces = Array.from(allInterfaces);
     }
 
     if (!type.isClass()) {


### PR DESCRIPTION
When processing interfaces from multiple declaration sites (e.g.
when a base class is erased), we need to make sure that only
include every interface once.

Fixes #496

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
