### PR TITLE
feat(jsii): protect against prohibited member names

### DIFF
--- a/packages/jsii/test/negatives/neg.prohibited-member-name.ts
+++ b/packages/jsii/test/negatives/neg.prohibited-member-name.ts
@@ -1,0 +1,8 @@
+// tslint:disable-next-line:comment-format
+///!MATCH_ERROR:Prohibited member name: equals
+
+export class SomeClass {
+  public equals(): boolean {
+    return true;
+  }
+}


### PR DESCRIPTION
We are not currently rigged to handle some special methods
that have meaning in runtimes that we target (specifically,
'equals', 'hashCode' and 'GetHashCode'). Just prohibit them for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
