### PR TITLE
fix(jsii-diff): catch exception if type disappeared from other assembly

### DIFF
--- a/packages/jsii-diff/lib/type-analysis.ts
+++ b/packages/jsii-diff/lib/type-analysis.ts
@@ -64,10 +64,16 @@ export function isSuperType(a: reflect.TypeReference, b: reflect.TypeReference, 
   // and the NEW type system.
   // We could do more complex analysis on typing of methods, but it doesn't seem
   // worth it.
-  const A = a.type!; // Note: lookup in old type system!
-  const B = b.type!;
-  if (A.isInterfaceType() && A.isDataType() && B.isInterfaceType() && B.datatype) {
-    return isStructuralSuperType(A, B, updatedSystem);
+  try {
+    const A = a.type!; // Note: lookup in old type system!
+    const B = b.type!;
+    if (A.isInterfaceType() && A.isDataType() && B.isInterfaceType() && B.datatype) {
+      return isStructuralSuperType(A, B, updatedSystem);
+    }
+  } catch (e) {
+    // We might get an exception if the type is supposed to come from a different
+    // assembly and the lookup fails.
+    return { success: false, reasons: [e.message] };
   }
 
   // All seems good


### PR DESCRIPTION
Make jsii-diff not crash in the following case:

- Assembly A depends on Assembly B, and they both update simultaneously.
- Assembly A' uses a return type T' freshly introduced in Assembly B'.

When doing the supertype check, the compatibility check of A -> A',
the lookup of T' inside B would lead to an exception, which would
crash the tool.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
