### PR TITLE
fix(python): support variadic arguments

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -479,8 +479,6 @@ abstract class BaseMethod implements PythonBase {
         }
 
         code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${modifiedParamNames.join(", ")}])`);
-
-        // code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${paramNames.join(", ")}])`);
     }
 
     private getLiftedProperties(resolver: TypeResolver): spec.Property[] {

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -472,7 +472,15 @@ abstract class BaseMethod implements PythonBase {
             paramNames.push(toPythonParameterName(param.name));
         }
 
-        code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${paramNames.join(", ")}])`);
+        // If the args are variadic, expand the last one
+        const modifiedParamNames: string[] = paramNames.slice();
+        if (this.parameters.length >= 1 && this.parameters[this.parameters.length - 1].variadic) {
+            modifiedParamNames.push("*" + modifiedParamNames.pop());
+        }
+
+        code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${modifiedParamNames.join(", ")}])`);
+
+        // code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${paramNames.join(", ")}])`);
     }
 
     private getLiftedProperties(resolver: TypeResolver): spec.Property[] {

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -467,14 +467,10 @@ abstract class BaseMethod implements PythonBase {
             jsiiMethodParams.push(`"${this.jsName}"`);
         }
 
+        // If the last arg is variadic, expand the tuple
         const paramNames: string[] = [];
         for (const param of this.parameters) {
-            paramNames.push(toPythonParameterName(param.name));
-        }
-
-        // If the args are variadic, expand the last one
-        if (this.parameters.length >= 1 && this.parameters[this.parameters.length - 1].variadic) {
-            paramNames.push("*" + paramNames.pop());
+            paramNames.push((param.variadic ? '*' : '') + toPythonParameterName(param.name));
         }
 
         code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${paramNames.join(", ")}])`);

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -473,12 +473,11 @@ abstract class BaseMethod implements PythonBase {
         }
 
         // If the args are variadic, expand the last one
-        const modifiedParamNames: string[] = paramNames.slice();
         if (this.parameters.length >= 1 && this.parameters[this.parameters.length - 1].variadic) {
-            modifiedParamNames.push("*" + modifiedParamNames.pop());
+            paramNames.push("*" + paramNames.pop());
         }
 
-        code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${modifiedParamNames.join(", ")}])`);
+        code.line(`${methodPrefix}jsii.${this.jsiiMethod}(${jsiiMethodParams.join(", ")}, [${paramNames.join(", ")}])`);
     }
 
     private getLiftedProperties(resolver: TypeResolver): spec.Property[] {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -678,7 +678,7 @@ class DontComplainAboutVariadicAfterOptional(metaclass=jsii.JSIIMeta, jsii_type=
             optional: -
             things: -
         """
-        return jsii.invoke(self, "optionalAndVariadic", [optional, things])
+        return jsii.invoke(self, "optionalAndVariadic", [optional, *things])
 
 
 class EraseUndefinedHashValues(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.EraseUndefinedHashValues"):
@@ -2994,7 +2994,7 @@ class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMetho
         Arguments:
             prefix: a prefix that will be use for all values returned by ``#asArray``.
         """
-        jsii.create(VariadicMethod, self, [prefix])
+        jsii.create(VariadicMethod, self, [*prefix])
 
     @jsii.member(jsii_name="asArray")
     def as_array(self, first: jsii.Number, *others: jsii.Number) -> typing.List[jsii.Number]:
@@ -3003,7 +3003,7 @@ class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMetho
             first: the first element of the array to be returned (after the ``prefix`` provided at construction time).
             others: other elements to be included in the array.
         """
-        return jsii.invoke(self, "asArray", [first, others])
+        return jsii.invoke(self, "asArray", [first, *others])
 
 
 class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VirtualMethodPlayground"):

--- a/packages/jsii-python-runtime/tests/test_compliance.py
+++ b/packages/jsii-python-runtime/tests/test_compliance.py
@@ -42,6 +42,7 @@ from jsii_calc import (
     UsesInterfaceWithProperties,
     composition,
     EraseUndefinedHashValues,
+    VariadicMethod,
 )
 from scope.jsii_calc_lib import IFriendly, EnumFromScopedModule, Number
 
@@ -895,3 +896,8 @@ def test_objectIdDoesNotGetReallocatedWhenTheConstructorPassesThisOut():
     reflector = PartiallyInitializedThisConsumerImpl()
     obj = ConstructorPassesThisOut(reflector)
     assert obj is not None
+
+
+def test_variadicMethodCanBeInvoked():
+    variadic = VariadicMethod(1)
+    assert variadic.as_array(3, 4, 5, 6) == [1, 3, 4, 5, 6]


### PR DESCRIPTION
Fixes #483 

Handles variadic args and adds a test of VariadicMethod to the compliance tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
