### PR TITLE
feat(jsii-spec): Add optional metadata field

### DIFF
--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -25,6 +25,13 @@
       },
       "sphinx": {}
     },
+    "metadata": {
+      "jsii:boolean": true,
+      "jsii:number": 1337,
+      "jsii:object": {
+        "string": "yes!"
+      }
+    },
     "versionFormat": "short"
   },
   "scripts": {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -185,6 +185,13 @@
   "homepage": "https://github.com/awslabs/jsii.git",
   "jsiiVersion": "0.11.0",
   "license": "Apache-2.0",
+  "metadata": {
+    "jsii:boolean": true,
+    "jsii:number": 1337,
+    "jsii:object": {
+      "string": "yes!"
+    }
+  },
   "name": "jsii-calc",
   "readme": {
     "markdown": "# jsii Calculator\n\nThis library is used to demonstrate and test the features of JSII\n\n## Sphinx\n\nThis file will be incorporated into the sphinx documentation.\n\nIf this file starts with an \"H1\" line (in our case `# jsii Calculator`), this\nheading will be used as the Sphinx topic name. Otherwise, the name of the module\n(`jsii-calc`) will be used instead.\n\n\n\n\n"
@@ -6803,5 +6810,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "bKi31JLqJ4B9MMHdwaDdxTQlL4VG06izio0DqYMQnt4="
+  "fingerprint": "i8GdLx7YlhttP5/pB0dKItig1wFkp/DwDdUtbYsIdfc="
 }

--- a/packages/jsii-dotnet-generator/build.sh
+++ b/packages/jsii-dotnet-generator/build.sh
@@ -3,12 +3,7 @@ set -euo pipefail
 
 npm run gen
 
-# TODO: Auto-rev NuGet package versions on each local build.
-# Because we we don't rev the versions, dotnet will pick
-# up an old build from the cache if it exists. So we
-# explicitly clear the cache as a temporary workaround.
-dotnet nuget locals all --clear
-dotnet build -c Release ./src/Amazon.JSII.Generator.sln
+dotnet build --force -c Release ./src/Amazon.JSII.Generator.sln
 dotnet publish -c Release src/Amazon.JSII.Generator.CLI/
 
 mkdir -p cli

--- a/packages/jsii-dotnet-jsonmodel/build.sh
+++ b/packages/jsii-dotnet-jsonmodel/build.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 npm run gen
 
-# TODO: Auto-rev NuGet package versions on each local build.
-# Because we we don't rev the versions, dotnet will pick
-# up an old build from the cache if it exists. So we
-# explicitly clear the cache as a temporary workaround.
-dotnet nuget locals all --clear
-dotnet build -c Release ./src/Amazon.JSII.JsonModel.sln
+dotnet build --force -c Release ./src/Amazon.JSII.JsonModel.sln
 
 cp -f ./bin/Release/NuGet/*.nupkg .

--- a/packages/jsii-dotnet-runtime-test/build.sh
+++ b/packages/jsii-dotnet-runtime-test/build.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-# TODO: Auto-rev NuGet package versions on each local build.
-# Because we we don't rev the versions, dotnet will pick
-# up an old build from the cache if it exists. So we
-# explicitly clear the cache as a temporary workaround.
-dotnet nuget locals all --clear
-dotnet build -c Release ./test/Amazon.JSII.Runtime.IntegrationTests
+dotnet build --force -c Release ./test/Amazon.JSII.Runtime.IntegrationTests

--- a/packages/jsii-dotnet-runtime/build.sh
+++ b/packages/jsii-dotnet-runtime/build.sh
@@ -6,15 +6,9 @@ bundle_dir="src/Amazon.JSII.Runtime/jsii-runtime"
 mkdir -p ${bundle_dir}
 rsync -av node_modules/jsii-runtime/webpack/ ${bundle_dir}
 
-# TODO: Auto-rev NuGet package versions on each local build.
-# Because we we don't rev the versions, dotnet will pick
-# up an old build from the cache if it exists. So we
-# explicitly clear the cache as a temporary workaround.
-dotnet nuget locals all --clear
-
 # Build just Runtime and it's dependencies instead of the
 # solution to avoid integration tests from trying to be
 # built before the calc packages are generated.
-dotnet build -c Release ./src/Amazon.JSII.Runtime
+dotnet build --force -c Release ./src/Amazon.JSII.Runtime
 
 cp -f ./bin/Release/NuGet/*.nupkg .

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -163,9 +163,7 @@ import { VERSION_DESC } from '../lib/version';
         // ``argv.target`` is guaranteed valid by ``yargs`` through the ``choices`` directive.
         const targetConstructor = targetConstructors[targetName];
         if (!targetConstructor) {
-            // tslint:disable-next-line: no-console
-            console.log(`Warning: Skipping unsupported target '${targetName}'`);
-            return;
+            throw new Error(`Unsupported target ${targetName}`);
         }
 
         const target = new targetConstructor({

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -163,7 +163,9 @@ import { VERSION_DESC } from '../lib/version';
         // ``argv.target`` is guaranteed valid by ``yargs`` through the ``choices`` directive.
         const targetConstructor = targetConstructors[targetName];
         if (!targetConstructor) {
-            throw new Error(`Unsupported target ${targetName}`);
+            // tslint:disable-next-line: no-console
+            console.log(`Warning: Skipping unsupported target '${targetName}'`);
+            return;
         }
 
         const target = new targetConstructor({

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -185,6 +185,13 @@
   "homepage": "https://github.com/awslabs/jsii.git",
   "jsiiVersion": "0.11.0",
   "license": "Apache-2.0",
+  "metadata": {
+    "jsii:boolean": true,
+    "jsii:number": 1337,
+    "jsii:object": {
+      "string": "yes!"
+    }
+  },
   "name": "jsii-calc",
   "readme": {
     "markdown": "# jsii Calculator\n\nThis library is used to demonstrate and test the features of JSII\n\n## Sphinx\n\nThis file will be incorporated into the sphinx documentation.\n\nIf this file starts with an \"H1\" line (in our case `# jsii Calculator`), this\nheading will be used as the Sphinx topic name. Otherwise, the name of the module\n(`jsii-calc`) will be used instead.\n\n\n\n\n"
@@ -6803,5 +6810,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "bKi31JLqJ4B9MMHdwaDdxTQlL4VG06izio0DqYMQnt4="
+  "fingerprint": "i8GdLx7YlhttP5/pB0dKItig1wFkp/DwDdUtbYsIdfc="
 }

--- a/packages/jsii-spec/lib/spec.ts
+++ b/packages/jsii-spec/lib/spec.ts
@@ -97,6 +97,15 @@ export interface Assembly extends Documentable {
     targets?: AssemblyTargets;
 
     /**
+     * Arbitrary key-value pairs of metadata, which the maintainer chose to
+     * document with the assembly. These entries do not carry normative
+     * semantics and their interpretation is up to the assembly maintainer.
+     *
+     * @default none
+     */
+    metadata?: { [key: string]: any };
+
+    /**
      * Direct dependencies on other assemblies (with semver), the key is the JSII
      * assembly name.
      *

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -114,6 +114,7 @@ export class Assembler implements Emitter {
       bundled: this.projectInfo.bundleDependencies,
       types: this._types,
       targets: this.projectInfo.targets,
+      metadata: this.projectInfo.metadata,
       readme,
       jsiiVersion,
       fingerprint: '<TBD>',

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -32,6 +32,7 @@ export interface ProjectInfo {
     readonly transitiveDependencies: ReadonlyArray<spec.Assembly>;
     readonly bundleDependencies?: { readonly [name: string]: string };
     readonly targets: spec.AssemblyTargets;
+    readonly metadata?: { [key: string]: any };
     readonly jsiiVersionFormat: 'short' | 'full';
     readonly description?: string;
     readonly homepage?: string;
@@ -123,6 +124,7 @@ export async function loadProjectInfo(projectRoot: string, { fixPeerDependencies
             ..._required(pkg.jsii, 'The "package.json" file must specify the "jsii" attribute').targets,
             js: { npm: pkg.name }
         },
+        metadata: pkg.jsii && pkg.jsii.metadata,
         jsiiVersionFormat: _validateVersionFormat(pkg.jsii.versionFormat || 'full'),
 
         description: pkg.description,


### PR DESCRIPTION
This can be used to track free-form maintainer data, for use in systems that
are not part of the standard JSII toolchain. For example, it can be used to
encode configuration behavior for proprietary tools that process assemblies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
