### PR TITLE
feat(jsii): Propagate stability to members

### DIFF
--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -122,6 +122,7 @@
     "@scope/jsii-calc-lib.EnumFromScopedModule": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
+        "stability": "deprecated",
         "summary": "Check that enums from \\@scoped packages can be references. See awslabs/jsii#138."
       },
       "fqn": "@scope/jsii-calc-lib.EnumFromScopedModule",
@@ -132,9 +133,15 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "deprecated"
+          },
           "name": "Value1"
         },
         {
+          "docs": {
+            "stability": "deprecated"
+          },
           "name": "Value2"
         }
       ],
@@ -143,6 +150,7 @@
     "@scope/jsii-calc-lib.IDoublable": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
+        "stability": "deprecated",
         "summary": "The general contract for a concrete number."
       },
       "fqn": "@scope/jsii-calc-lib.IDoublable",
@@ -155,6 +163,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -171,6 +182,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
         "remarks": "These classes can be greeted with\na \"hello\" or \"goodbye\" blessing and they will respond back in a fun and friendly manner.",
+        "stability": "deprecated",
         "summary": "Applies to classes that are considered friendly."
       },
       "fqn": "@scope/jsii-calc-lib.IFriendly",
@@ -183,6 +195,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -203,6 +216,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
         "remarks": "Their presence validates that .NET/Java/jsii-reflect can track all fields\nfar enough up the tree.",
+        "stability": "deprecated",
         "summary": "Interface that inherits from packages 2 levels up the tree."
       },
       "fqn": "@scope/jsii-calc-lib.IThreeLevelsInterface",
@@ -217,6 +231,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "locationInModule": {
             "filename": "lib/index.ts",
             "line": 109
@@ -230,6 +247,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "datatype": true,
       "docs": {
+        "stability": "deprecated",
         "summary": "This is the first struct we have created in jsii."
       },
       "fqn": "@scope/jsii-calc-lib.MyFirstStruct",
@@ -243,6 +261,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "An awesome number value."
           },
           "immutable": true,
@@ -258,6 +277,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "A string value."
           },
           "immutable": true,
@@ -272,6 +292,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -294,11 +317,13 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-lib.Value",
       "docs": {
+        "stability": "deprecated",
         "summary": "Represents a concrete number."
       },
       "fqn": "@scope/jsii-calc-lib.Number",
       "initializer": {
         "docs": {
+          "stability": "deprecated",
           "summary": "Creates a Number object."
         },
         "parameters": [
@@ -325,6 +350,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "The number multiplied by 2."
           },
           "immutable": true,
@@ -340,6 +366,7 @@
         },
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "The number."
           },
           "immutable": true,
@@ -360,6 +387,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-lib.Value",
       "docs": {
+        "stability": "deprecated",
         "summary": "Represents an operation on values."
       },
       "fqn": "@scope/jsii-calc-lib.Operation",
@@ -373,6 +401,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -394,6 +423,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "datatype": true,
       "docs": {
+        "stability": "deprecated",
         "summary": "This is a struct with only optional properties."
       },
       "fqn": "@scope/jsii-calc-lib.StructWithOnlyOptionals",
@@ -407,6 +437,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "The first optional!"
           },
           "immutable": true,
@@ -422,6 +453,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -435,6 +469,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -453,6 +490,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-base.Base",
       "docs": {
+        "stability": "deprecated",
         "summary": "Abstract class which represents a numeric value."
       },
       "fqn": "@scope/jsii-calc-lib.Value",
@@ -465,6 +503,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -484,6 +523,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "The value."
           },
           "immutable": true,
@@ -500,5 +540,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "x/BbPdAJTYB6QY83ucqo0CNLa2NoLebqPMbMY7BsyR4="
+  "fingerprint": "ysbOu5OVvyznNc3J8nCmLW9NRtZwUTw4YgeMb8c+OPA="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -230,6 +230,9 @@
       "abstract": true,
       "assembly": "jsii-calc",
       "base": "jsii-calc.AbstractClassBase",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClass",
       "initializer": {},
       "interfaces": [
@@ -243,6 +246,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1072
@@ -263,6 +269,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1068
@@ -278,6 +287,9 @@
       "name": "AbstractClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -294,6 +306,9 @@
     "jsii-calc.AbstractClassBase": {
       "abstract": true,
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClassBase",
       "initializer": {},
       "kind": "class",
@@ -305,6 +320,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -319,6 +337,9 @@
     },
     "jsii-calc.AbstractClassReturner": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClassReturner",
       "initializer": {},
       "kind": "class",
@@ -328,6 +349,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1090
@@ -340,6 +364,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1094
@@ -355,6 +382,9 @@
       "name": "AbstractClassReturner",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -371,11 +401,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.BinaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The \"+\" binary operation."
       },
       "fqn": "jsii-calc.Add",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -407,6 +439,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -426,6 +459,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -445,6 +479,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "The setters will validate\nthat the value set is of the expected type and throw otherwise.",
+        "stability": "experimental",
         "summary": "This class includes property for all types supported by jsii."
       },
       "fqn": "jsii-calc.AllTypes",
@@ -456,6 +491,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 207
@@ -471,6 +509,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 199
@@ -483,6 +524,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 194
@@ -506,6 +550,9 @@
       "name": "AllTypes",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -517,6 +564,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 154
@@ -532,6 +582,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 155
@@ -547,6 +600,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 153
@@ -557,6 +613,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 139
@@ -572,6 +631,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 45
@@ -582,6 +644,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 91
@@ -592,6 +657,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 174
@@ -602,6 +670,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 108
@@ -612,6 +683,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 124
@@ -627,6 +701,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 76
@@ -637,6 +714,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 60
@@ -647,6 +727,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 166
@@ -671,6 +754,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 167
@@ -698,6 +784,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 165
@@ -723,6 +812,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 160
@@ -738,6 +830,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 161
@@ -753,6 +848,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 159
@@ -763,6 +861,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 171
@@ -777,6 +878,9 @@
     },
     "jsii-calc.AllTypesEnum": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AllTypesEnum",
       "kind": "enum",
       "locationInModule": {
@@ -785,12 +889,21 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "MyEnumValue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "YourEnumValue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "ThisIsGreat"
         }
       ],
@@ -798,6 +911,9 @@
     },
     "jsii-calc.AllowedMethodNames": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AllowedMethodNames",
       "initializer": {},
       "kind": "class",
@@ -807,6 +923,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 602
@@ -829,6 +948,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay."
           },
           "locationInModule": {
@@ -851,6 +971,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 613
@@ -879,6 +1002,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay."
           },
           "locationInModule": {
@@ -906,6 +1030,9 @@
     },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AsyncVirtualMethods",
       "initializer": {},
       "kind": "class",
@@ -916,6 +1043,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 309
@@ -930,6 +1060,7 @@
         {
           "async": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Just calls \"overrideMeToo\"."
           },
           "locationInModule": {
@@ -947,6 +1078,7 @@
           "async": true,
           "docs": {
             "remarks": "This is a \"double promise\" situation, which\nmeans that callbacks are not going to be available immediate, but only\nafter an \"immediates\" cycle.",
+            "stability": "experimental",
             "summary": "This method calls the \"callMe\" async method indirectly, which will then invoke a virtual method."
           },
           "locationInModule": {
@@ -961,6 +1093,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 342
@@ -974,6 +1109,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 313
@@ -995,6 +1133,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 317
@@ -1011,6 +1152,9 @@
     },
     "jsii-calc.AugmentableClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AugmentableClass",
       "initializer": {},
       "kind": "class",
@@ -1020,6 +1164,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1322
@@ -1027,6 +1174,9 @@
           "name": "methodOne"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1328
@@ -1041,11 +1191,13 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "Represents an operation with two operands."
       },
       "fqn": "jsii-calc.BinaryOperation",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -1080,6 +1232,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -1099,6 +1252,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Left-hand side operand."
           },
           "immutable": true,
@@ -1113,6 +1267,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Right-hand side operand."
           },
           "immutable": true,
@@ -1131,11 +1286,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "A calculator which maintains a current value and allows adding operations."
       },
       "fqn": "jsii-calc.Calculator",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a Calculator object."
         },
         "parameters": [
@@ -1159,6 +1316,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Adds a number to the current value."
           },
           "locationInModule": {
@@ -1177,6 +1335,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Multiplies the current value by a number."
           },
           "locationInModule": {
@@ -1195,6 +1354,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Negates the current value."
           },
           "locationInModule": {
@@ -1205,6 +1365,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Raises the current value by a power."
           },
           "locationInModule": {
@@ -1223,6 +1384,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns teh value of the union property (if defined)."
           },
           "locationInModule": {
@@ -1241,6 +1403,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the expression."
           },
           "immutable": true,
@@ -1256,6 +1419,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A log of all operations."
           },
           "immutable": true,
@@ -1275,6 +1439,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A map of per operation name of all operations performed."
           },
           "immutable": true,
@@ -1299,6 +1464,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The current value."
           },
           "locationInModule": {
@@ -1312,6 +1478,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The maximum value allows in this calculator."
           },
           "locationInModule": {
@@ -1326,6 +1493,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Example of a property that accepts a union of types."
           },
           "locationInModule": {
@@ -1356,6 +1524,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "Properties for Calculator."
       },
       "fqn": "jsii-calc.CalculatorProps",
@@ -1368,6 +1537,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -1381,6 +1553,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -1396,6 +1571,9 @@
     },
     "jsii-calc.ClassThatImplementsTheInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassThatImplementsTheInternalInterface",
       "initializer": {},
       "interfaces": [
@@ -1409,6 +1587,9 @@
       "name": "ClassThatImplementsTheInternalInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1564
@@ -1420,6 +1601,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1565
@@ -1431,6 +1615,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1566
@@ -1442,6 +1629,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1567
@@ -1455,6 +1645,9 @@
     },
     "jsii-calc.ClassThatImplementsThePrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassThatImplementsThePrivateInterface",
       "initializer": {},
       "interfaces": [
@@ -1468,6 +1661,9 @@
       "name": "ClassThatImplementsThePrivateInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1571
@@ -1479,6 +1675,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1572
@@ -1490,6 +1689,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1573
@@ -1501,6 +1703,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1574
@@ -1535,6 +1740,9 @@
     },
     "jsii-calc.ClassWithMutableObjectLiteralProperty": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
       "initializer": {},
       "kind": "class",
@@ -1545,6 +1753,9 @@
       "name": "ClassWithMutableObjectLiteralProperty",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1110
@@ -1559,6 +1770,7 @@
     "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Class that implements interface properties automatically, but using a private constructor."
       },
       "fqn": "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
@@ -1572,6 +1784,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1137
@@ -1602,6 +1817,9 @@
       "name": "ClassWithPrivateConstructorAndAutomaticProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1614,6 +1832,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1141
@@ -1628,8 +1849,14 @@
     },
     "jsii-calc.ConstructorPassesThisOut": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ConstructorPassesThisOut",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "consumer",
@@ -1648,6 +1875,9 @@
     },
     "jsii-calc.Constructors": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Constructors",
       "initializer": {},
       "kind": "class",
@@ -1657,6 +1887,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1377
@@ -1670,6 +1903,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1381
@@ -1688,6 +1924,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1385
@@ -1706,6 +1945,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1361
@@ -1719,6 +1961,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1365
@@ -1732,6 +1977,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1369
@@ -1745,6 +1993,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1373
@@ -1767,6 +2018,9 @@
     },
     "jsii-calc.ConsumersOfThisCrazyTypeSystem": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ConsumersOfThisCrazyTypeSystem",
       "initializer": {},
       "kind": "class",
@@ -1776,6 +2030,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1578
@@ -1796,6 +2053,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1582
@@ -1820,8 +2080,14 @@
     },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DefaultedConstructorArgument",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "arg1",
@@ -1854,6 +2120,9 @@
       "name": "DefaultedConstructorArgument",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1865,6 +2134,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1876,6 +2148,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2034,6 +2309,9 @@
     },
     "jsii-calc.DerivedClassHasNoProperties.Base": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Base",
       "initializer": {},
       "kind": "class",
@@ -2045,6 +2323,9 @@
       "namespace": "DerivedClassHasNoProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 299
@@ -2059,6 +2340,9 @@
     "jsii-calc.DerivedClassHasNoProperties.Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.DerivedClassHasNoProperties.Base",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Derived",
       "initializer": {},
       "kind": "class",
@@ -2073,6 +2357,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "A struct which derives from another struct."
       },
       "fqn": "jsii-calc.DerivedStruct",
@@ -2088,6 +2373,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2100,6 +2388,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2113,6 +2404,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "An example of a non primitive property."
           },
           "immutable": true,
@@ -2128,6 +2420,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "This is optional."
           },
           "immutable": true,
@@ -2148,6 +2441,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2161,6 +2457,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2181,6 +2480,9 @@
     },
     "jsii-calc.DoNotOverridePrivates": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DoNotOverridePrivates",
       "initializer": {},
       "kind": "class",
@@ -2190,6 +2492,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1128
@@ -2205,6 +2510,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1120
@@ -2217,6 +2525,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1124
@@ -2234,6 +2545,7 @@
     "jsii-calc.DoNotRecognizeAnyAsOptional": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#284: do not recognize \"any\" as an optional argument."
       },
       "fqn": "jsii-calc.DoNotRecognizeAnyAsOptional",
@@ -2245,6 +2557,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1163
@@ -2295,6 +2610,7 @@
           "docs": {
             "remarks": "This will print out a friendly greeting intended for\nthe indicated person.",
             "returns": "A number that everyone knows very well",
+            "stability": "stable",
             "summary": "Greet the indicated person."
           },
           "locationInModule": {
@@ -2336,6 +2652,9 @@
     },
     "jsii-calc.DontComplainAboutVariadicAfterOptional": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DontComplainAboutVariadicAfterOptional",
       "initializer": {},
       "kind": "class",
@@ -2345,6 +2664,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1214
@@ -2378,6 +2700,9 @@
     },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DoubleTrouble",
       "initializer": {},
       "interfaces": [
@@ -2391,6 +2716,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -2407,6 +2733,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -2426,6 +2753,9 @@
     },
     "jsii-calc.EraseUndefinedHashValues": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.EraseUndefinedHashValues",
       "initializer": {},
       "kind": "class",
@@ -2437,6 +2767,7 @@
         {
           "docs": {
             "remarks": "Used to check that undefined/null hash values\nare being erased when sending values from native code to JS.",
+            "stability": "experimental",
             "summary": "Returns `true` if `key` is defined in `opts`."
           },
           "locationInModule": {
@@ -2467,6 +2798,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "We expect \"prop1\" to be erased."
           },
           "locationInModule": {
@@ -2483,6 +2815,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "We expect \"prop2\" to be erased."
           },
           "locationInModule": {
@@ -2503,6 +2836,9 @@
     "jsii-calc.EraseUndefinedHashValuesOptions": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.EraseUndefinedHashValuesOptions",
       "kind": "interface",
       "locationInModule": {
@@ -2513,6 +2849,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2526,6 +2865,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2674,8 +3016,14 @@
     },
     "jsii-calc.ExportedBaseClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ExportedBaseClass",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "success",
@@ -2693,6 +3041,9 @@
       "name": "ExportedBaseClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2708,6 +3059,9 @@
     "jsii-calc.ExtendsInternalInterface": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ExtendsInternalInterface",
       "kind": "interface",
       "locationInModule": {
@@ -2718,6 +3072,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2730,6 +3087,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2744,6 +3104,9 @@
     },
     "jsii-calc.GiveMeStructs": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.GiveMeStructs",
       "initializer": {},
       "kind": "class",
@@ -2754,6 +3117,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct."
           },
           "locationInModule": {
@@ -2777,6 +3141,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the boolean from a DerivedStruct struct."
           },
           "locationInModule": {
@@ -2800,6 +3165,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the \"anumber\" from a MyFirstStruct struct;"
           },
           "locationInModule": {
@@ -2825,6 +3191,9 @@
       "name": "GiveMeStructs",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2841,6 +3210,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "These are some arguments you can pass to a method."
       },
       "fqn": "jsii-calc.Greetee",
@@ -2855,6 +3225,7 @@
           "abstract": true,
           "docs": {
             "default": "world",
+            "stability": "experimental",
             "summary": "The name of the greetee."
           },
           "immutable": true,
@@ -2872,6 +3243,9 @@
     },
     "jsii-calc.GreetingAugmenter": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.GreetingAugmenter",
       "initializer": {},
       "kind": "class",
@@ -2881,6 +3255,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 512
@@ -2905,6 +3282,9 @@
     },
     "jsii-calc.IAnotherPublicInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IAnotherPublicInterface",
       "kind": "interface",
       "locationInModule": {
@@ -2915,6 +3295,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1541
@@ -3017,6 +3400,9 @@
     },
     "jsii-calc.IExtendsPrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IExtendsPrivateInterface",
       "kind": "interface",
       "locationInModule": {
@@ -3027,6 +3413,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3044,6 +3433,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1516
@@ -3058,6 +3450,7 @@
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Even friendlier classes can implement this interface."
       },
       "fqn": "jsii-calc.IFriendlier",
@@ -3073,6 +3466,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -3090,6 +3484,7 @@
           "abstract": true,
           "docs": {
             "returns": "A goodbye blessing.",
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -3108,6 +3503,9 @@
     },
     "jsii-calc.IFriendlyRandomGenerator": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IFriendlyRandomGenerator",
       "interfaces": [
         "jsii-calc.IRandomNumberGenerator",
@@ -3123,6 +3521,7 @@
     "jsii-calc.IInterfaceImplementedByAbstractClass": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "awslabs/jsii#220 Abstract return type."
       },
       "fqn": "jsii-calc.IInterfaceImplementedByAbstractClass",
@@ -3135,6 +3534,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3150,6 +3552,7 @@
     "jsii-calc.IInterfaceThatShouldNotBeADataType": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."
       },
       "fqn": "jsii-calc.IInterfaceThatShouldNotBeADataType",
@@ -3165,6 +3568,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3179,6 +3585,9 @@
     },
     "jsii-calc.IInterfaceWithInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithInternal",
       "kind": "interface",
       "locationInModule": {
@@ -3188,6 +3597,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1480
@@ -3199,6 +3611,9 @@
     },
     "jsii-calc.IInterfaceWithMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithMethods",
       "kind": "interface",
       "locationInModule": {
@@ -3208,6 +3623,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1148
@@ -3219,6 +3637,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3234,6 +3655,7 @@
     "jsii-calc.IInterfaceWithOptionalMethodArguments": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."
       },
       "fqn": "jsii-calc.IInterfaceWithOptionalMethodArguments",
@@ -3245,6 +3667,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1051
@@ -3271,6 +3696,9 @@
     },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithProperties",
       "kind": "interface",
       "locationInModule": {
@@ -3281,6 +3709,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3293,6 +3724,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 567
@@ -3306,6 +3740,9 @@
     },
     "jsii-calc.IInterfaceWithPropertiesExtension": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithPropertiesExtension",
       "interfaces": [
         "jsii-calc.IInterfaceWithProperties"
@@ -3319,6 +3756,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 571
@@ -3332,6 +3772,9 @@
     },
     "jsii-calc.IJSII417Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJSII417Derived",
       "interfaces": [
         "jsii-calc.IJSII417PublicBaseOfBase"
@@ -3344,6 +3787,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 37
@@ -3352,6 +3798,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 40
@@ -3363,6 +3812,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3377,6 +3829,9 @@
     },
     "jsii-calc.IJSII417PublicBaseOfBase": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJSII417PublicBaseOfBase",
       "kind": "interface",
       "locationInModule": {
@@ -3386,6 +3841,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 33
@@ -3397,6 +3855,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3411,6 +3872,9 @@
     },
     "jsii-calc.IJsii487External": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii487External",
       "kind": "interface",
       "locationInModule": {
@@ -3421,6 +3885,9 @@
     },
     "jsii-calc.IJsii487External2": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii487External2",
       "kind": "interface",
       "locationInModule": {
@@ -3431,6 +3898,9 @@
     },
     "jsii-calc.IJsii496": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii496",
       "kind": "interface",
       "locationInModule": {
@@ -3441,6 +3911,9 @@
     },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IMutableObjectLiteral",
       "kind": "interface",
       "locationInModule": {
@@ -3451,6 +3924,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1106
@@ -3464,6 +3940,9 @@
     },
     "jsii-calc.INonInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.INonInternalInterface",
       "interfaces": [
         "jsii-calc.IAnotherPublicInterface"
@@ -3477,6 +3956,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1547
@@ -3488,6 +3970,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1551
@@ -3501,6 +3986,9 @@
     },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPrivatelyImplemented",
       "kind": "interface",
       "locationInModule": {
@@ -3511,6 +3999,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3525,6 +4016,9 @@
     },
     "jsii-calc.IPublicInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPublicInterface",
       "kind": "interface",
       "locationInModule": {
@@ -3534,6 +4028,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1339
@@ -3550,6 +4047,9 @@
     },
     "jsii-calc.IPublicInterface2": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPublicInterface2",
       "kind": "interface",
       "locationInModule": {
@@ -3559,6 +4059,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1343
@@ -3576,6 +4079,7 @@
     "jsii-calc.IRandomNumberGenerator": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Generates random numbers."
       },
       "fqn": "jsii-calc.IRandomNumberGenerator",
@@ -3589,6 +4093,7 @@
           "abstract": true,
           "docs": {
             "returns": "A random number.",
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -3607,6 +4112,9 @@
     },
     "jsii-calc.IReturnsNumber": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IReturnsNumber",
       "kind": "interface",
       "locationInModule": {
@@ -3616,6 +4124,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 619
@@ -3632,6 +4143,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3689,6 +4203,9 @@
     },
     "jsii-calc.ImplementInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementInternalInterface",
       "initializer": {},
       "kind": "class",
@@ -3699,6 +4216,9 @@
       "name": "ImplementInternalInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1524
@@ -3712,6 +4232,9 @@
     },
     "jsii-calc.ImplementsInterfaceWithInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsInterfaceWithInternal",
       "initializer": {},
       "interfaces": [
@@ -3724,6 +4247,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1487
@@ -3737,6 +4263,9 @@
     "jsii-calc.ImplementsInterfaceWithInternalSubclass": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.ImplementsInterfaceWithInternal",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsInterfaceWithInternalSubclass",
       "initializer": {},
       "kind": "class",
@@ -3748,6 +4277,9 @@
     },
     "jsii-calc.ImplementsPrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsPrivateInterface",
       "initializer": {},
       "kind": "class",
@@ -3758,6 +4290,9 @@
       "name": "ImplementsPrivateInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1528
@@ -3772,6 +4307,9 @@
     "jsii-calc.ImplictBaseOfBase": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplictBaseOfBase",
       "interfaces": [
         "@scope/jsii-calc-base.BaseProps"
@@ -3785,6 +4323,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3800,6 +4341,9 @@
     "jsii-calc.InbetweenClass": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.PublicClass",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InbetweenClass",
       "initializer": {},
       "interfaces": [
@@ -3812,6 +4356,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1346
@@ -3829,6 +4376,9 @@
     },
     "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
       "initializer": {},
       "kind": "class",
@@ -3840,6 +4390,9 @@
       "namespace": "InterfaceInNamespaceIncludesClasses",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1038
@@ -3855,6 +4408,9 @@
     "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
       "kind": "interface",
       "locationInModule": {
@@ -3866,6 +4422,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3881,6 +4440,9 @@
     "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello",
       "kind": "interface",
       "locationInModule": {
@@ -3892,6 +4454,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3907,8 +4472,14 @@
     "jsii-calc.JSII417Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.JSII417PublicBaseOfBase",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSII417Derived",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "property",
@@ -3925,6 +4496,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 23
@@ -3932,6 +4506,9 @@
           "name": "bar"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 26
@@ -3942,6 +4519,9 @@
       "name": "JSII417Derived",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3957,6 +4537,9 @@
     },
     "jsii-calc.JSII417PublicBaseOfBase": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSII417PublicBaseOfBase",
       "initializer": {},
       "kind": "class",
@@ -3966,6 +4549,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 11
@@ -3979,6 +4565,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 14
@@ -3989,6 +4578,9 @@
       "name": "JSII417PublicBaseOfBase",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -4003,6 +4595,9 @@
     },
     "jsii-calc.JSObjectLiteralForInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralForInterface",
       "initializer": {},
       "kind": "class",
@@ -4012,6 +4607,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 496
@@ -4024,6 +4622,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 502
@@ -4040,6 +4641,9 @@
     },
     "jsii-calc.JSObjectLiteralToNative": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralToNative",
       "initializer": {},
       "kind": "class",
@@ -4049,6 +4653,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 221
@@ -4065,6 +4672,9 @@
     },
     "jsii-calc.JSObjectLiteralToNativeClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralToNativeClass",
       "initializer": {},
       "kind": "class",
@@ -4075,6 +4685,9 @@
       "name": "JSObjectLiteralToNativeClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 230
@@ -4085,6 +4698,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 231
@@ -4098,6 +4714,9 @@
     },
     "jsii-calc.JavaReservedWords": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JavaReservedWords",
       "initializer": {},
       "kind": "class",
@@ -4107,6 +4726,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 715
@@ -4114,6 +4736,9 @@
           "name": "abstract"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 718
@@ -4121,6 +4746,9 @@
           "name": "assert"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 721
@@ -4128,6 +4756,9 @@
           "name": "boolean"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 724
@@ -4135,6 +4766,9 @@
           "name": "break"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 727
@@ -4142,6 +4776,9 @@
           "name": "byte"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 730
@@ -4149,6 +4786,9 @@
           "name": "case"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 733
@@ -4156,6 +4796,9 @@
           "name": "catch"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 736
@@ -4163,6 +4806,9 @@
           "name": "char"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 739
@@ -4170,6 +4816,9 @@
           "name": "class"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 742
@@ -4177,6 +4826,9 @@
           "name": "const"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 745
@@ -4184,6 +4836,9 @@
           "name": "continue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 748
@@ -4191,6 +4846,9 @@
           "name": "default"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 754
@@ -4198,6 +4856,9 @@
           "name": "do"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 751
@@ -4205,6 +4866,9 @@
           "name": "double"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 757
@@ -4212,6 +4876,9 @@
           "name": "else"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 760
@@ -4219,6 +4886,9 @@
           "name": "enum"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 763
@@ -4226,6 +4896,9 @@
           "name": "extends"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 766
@@ -4233,6 +4906,9 @@
           "name": "false"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 769
@@ -4240,6 +4916,9 @@
           "name": "final"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 772
@@ -4247,6 +4926,9 @@
           "name": "finally"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 775
@@ -4254,6 +4936,9 @@
           "name": "float"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 778
@@ -4261,6 +4946,9 @@
           "name": "for"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 781
@@ -4268,6 +4956,9 @@
           "name": "goto"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 784
@@ -4275,6 +4966,9 @@
           "name": "if"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 787
@@ -4282,6 +4976,9 @@
           "name": "implements"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 790
@@ -4289,6 +4986,9 @@
           "name": "import"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 793
@@ -4296,6 +4996,9 @@
           "name": "instanceof"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 796
@@ -4303,6 +5006,9 @@
           "name": "int"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 799
@@ -4310,6 +5016,9 @@
           "name": "interface"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 802
@@ -4317,6 +5026,9 @@
           "name": "long"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 805
@@ -4324,6 +5036,9 @@
           "name": "native"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 808
@@ -4331,6 +5046,9 @@
           "name": "new"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 811
@@ -4338,6 +5056,9 @@
           "name": "null"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 814
@@ -4345,6 +5066,9 @@
           "name": "package"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 817
@@ -4352,6 +5076,9 @@
           "name": "private"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 820
@@ -4359,6 +5086,9 @@
           "name": "protected"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 823
@@ -4366,6 +5096,9 @@
           "name": "public"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 826
@@ -4373,6 +5106,9 @@
           "name": "return"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 829
@@ -4380,6 +5116,9 @@
           "name": "short"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 832
@@ -4387,6 +5126,9 @@
           "name": "static"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 835
@@ -4394,6 +5136,9 @@
           "name": "strictfp"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 838
@@ -4401,6 +5146,9 @@
           "name": "super"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 841
@@ -4408,6 +5156,9 @@
           "name": "switch"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 844
@@ -4415,6 +5166,9 @@
           "name": "synchronized"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 847
@@ -4422,6 +5176,9 @@
           "name": "this"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 850
@@ -4429,6 +5186,9 @@
           "name": "throw"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 853
@@ -4436,6 +5196,9 @@
           "name": "throws"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 856
@@ -4443,6 +5206,9 @@
           "name": "transient"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 859
@@ -4450,6 +5216,9 @@
           "name": "true"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 862
@@ -4457,6 +5226,9 @@
           "name": "try"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 865
@@ -4464,6 +5236,9 @@
           "name": "void"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 868
@@ -4474,6 +5249,9 @@
       "name": "JavaReservedWords",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 871
@@ -4487,6 +5265,9 @@
     },
     "jsii-calc.Jsii487Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Jsii487Derived",
       "initializer": {},
       "interfaces": [
@@ -4502,6 +5283,9 @@
     },
     "jsii-calc.Jsii496Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Jsii496Derived",
       "initializer": {},
       "interfaces": [
@@ -4517,6 +5301,7 @@
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Host runtime version should be set via JSII_AGENT."
       },
       "fqn": "jsii-calc.JsiiAgent",
@@ -4530,6 +5315,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the value of the JSII_AGENT environment variable."
           },
           "immutable": true,
@@ -4550,6 +5336,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#298: show default values in sphinx documentation, and respect newlines."
       },
       "fqn": "jsii-calc.LoadBalancedFargateServiceProps",
@@ -4565,6 +5352,7 @@
           "docs": {
             "default": "80",
             "remarks": "Corresponds to container port mapping.",
+            "stability": "experimental",
             "summary": "The container port of the application load balancer attached to your Fargate service."
           },
           "immutable": true,
@@ -4583,6 +5371,7 @@
           "docs": {
             "default": "256",
             "remarks": "This default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "experimental",
             "summary": "The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments."
           },
           "immutable": true,
@@ -4601,6 +5390,7 @@
           "docs": {
             "default": "512",
             "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)\n\n1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)\n\n2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)\n\nBetween 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)\n\nBetween 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "experimental",
             "summary": "The amount (in MiB) of memory used by the task."
           },
           "immutable": true,
@@ -4618,6 +5408,7 @@
           "abstract": true,
           "docs": {
             "default": "true",
+            "stability": "experimental",
             "summary": "Determines whether the Application Load Balancer will be internet-facing."
           },
           "immutable": true,
@@ -4635,6 +5426,7 @@
           "abstract": true,
           "docs": {
             "default": "false",
+            "stability": "experimental",
             "summary": "Determines whether your Fargate Service will be assigned a public IP address."
           },
           "immutable": true,
@@ -4654,11 +5446,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.BinaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The \"*\" binary operation."
       },
       "fqn": "jsii-calc.Multiply",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -4694,6 +5488,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -4710,6 +5505,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -4726,6 +5522,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -4742,6 +5539,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -4761,6 +5559,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -4780,10 +5579,14 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.UnaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The negation operation (\"-value\")."
       },
       "fqn": "jsii-calc.Negate",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "operand",
@@ -4804,6 +5607,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -4820,6 +5624,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -4836,6 +5641,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -4852,6 +5658,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -4871,6 +5678,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -4889,6 +5697,7 @@
     "jsii-calc.NodeStandardLibrary": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Test fixture to verify that jsii modules can use the node standard library."
       },
       "fqn": "jsii-calc.NodeStandardLibrary",
@@ -4902,6 +5711,7 @@
         {
           "docs": {
             "returns": "\"6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50\"",
+            "stability": "experimental",
             "summary": "Uses node.js \"crypto\" module to calculate sha256 of a string."
           },
           "locationInModule": {
@@ -4919,6 +5729,7 @@
           "async": true,
           "docs": {
             "returns": "\"Hello, resource!\"",
+            "stability": "experimental",
             "summary": "Reads a local resource file (resource.txt) asynchronously."
           },
           "locationInModule": {
@@ -4935,6 +5746,7 @@
         {
           "docs": {
             "returns": "\"Hello, resource! SYNC!\"",
+            "stability": "experimental",
             "summary": "Sync version of fsReadFile."
           },
           "locationInModule": {
@@ -4953,6 +5765,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the current os.platform() from the \"os\" node module."
           },
           "immutable": true,
@@ -4970,10 +5783,14 @@
     "jsii-calc.NullShouldBeTreatedAsUndefined": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#282, aws-cdk#157: null should be treated as \"undefined\"."
       },
       "fqn": "jsii-calc.NullShouldBeTreatedAsUndefined",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "_param1",
@@ -4997,6 +5814,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1180
@@ -5013,6 +5833,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1186
@@ -5028,6 +5851,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1201
@@ -5038,6 +5864,9 @@
       "name": "NullShouldBeTreatedAsUndefined",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1172
@@ -5053,6 +5882,9 @@
     "jsii-calc.NullShouldBeTreatedAsUndefinedData": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.NullShouldBeTreatedAsUndefinedData",
       "kind": "interface",
       "locationInModule": {
@@ -5063,6 +5895,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5080,6 +5915,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5096,10 +5934,14 @@
     "jsii-calc.NumberGenerator": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "This allows us to test that a reference can be stored for objects that implement interfaces."
       },
       "fqn": "jsii-calc.NumberGenerator",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "generator",
@@ -5116,6 +5958,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 489
@@ -5136,6 +5981,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 485
@@ -5151,6 +5999,9 @@
       "name": "NumberGenerator",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 481
@@ -5165,6 +6016,7 @@
     "jsii-calc.ObjectRefsInCollections": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Verify that object references can be passed inside collections."
       },
       "fqn": "jsii-calc.ObjectRefsInCollections",
@@ -5177,6 +6029,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the sum of all values."
           },
           "locationInModule": {
@@ -5205,6 +6058,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the sum of all values in a map."
           },
           "locationInModule": {
@@ -5251,6 +6105,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "Doo wop that thing."
           },
           "locationInModule": {
@@ -5264,8 +6119,14 @@
     },
     "jsii-calc.OptionalConstructorArgument": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalConstructorArgument",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "arg1",
@@ -5296,6 +6157,9 @@
       "name": "OptionalConstructorArgument",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5307,6 +6171,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5318,6 +6185,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5334,6 +6204,9 @@
     "jsii-calc.OptionalStruct": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalStruct",
       "kind": "interface",
       "locationInModule": {
@@ -5344,6 +6217,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5359,8 +6235,14 @@
     },
     "jsii-calc.OptionalStructConsumer": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalStructConsumer",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "optionalStruct",
@@ -5379,6 +6261,9 @@
       "name": "OptionalStructConsumer",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5390,6 +6275,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5405,6 +6293,9 @@
     },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OverrideReturnsObject",
       "initializer": {},
       "kind": "class",
@@ -5414,6 +6305,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 625
@@ -5439,6 +6333,9 @@
     "jsii-calc.PartiallyInitializedThisConsumer": {
       "abstract": true,
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PartiallyInitializedThisConsumer",
       "initializer": {},
       "kind": "class",
@@ -5449,6 +6346,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1592
@@ -5485,6 +6385,9 @@
     },
     "jsii-calc.Polymorphism": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Polymorphism",
       "initializer": {},
       "kind": "class",
@@ -5494,6 +6397,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 471
@@ -5520,11 +6426,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The power operation."
       },
       "fqn": "jsii-calc.Power",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a Power operation."
         },
         "parameters": [
@@ -5557,6 +6465,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The base of the power."
           },
           "immutable": true,
@@ -5571,6 +6480,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -5586,6 +6496,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The number of times to multiply."
           },
           "immutable": true,
@@ -5602,6 +6513,9 @@
     },
     "jsii-calc.PublicClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PublicClass",
       "initializer": {},
       "kind": "class",
@@ -5611,6 +6525,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1336
@@ -5622,6 +6539,9 @@
     },
     "jsii-calc.PythonReservedWords": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PythonReservedWords",
       "initializer": {},
       "kind": "class",
@@ -5631,6 +6551,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 876
@@ -5638,6 +6561,9 @@
           "name": "and"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 878
@@ -5645,6 +6571,9 @@
           "name": "as"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 880
@@ -5652,6 +6581,9 @@
           "name": "assert"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 882
@@ -5659,6 +6591,9 @@
           "name": "async"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 884
@@ -5666,6 +6601,9 @@
           "name": "await"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 886
@@ -5673,6 +6611,9 @@
           "name": "break"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 888
@@ -5680,6 +6621,9 @@
           "name": "class"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 890
@@ -5687,6 +6631,9 @@
           "name": "continue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 892
@@ -5694,6 +6641,9 @@
           "name": "def"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 894
@@ -5701,6 +6651,9 @@
           "name": "del"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 896
@@ -5708,6 +6661,9 @@
           "name": "elif"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 898
@@ -5715,6 +6671,9 @@
           "name": "else"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 900
@@ -5722,6 +6681,9 @@
           "name": "except"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 902
@@ -5729,6 +6691,9 @@
           "name": "finally"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 904
@@ -5736,6 +6701,9 @@
           "name": "for"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 906
@@ -5743,6 +6711,9 @@
           "name": "from"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 908
@@ -5750,6 +6721,9 @@
           "name": "global"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 910
@@ -5757,6 +6731,9 @@
           "name": "if"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 912
@@ -5764,6 +6741,9 @@
           "name": "import"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 914
@@ -5771,6 +6751,9 @@
           "name": "in"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 916
@@ -5778,6 +6761,9 @@
           "name": "is"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 918
@@ -5785,6 +6771,9 @@
           "name": "lambda"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 920
@@ -5792,6 +6781,9 @@
           "name": "nonlocal"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 922
@@ -5799,6 +6791,9 @@
           "name": "not"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 924
@@ -5806,6 +6801,9 @@
           "name": "or"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 926
@@ -5813,6 +6811,9 @@
           "name": "pass"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 928
@@ -5820,6 +6821,9 @@
           "name": "raise"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 930
@@ -5827,6 +6831,9 @@
           "name": "return"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 932
@@ -5834,6 +6841,9 @@
           "name": "try"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 934
@@ -5841,6 +6851,9 @@
           "name": "while"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 936
@@ -5848,6 +6861,9 @@
           "name": "with"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 938
@@ -5860,6 +6876,7 @@
     "jsii-calc.ReferenceEnumFromScopedPackage": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "See awslabs/jsii#138."
       },
       "fqn": "jsii-calc.ReferenceEnumFromScopedPackage",
@@ -5871,6 +6888,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1013
@@ -5884,6 +6904,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1017
@@ -5902,6 +6925,9 @@
       "name": "ReferenceEnumFromScopedPackage",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1011
@@ -5919,6 +6945,7 @@
       "docs": {
         "returns": "an instance of an un-exported class that extends `ExportedBaseClass`, declared as `IPrivatelyImplemented`.",
         "see": "https://github.com/awslabs/jsii/issues/320",
+        "stability": "experimental",
         "summary": "Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class."
       },
       "fqn": "jsii-calc.ReturnsPrivateImplementationOfInterface",
@@ -5931,6 +6958,9 @@
       "name": "ReturnsPrivateImplementationOfInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5945,6 +6975,9 @@
     },
     "jsii-calc.RuntimeTypeChecking": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.RuntimeTypeChecking",
       "initializer": {},
       "kind": "class",
@@ -5954,6 +6987,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 271
@@ -5984,6 +7020,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 277
@@ -6001,6 +7040,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Used to verify verification of number of method arguments."
           },
           "locationInModule": {
@@ -6037,6 +7077,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "JSII clients can instantiate 2 different strongly-typed wrappers for the same\nobject. Unfortunately, this will break object equality, but if we didn't do\nthis it would break runtime type checks in the JVM or CLR.",
+        "stability": "experimental",
         "summary": "Test that a single instance can be returned under two different FQNs."
       },
       "fqn": "jsii-calc.SingleInstanceTwoTypes",
@@ -6048,6 +7089,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1400
@@ -6060,6 +7104,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1404
@@ -6211,6 +7258,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "https://github.com/awslabs/aws-cdk/issues/2304",
+        "stability": "experimental",
         "summary": "This is used to validate the ability to use `this` from within a static context."
       },
       "fqn": "jsii-calc.StaticContext",
@@ -6221,6 +7269,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1647
@@ -6237,6 +7288,9 @@
       "name": "StaticContext",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1655
@@ -6251,8 +7305,14 @@
     },
     "jsii-calc.Statics": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Statics",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "value",
@@ -6270,6 +7330,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static method."
           },
           "locationInModule": {
@@ -6296,6 +7357,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 671
@@ -6313,6 +7377,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Constants may also use all-caps."
           },
           "immutable": true,
@@ -6328,6 +7393,9 @@
         },
         {
           "const": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6342,6 +7410,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static property."
           },
           "immutable": true,
@@ -6358,6 +7427,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Constants can also use camelCase."
           },
           "immutable": true,
@@ -6378,6 +7448,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static getter. Jsdocs for static setter."
           },
           "locationInModule": {
@@ -6391,6 +7462,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 709
@@ -6402,6 +7476,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6416,6 +7493,9 @@
     },
     "jsii-calc.StringEnum": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.StringEnum",
       "kind": "enum",
       "locationInModule": {
@@ -6424,12 +7504,21 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "A"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "B"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "C"
         }
       ],
@@ -6437,6 +7526,9 @@
     },
     "jsii-calc.StripInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.StripInternal",
       "initializer": {},
       "kind": "class",
@@ -6447,6 +7539,9 @@
       "name": "StripInternal",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1448
@@ -6462,10 +7557,15 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "An operation that sums multiple values."
       },
       "fqn": "jsii-calc.Sum",
-      "initializer": {},
+      "initializer": {
+        "docs": {
+          "stability": "experimental"
+        }
+      },
       "kind": "class",
       "locationInModule": {
         "filename": "lib/calculator.ts",
@@ -6475,6 +7575,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -6490,6 +7591,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The parts to sum."
           },
           "locationInModule": {
@@ -6510,6 +7612,9 @@
     },
     "jsii-calc.SyncVirtualMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.SyncVirtualMethods",
       "initializer": {},
       "kind": "class",
@@ -6520,6 +7625,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 360
@@ -6532,6 +7640,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 348
@@ -6544,6 +7655,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 400
@@ -6559,6 +7673,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 372
@@ -6574,6 +7691,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 413
@@ -6586,6 +7706,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 404
@@ -6598,6 +7721,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 384
@@ -6610,6 +7736,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 376
@@ -6622,6 +7751,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 364
@@ -6642,6 +7774,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 417
@@ -6660,6 +7795,9 @@
       "name": "SyncVirtualMethods",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6671,6 +7809,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 411
@@ -6681,6 +7822,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 352
@@ -6691,6 +7835,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 390
@@ -6701,6 +7848,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 370
@@ -6711,6 +7861,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 398
@@ -6724,6 +7877,9 @@
     },
     "jsii-calc.Thrower": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Thrower",
       "initializer": {},
       "kind": "class",
@@ -6733,6 +7889,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 631
@@ -6747,10 +7906,14 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "An operation on a single operand."
       },
       "fqn": "jsii-calc.UnaryOperation",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "operand",
@@ -6768,6 +7931,9 @@
       "name": "UnaryOperation",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -6783,6 +7949,9 @@
     "jsii-calc.UnionProperties": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UnionProperties",
       "kind": "interface",
       "locationInModule": {
@@ -6793,6 +7962,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6817,6 +7989,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6841,6 +8016,9 @@
     },
     "jsii-calc.UseBundledDependency": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UseBundledDependency",
       "initializer": {},
       "kind": "class",
@@ -6850,6 +8028,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 947
@@ -6867,6 +8048,7 @@
     "jsii-calc.UseCalcBase": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Depend on a type from jsii-calc-base as a test for awslabs/jsii#128."
       },
       "fqn": "jsii-calc.UseCalcBase",
@@ -6878,6 +8060,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 996
@@ -6894,8 +8079,14 @@
     },
     "jsii-calc.UsesInterfaceWithProperties": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UsesInterfaceWithProperties",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "obj",
@@ -6912,6 +8103,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 579
@@ -6924,6 +8118,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 588
@@ -6944,6 +8141,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 583
@@ -6967,6 +8167,9 @@
       "name": "UsesInterfaceWithProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6981,8 +8184,14 @@
     },
     "jsii-calc.VariadicMethod": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.VariadicMethod",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "docs": {
@@ -7004,6 +8213,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 654
@@ -7047,6 +8259,9 @@
     },
     "jsii-calc.VirtualMethodPlayground": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.VirtualMethodPlayground",
       "initializer": {},
       "kind": "class",
@@ -7057,6 +8272,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 451
@@ -7077,6 +8295,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 455
@@ -7098,6 +8319,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 433
@@ -7119,6 +8343,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 424
@@ -7139,6 +8366,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 443
@@ -7166,6 +8396,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "- Implement `overrideMe` (method does not have to do anything).\n- Invoke `callMe`\n- Verify that `methodWasCalled` is `true`.",
+        "stability": "experimental",
         "summary": "This test is used to validate the runtimes can return correctly from a void callback."
       },
       "fqn": "jsii-calc.VoidCallback",
@@ -7177,6 +8408,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1678
@@ -7185,6 +8419,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1682
@@ -7196,6 +8433,9 @@
       "name": "VoidCallback",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -7213,6 +8453,7 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "Abstract operation composed from an expression of other operations."
       },
       "fqn": "jsii-calc.composition.CompositeOperation",
@@ -7225,6 +8466,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -7246,6 +8488,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -7260,6 +8503,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -7275,6 +8519,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A set of postfixes to include in a decorated .toString()."
           },
           "locationInModule": {
@@ -7293,6 +8538,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A set of prefixes to include in a decorated .toString()."
           },
           "locationInModule": {
@@ -7311,6 +8557,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The .toString() style."
           },
           "locationInModule": {
@@ -7327,6 +8574,7 @@
     "jsii-calc.composition.CompositeOperation.CompositionStringStyle": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Style of .toString() output for CompositeOperation."
       },
       "fqn": "jsii-calc.composition.CompositeOperation.CompositionStringStyle",
@@ -7338,12 +8586,14 @@
       "members": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Normal string expression."
           },
           "name": "Normal"
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Decorated string expression."
           },
           "name": "Decorated"
@@ -7354,5 +8604,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "aNWCih3NfgXU4mll5c+zKXj3ekSyaT9S+67MAugCfNo="
+  "fingerprint": "eOHyVzmCXMA46bGWMkxa9to4jM7N/B7DGm3TvKR6tNw="
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
@@ -52,16 +52,13 @@ namespace Amazon.JSII.Generator.Class
                         )
                     }));
 
-                    if (Type.Docs?.Deprecated != null)
+                    if (Type.Docs?.Stability == Stability.Deprecated)
                     {
+                        var argument = Type.Docs?.Deprecated != null ? SF.Literal(Type.Docs?.Deprecated).ToString() : "";
                         yield return SF.AttributeList(SF.SeparatedList(new[] {
                             SF.Attribute(
                                 SF.ParseName("System.Obsolete"),
-                                SF.AttributeArgumentList(
-                                    SF.SingletonSeparatedList(
-                                        SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(Type.Docs.Deprecated)))
-                                    )
-                                )
+                                SF.ParseAttributeArgumentList($"({argument})")
                             )
                         }));
                     }
@@ -215,19 +212,15 @@ namespace Amazon.JSII.Generator.Class
 
             SyntaxList<AttributeListSyntax> GetAttributeLists()
             {
-                var deprecated = Type.Initializer?.Docs?.Deprecated;
-                if (deprecated == null)
+                if (Type.Initializer?.Docs?.Stability != Stability.Deprecated)
                 {
                     return SF.List<AttributeListSyntax>();
                 }
+                var argument = Type.Initializer?.Docs?.Deprecated != null ? SF.Literal(Type.Initializer?.Docs?.Deprecated).ToString() : "";
                 return SF.List(new[] { SF.AttributeList(SF.SingletonSeparatedList(
                     SF.Attribute(
                         SF.ParseName("System.Obsolete"),
-                        SF.AttributeArgumentList(
-                            SF.SingletonSeparatedList(
-                                SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(deprecated)))
-                            )
-                        )
+                        SF.ParseAttributeArgumentList($"({argument})")
                     )
                 )) });
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Enum/EnumGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Enum/EnumGenerator.cs
@@ -44,16 +44,13 @@ namespace Amazon.JSII.Generator.Enum
                     )
                 }));
 
-                if (Type.Docs?.Deprecated != null)
+                if (Type.Docs?.Stability == Stability.Deprecated)
                 {
+                    var argument = Type.Docs?.Deprecated != null ? SF.Literal(Type.Docs?.Deprecated).ToString() : "";
                     yield return SF.AttributeList(SF.SeparatedList(new[] {
                             SF.Attribute(
                                 SF.ParseName("System.Obsolete"),
-                                SF.AttributeArgumentList(
-                                    SF.SingletonSeparatedList(
-                                        SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(Type.Docs.Deprecated)))
-                                    )
-                                )
+                                SF.ParseAttributeArgumentList($"({argument})")
                             )
                         }));
                 }
@@ -94,10 +91,11 @@ namespace Amazon.JSII.Generator.Enum
 
                     if (member.Docs?.Stability == Stability.Deprecated)
                     {
+                        var argument = member.Docs?.Deprecated != null ? SF.Literal(member.Docs?.Deprecated).ToString() : "";
                         yield return SF.AttributeList(SF.SingletonSeparatedList(
                             SF.Attribute(
                                 SF.ParseName("System.Obsolete"),
-                                SF.ParseAttributeArgumentList($"({SF.Literal(member.Docs?.Deprecated ?? "")})")
+                                SF.ParseAttributeArgumentList($"({argument})")
                             )
                         ));
                     }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
@@ -45,16 +45,13 @@ namespace Amazon.JSII.Generator.Interface
                         )
                     }));
 
-                    if (Type.Docs?.Deprecated != null)
+                    if (Type.Docs?.Stability == Stability.Deprecated)
                     {
+                        var argument = Type.Docs?.Deprecated != null ? SF.Literal(Type.Docs?.Deprecated).ToString() : "";
                         yield return SF.AttributeList(SF.SeparatedList(new[] {
                             SF.Attribute(
                                 SF.ParseName("System.Obsolete"),
-                                SF.AttributeArgumentList(
-                                    SF.SingletonSeparatedList(
-                                        SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(Type.Docs.Deprecated)))
-                                    )
-                                )
+                                SF.ParseAttributeArgumentList($"({argument})")
                             )
                         }));
                     }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/MethodGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/MethodGeneratorBase.cs
@@ -202,15 +202,12 @@ namespace Amazon.JSII.Generator
                     SF.ParseAttributeArgumentList($"({argumentList})")
                 )));
 
-                if (Method.Docs?.Deprecated != null)
+                if (Method.Docs?.Stability == Stability.Deprecated)
                 {
+                    var argument = Method.Docs?.Deprecated != null ? SF.Literal(Method.Docs?.Deprecated).ToString() : "";
                     yield return SF.AttributeList(SF.SingletonSeparatedList(SF.Attribute(
                         SF.ParseName("System.Obsolete"),
-                        SF.AttributeArgumentList(
-                            SF.SingletonSeparatedList(
-                                SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(Method.Docs.Deprecated)))
-                            )
-                        )
+                        SF.ParseAttributeArgumentList($"({argument})")
                     )));
                 }
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/PropertyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/PropertyGeneratorBase.cs
@@ -180,15 +180,12 @@ namespace Amazon.JSII.Generator
                     SF.ParseAttributeArgumentList($"({argumentList})")
                 )));
 
-                if (Property.Docs?.Deprecated != null)
+                if (Property.Docs?.Stability == Stability.Deprecated)
                 {
+                    var argument = Property.Docs?.Deprecated != null ? SF.Literal(Property.Docs?.Deprecated).ToString() : "";
                     yield return SF.AttributeList(SF.SingletonSeparatedList(SF.Attribute(
                         SF.ParseName("System.Obsolete"),
-                        SF.AttributeArgumentList(
-                            SF.SingletonSeparatedList(
-                                SF.AttributeArgument(SF.LiteralExpression(SyntaxKind.StringLiteralExpression, SF.Literal(Property.Docs.Deprecated)))
-                            )
-                        )
+                        SF.ParseAttributeArgumentList($"({argument})")
                     )));
                 }
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
@@ -48,10 +48,11 @@ namespace Amazon.JSII.Generator
 
                     if (Type.Docs?.Stability == Stability.Deprecated)
                     {
+                        var argument = Type.Docs?.Deprecated != null ? SF.Literal(Type.Docs?.Deprecated).ToString() : "";
                         yield return SF.AttributeList(SF.SingletonSeparatedList(
                             SF.Attribute(
                                 SF.ParseName("System.Obsolete"),
-                                SF.ParseAttributeArgumentList($"({SF.Literal(Type.Docs?.Deprecated ?? "")})")
+                                SF.ParseAttributeArgumentList($"({argument})")
                             )
                         ));
                     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -122,6 +122,7 @@
     "@scope/jsii-calc-lib.EnumFromScopedModule": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
+        "stability": "deprecated",
         "summary": "Check that enums from \\@scoped packages can be references. See awslabs/jsii#138."
       },
       "fqn": "@scope/jsii-calc-lib.EnumFromScopedModule",
@@ -132,9 +133,15 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "deprecated"
+          },
           "name": "Value1"
         },
         {
+          "docs": {
+            "stability": "deprecated"
+          },
           "name": "Value2"
         }
       ],
@@ -143,6 +150,7 @@
     "@scope/jsii-calc-lib.IDoublable": {
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
+        "stability": "deprecated",
         "summary": "The general contract for a concrete number."
       },
       "fqn": "@scope/jsii-calc-lib.IDoublable",
@@ -155,6 +163,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -171,6 +182,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
         "remarks": "These classes can be greeted with\na \"hello\" or \"goodbye\" blessing and they will respond back in a fun and friendly manner.",
+        "stability": "deprecated",
         "summary": "Applies to classes that are considered friendly."
       },
       "fqn": "@scope/jsii-calc-lib.IFriendly",
@@ -183,6 +195,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -203,6 +216,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "docs": {
         "remarks": "Their presence validates that .NET/Java/jsii-reflect can track all fields\nfar enough up the tree.",
+        "stability": "deprecated",
         "summary": "Interface that inherits from packages 2 levels up the tree."
       },
       "fqn": "@scope/jsii-calc-lib.IThreeLevelsInterface",
@@ -217,6 +231,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "locationInModule": {
             "filename": "lib/index.ts",
             "line": 109
@@ -230,6 +247,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "datatype": true,
       "docs": {
+        "stability": "deprecated",
         "summary": "This is the first struct we have created in jsii."
       },
       "fqn": "@scope/jsii-calc-lib.MyFirstStruct",
@@ -243,6 +261,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "An awesome number value."
           },
           "immutable": true,
@@ -258,6 +277,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "A string value."
           },
           "immutable": true,
@@ -272,6 +292,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -294,11 +317,13 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-lib.Value",
       "docs": {
+        "stability": "deprecated",
         "summary": "Represents a concrete number."
       },
       "fqn": "@scope/jsii-calc-lib.Number",
       "initializer": {
         "docs": {
+          "stability": "deprecated",
           "summary": "Creates a Number object."
         },
         "parameters": [
@@ -325,6 +350,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "The number multiplied by 2."
           },
           "immutable": true,
@@ -340,6 +366,7 @@
         },
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "The number."
           },
           "immutable": true,
@@ -360,6 +387,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-lib.Value",
       "docs": {
+        "stability": "deprecated",
         "summary": "Represents an operation on values."
       },
       "fqn": "@scope/jsii-calc-lib.Operation",
@@ -373,6 +401,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -394,6 +423,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "datatype": true,
       "docs": {
+        "stability": "deprecated",
         "summary": "This is a struct with only optional properties."
       },
       "fqn": "@scope/jsii-calc-lib.StructWithOnlyOptionals",
@@ -407,6 +437,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "The first optional!"
           },
           "immutable": true,
@@ -422,6 +453,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -435,6 +469,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "deprecated"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
@@ -453,6 +490,7 @@
       "assembly": "@scope/jsii-calc-lib",
       "base": "@scope/jsii-calc-base.Base",
       "docs": {
+        "stability": "deprecated",
         "summary": "Abstract class which represents a numeric value."
       },
       "fqn": "@scope/jsii-calc-lib.Value",
@@ -465,6 +503,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -484,6 +523,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "deprecated",
             "summary": "The value."
           },
           "immutable": true,
@@ -500,5 +540,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "x/BbPdAJTYB6QY83ucqo0CNLa2NoLebqPMbMY7BsyR4="
+  "fingerprint": "ysbOu5OVvyznNc3J8nCmLW9NRtZwUTw4YgeMb8c+OPA="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/EnumFromScopedModule.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/EnumFromScopedModule.cs
@@ -3,12 +3,18 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Check that enums from \@scoped packages can be references. See awslabs/jsii#138.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiEnum(nativeType: typeof(EnumFromScopedModule), fullyQualifiedName: "@scope/jsii-calc-lib.EnumFromScopedModule")]
+    [System.Obsolete()]
     public enum EnumFromScopedModule
     {
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiEnumMember(name: "Value1")]
+        [System.Obsolete()]
         Value1,
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiEnumMember(name: "Value2")]
+        [System.Obsolete()]
         Value2
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
@@ -3,14 +3,18 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>The general contract for a concrete number.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIDoublable), fullyQualifiedName: "@scope/jsii-calc-lib.IDoublable")]
+    [System.Obsolete()]
     internal sealed class IDoublableProxy : DeputyBase, IIDoublable
     {
         private IDoublableProxy(ByRefValue reference): base(reference)
         {
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "doubleValue", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public double DoubleValue
         {
             get => GetInstanceProperty<double>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
@@ -6,8 +6,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// These classes can be greeted with
     /// a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+    /// stability: Deprecated
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendly), fullyQualifiedName: "@scope/jsii-calc-lib.IFriendly")]
+    [System.Obsolete()]
     internal sealed class IFriendlyProxy : DeputyBase, IIFriendly
     {
         private IFriendlyProxy(ByRefValue reference): base(reference)
@@ -15,7 +17,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        [System.Obsolete()]
         public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIDoublable.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIDoublable.cs
@@ -3,10 +3,14 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>The general contract for a concrete number.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiInterface(nativeType: typeof(IIDoublable), fullyQualifiedName: "@scope/jsii-calc-lib.IDoublable")]
+    [System.Obsolete()]
     public interface IIDoublable
     {
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "doubleValue", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         double DoubleValue
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIFriendly.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIFriendly.cs
@@ -6,12 +6,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// These classes can be greeted with
     /// a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+    /// stability: Deprecated
     /// </remarks>
     [JsiiInterface(nativeType: typeof(IIFriendly), fullyQualifiedName: "@scope/jsii-calc-lib.IFriendly")]
+    [System.Obsolete()]
     public interface IIFriendly
     {
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        [System.Obsolete()]
         string Hello();
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIThreeLevelsInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIThreeLevelsInterface.cs
@@ -7,11 +7,15 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// Their presence validates that .NET/Java/jsii-reflect can track all fields
     /// far enough up the tree.
+    /// stability: Deprecated
     /// </remarks>
     [JsiiInterface(nativeType: typeof(IIThreeLevelsInterface), fullyQualifiedName: "@scope/jsii-calc-lib.IThreeLevelsInterface")]
+    [System.Obsolete()]
     public interface IIThreeLevelsInterface : IIBaseInterface
     {
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "baz")]
+        [System.Obsolete()]
         void Baz();
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IMyFirstStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IMyFirstStruct.cs
@@ -3,24 +3,32 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is the first struct we have created in jsii.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiInterface(nativeType: typeof(IMyFirstStruct), fullyQualifiedName: "@scope/jsii-calc-lib.MyFirstStruct")]
+    [System.Obsolete()]
     public interface IMyFirstStruct
     {
         /// <summary>An awesome number value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "anumber", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         double Anumber
         {
             get;
         }
 
         /// <summary>A string value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "astring", typeJson: "{\"primitive\":\"string\"}")]
+        [System.Obsolete()]
         string Astring
         {
             get;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "firstOptional", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true)]
+        [System.Obsolete()]
         string[] FirstOptional
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IStructWithOnlyOptionals.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IStructWithOnlyOptionals.cs
@@ -3,23 +3,31 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is a struct with only optional properties.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiInterface(nativeType: typeof(IStructWithOnlyOptionals), fullyQualifiedName: "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
+    [System.Obsolete()]
     public interface IStructWithOnlyOptionals
     {
         /// <summary>The first optional!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional1", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
+        [System.Obsolete()]
         string Optional1
         {
             get;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional2", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
+        [System.Obsolete()]
         double? Optional2
         {
             get;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional3", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
+        [System.Obsolete()]
         bool? Optional3
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IThreeLevelsInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IThreeLevelsInterfaceProxy.cs
@@ -6,15 +6,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// Their presence validates that .NET/Java/jsii-reflect can track all fields
     /// far enough up the tree.
+    /// stability: Deprecated
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(IIThreeLevelsInterface), fullyQualifiedName: "@scope/jsii-calc-lib.IThreeLevelsInterface")]
+    [System.Obsolete()]
     internal sealed class IThreeLevelsInterfaceProxy : DeputyBase, IIThreeLevelsInterface
     {
         private IThreeLevelsInterfaceProxy(ByRefValue reference): base(reference)
         {
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "baz")]
+        [System.Obsolete()]
         public void Baz()
         {
             InvokeInstanceVoidMethod(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
@@ -3,11 +3,14 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is the first struct we have created in jsii.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiByValue]
     public class MyFirstStruct : IMyFirstStruct
     {
         /// <summary>An awesome number value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "anumber", typeJson: "{\"primitive\":\"number\"}", isOverride: true)]
+        [System.Obsolete()]
         public double Anumber
         {
             get;
@@ -15,14 +18,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>A string value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "astring", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        [System.Obsolete()]
         public string Astring
         {
             get;
             set;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "firstOptional", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true, isOverride: true)]
+        [System.Obsolete()]
         public string[] FirstOptional
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
@@ -3,7 +3,9 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is the first struct we have created in jsii.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IMyFirstStruct), fullyQualifiedName: "@scope/jsii-calc-lib.MyFirstStruct")]
+    [System.Obsolete()]
     internal sealed class MyFirstStructProxy : DeputyBase, IMyFirstStruct
     {
         private MyFirstStructProxy(ByRefValue reference): base(reference)
@@ -11,20 +13,26 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>An awesome number value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "anumber", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public double Anumber
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>A string value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "astring", typeJson: "{\"primitive\":\"string\"}")]
+        [System.Obsolete()]
         public string Astring
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "firstOptional", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true)]
+        [System.Obsolete()]
         public string[] FirstOptional
         {
             get => GetInstanceProperty<string[]>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
@@ -3,32 +3,42 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Represents a concrete number.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Number), fullyQualifiedName: "@scope/jsii-calc-lib.Number", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
+    [System.Obsolete()]
     public class Number : Value_, IIDoublable
     {
         /// <summary>Creates a Number object.</summary>
         /// <param name = "value">The number.</param>
+        /// <remarks>stability: Deprecated</remarks>
+        [System.Obsolete()]
         public Number(double value): base(new DeputyProps(new object[]{value}))
         {
         }
 
+        [System.Obsolete()]
         protected Number(ByRefValue reference): base(reference)
         {
         }
 
+        [System.Obsolete()]
         protected Number(DeputyProps props): base(props)
         {
         }
 
         /// <summary>The number multiplied by 2.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "doubleValue", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public virtual double DoubleValue
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>The number.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public override double Value
         {
             get => GetInstanceProperty<double>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Operation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Operation.cs
@@ -3,7 +3,9 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Represents an operation on values.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Operation), fullyQualifiedName: "@scope/jsii-calc-lib.Operation")]
+    [System.Obsolete()]
     public abstract class Operation : Value_
     {
         protected Operation(): base(new DeputyProps(new object[]{}))
@@ -19,7 +21,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
+        [System.Obsolete()]
         public override abstract string ToString();
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
@@ -3,7 +3,9 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Represents an operation on values.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(Operation), fullyQualifiedName: "@scope/jsii-calc-lib.Operation")]
+    [System.Obsolete()]
     internal sealed class OperationProxy : Operation
     {
         private OperationProxy(ByRefValue reference): base(reference)
@@ -11,14 +13,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public override double Value
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
+        [System.Obsolete()]
         public override string ToString()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
@@ -3,25 +3,32 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is a struct with only optional properties.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiByValue]
     public class StructWithOnlyOptionals : IStructWithOnlyOptionals
     {
         /// <summary>The first optional!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional1", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
+        [System.Obsolete()]
         public string Optional1
         {
             get;
             set;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional2", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]
+        [System.Obsolete()]
         public double? Optional2
         {
             get;
             set;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional3", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true, isOverride: true)]
+        [System.Obsolete()]
         public bool? Optional3
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
@@ -3,7 +3,9 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>This is a struct with only optional properties.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IStructWithOnlyOptionals), fullyQualifiedName: "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
+    [System.Obsolete()]
     internal sealed class StructWithOnlyOptionalsProxy : DeputyBase, IStructWithOnlyOptionals
     {
         private StructWithOnlyOptionalsProxy(ByRefValue reference): base(reference)
@@ -11,19 +13,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>The first optional!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional1", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
+        [System.Obsolete()]
         public string Optional1
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional2", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
+        [System.Obsolete()]
         public double? Optional2
         {
             get => GetInstanceProperty<double? >();
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "optional3", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
+        [System.Obsolete()]
         public bool? Optional3
         {
             get => GetInstanceProperty<bool? >();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
@@ -3,7 +3,9 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Abstract class which represents a numeric value.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(Value_), fullyQualifiedName: "@scope/jsii-calc-lib.Value")]
+    [System.Obsolete()]
     internal sealed class ValueProxy : Value_
     {
         private ValueProxy(ByRefValue reference): base(reference)
@@ -11,7 +13,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public override double Value
         {
             get => GetInstanceProperty<double>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Value_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Value_.cs
@@ -4,7 +4,9 @@ using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
     /// <summary>Abstract class which represents a numeric value.</summary>
+    /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Value_), fullyQualifiedName: "@scope/jsii-calc-lib.Value")]
+    [System.Obsolete()]
     public abstract class Value_ : Base
     {
         protected Value_(): base(new DeputyProps(new object[]{}))
@@ -20,14 +22,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public virtual double Value
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        [System.Obsolete()]
         public override string ToString()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/EnumFromScopedModule.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/EnumFromScopedModule.java
@@ -4,8 +4,18 @@ package software.amazon.jsii.tests.calculator.lib;
  * Check that enums from \@scoped packages can be references. See awslabs/jsii#138.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.EnumFromScopedModule")
 public enum EnumFromScopedModule {
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     Value1,
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     Value2,
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -4,7 +4,13 @@ package software.amazon.jsii.tests.calculator.lib;
  * The general contract for a concrete number.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getDoubleValue();
 
     /**
@@ -15,7 +21,11 @@ public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getDoubleValue() {
             return this.jsiiGet("doubleValue", java.lang.Number.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -7,10 +7,14 @@ package software.amazon.jsii.tests.calculator.lib;
  * a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
     /**
      * Say hello!
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String hello();
 
     /**
@@ -24,6 +28,8 @@ public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
         /**
          * Say hello!
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
@@ -7,7 +7,13 @@ package software.amazon.jsii.tests.calculator.lib;
  * far enough up the tree.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IThreeLevelsInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.base.IBaseInterface {
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     void baz();
 
     /**
@@ -18,6 +24,10 @@ public interface IThreeLevelsInterface extends software.amazon.jsii.JsiiSerializ
             super(mode);
         }
 
+        /**
+         */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public void baz() {
             this.jsiiCall("baz", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -4,20 +4,32 @@ package software.amazon.jsii.tests.calculator.lib;
  * This is the first struct we have created in jsii.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     /**
      * An awesome number value.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getAnumber();
     /**
      * A string value.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String getAstring();
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.util.List<java.lang.String> getFirstOptional();
 
     /**
      * @return a {@link Builder} of {@link MyFirstStruct}
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     static Builder builder() {
         return new Builder();
     }
@@ -25,6 +37,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link MyFirstStruct}
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     final class Builder {
         private java.lang.Number _anumber;
         private java.lang.String _astring;
@@ -36,6 +50,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * @param value An awesome number value.
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withAnumber(final java.lang.Number value) {
             this._anumber = java.util.Objects.requireNonNull(value, "anumber is required");
             return this;
@@ -45,6 +61,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * @param value A string value.
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withAstring(final java.lang.String value) {
             this._astring = java.util.Objects.requireNonNull(value, "astring is required");
             return this;
@@ -54,6 +72,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this._firstOptional = value;
             return this;
@@ -64,6 +84,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link MyFirstStruct}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public MyFirstStruct build() {
             return new MyFirstStruct() {
                 private final java.lang.Number $anumber = java.util.Objects.requireNonNull(_anumber, "anumber is required");
@@ -111,6 +133,8 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * An awesome number value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getAnumber() {
             return this.jsiiGet("anumber", java.lang.Number.class);
         }
@@ -119,11 +143,17 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          * A string value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.String getAstring() {
             return this.jsiiGet("astring", java.lang.String.class);
         }
 
+        /**
+         */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @javax.annotation.Nullable
         public java.util.List<java.lang.String> getFirstOptional() {
             return this.jsiiGet("firstOptional", java.util.List.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -4,6 +4,8 @@ package software.amazon.jsii.tests.calculator.lib;
  * Represents a concrete number.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Number")
 public class Number extends software.amazon.jsii.tests.calculator.lib.Value implements software.amazon.jsii.tests.calculator.lib.IDoublable {
     protected Number(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -14,6 +16,8 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
      * 
      * @param value The number.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public Number(final java.lang.Number value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
@@ -23,6 +27,8 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
      * The number multiplied by 2.
      */
     @Override
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public java.lang.Number getDoubleValue() {
         return this.jsiiGet("doubleValue", java.lang.Number.class);
     }
@@ -31,6 +37,8 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
      * The number.
      */
     @Override
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -4,6 +4,8 @@ package software.amazon.jsii.tests.calculator.lib;
  * Represents an operation on values.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Operation")
 public abstract class Operation extends software.amazon.jsii.tests.calculator.lib.Value {
     protected Operation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -17,6 +19,8 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
     /**
      * String representation of the value.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Override
     public abstract java.lang.String toString();
 
@@ -32,6 +36,8 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
          * The value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
@@ -39,6 +45,8 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
         /**
          * String representation of the value.
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -4,17 +4,31 @@ package software.amazon.jsii.tests.calculator.lib;
  * This is a struct with only optional properties.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerializable {
     /**
      * The first optional!
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String getOptional1();
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getOptional2();
+    /**
+     */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Boolean getOptional3();
 
     /**
      * @return a {@link Builder} of {@link StructWithOnlyOptionals}
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     static Builder builder() {
         return new Builder();
     }
@@ -22,6 +36,8 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
     /**
      * A builder for {@link StructWithOnlyOptionals}
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.String _optional1;
@@ -35,6 +51,8 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          * @param value The first optional!
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withOptional1(@javax.annotation.Nullable final java.lang.String value) {
             this._optional1 = value;
             return this;
@@ -44,6 +62,8 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          * @param value the value to be set
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withOptional2(@javax.annotation.Nullable final java.lang.Number value) {
             this._optional2 = value;
             return this;
@@ -53,6 +73,8 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          * @param value the value to be set
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withOptional3(@javax.annotation.Nullable final java.lang.Boolean value) {
             this._optional3 = value;
             return this;
@@ -63,6 +85,8 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          * @return a new instance of {@link StructWithOnlyOptionals}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public StructWithOnlyOptionals build() {
             return new StructWithOnlyOptionals() {
                 @javax.annotation.Nullable
@@ -112,18 +136,28 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          * The first optional!
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @javax.annotation.Nullable
         public java.lang.String getOptional1() {
             return this.jsiiGet("optional1", java.lang.String.class);
         }
 
+        /**
+         */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @javax.annotation.Nullable
         public java.lang.Number getOptional2() {
             return this.jsiiGet("optional2", java.lang.Number.class);
         }
 
+        /**
+         */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @javax.annotation.Nullable
         public java.lang.Boolean getOptional3() {
             return this.jsiiGet("optional3", java.lang.Boolean.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -4,6 +4,8 @@ package software.amazon.jsii.tests.calculator.lib;
  * Abstract class which represents a numeric value.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@Deprecated
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Value")
 public abstract class Value extends software.amazon.jsii.tests.calculator.base.Base {
     protected Value(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -17,6 +19,8 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
     /**
      * String representation of the value.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
@@ -24,6 +28,8 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
     /**
      * The value.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
@@ -40,6 +46,8 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
          * The value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/__init__.py
@@ -13,13 +13,29 @@ import scope.jsii_calc_base
 __jsii_assembly__ = jsii.JSIIAssembly.load("@scope/jsii-calc-lib", "0.11.0", __name__, "jsii-calc-lib@0.11.0.jsii.tgz")
 @jsii.enum(jsii_type="@scope/jsii-calc-lib.EnumFromScopedModule")
 class EnumFromScopedModule(enum.Enum):
-    """Check that enums from @scoped packages can be references. See awslabs/jsii#138."""
+    """Check that enums from @scoped packages can be references. See awslabs/jsii#138.
+
+    Stability:
+        deprecated
+    """
     Value1 = "Value1"
+    """
+    Stability:
+        deprecated
+    """
     Value2 = "Value2"
+    """
+    Stability:
+        deprecated
+    """
 
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IDoublable")
 class IDoublable(jsii.compat.Protocol):
-    """The general contract for a concrete number."""
+    """The general contract for a concrete number.
+
+    Stability:
+        deprecated
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IDoublableProxy
@@ -27,15 +43,27 @@ class IDoublable(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
+        """
+        Stability:
+            deprecated
+        """
         ...
 
 
 class _IDoublableProxy():
-    """The general contract for a concrete number."""
+    """The general contract for a concrete number.
+
+    Stability:
+        deprecated
+    """
     __jsii_type__ = "@scope/jsii-calc-lib.IDoublable"
     @property
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
+        """
+        Stability:
+            deprecated
+        """
         return jsii.get(self, "doubleValue")
 
 
@@ -45,6 +73,9 @@ class IFriendly(jsii.compat.Protocol):
 
     These classes can be greeted with
     a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+
+    Stability:
+        deprecated
     """
     @staticmethod
     def __jsii_proxy_class__():
@@ -52,7 +83,11 @@ class IFriendly(jsii.compat.Protocol):
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> str:
-        """Say hello!"""
+        """Say hello!
+
+        Stability:
+            deprecated
+        """
         ...
 
 
@@ -61,11 +96,18 @@ class _IFriendlyProxy():
 
     These classes can be greeted with
     a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+
+    Stability:
+        deprecated
     """
     __jsii_type__ = "@scope/jsii-calc-lib.IFriendly"
     @jsii.member(jsii_name="hello")
     def hello(self) -> str:
-        """Say hello!"""
+        """Say hello!
+
+        Stability:
+            deprecated
+        """
         return jsii.invoke(self, "hello", [])
 
 
@@ -75,6 +117,9 @@ class IThreeLevelsInterface(scope.jsii_calc_base.IBaseInterface, jsii.compat.Pro
 
     Their presence validates that .NET/Java/jsii-reflect can track all fields
     far enough up the tree.
+
+    Stability:
+        deprecated
     """
     @staticmethod
     def __jsii_proxy_class__():
@@ -82,6 +127,10 @@ class IThreeLevelsInterface(scope.jsii_calc_base.IBaseInterface, jsii.compat.Pro
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
+        """
+        Stability:
+            deprecated
+        """
         ...
 
 
@@ -90,38 +139,81 @@ class _IThreeLevelsInterfaceProxy(jsii.proxy_for(scope.jsii_calc_base.IBaseInter
 
     Their presence validates that .NET/Java/jsii-reflect can track all fields
     far enough up the tree.
+
+    Stability:
+        deprecated
     """
     __jsii_type__ = "@scope/jsii-calc-lib.IThreeLevelsInterface"
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
+        """
+        Stability:
+            deprecated
+        """
         return jsii.invoke(self, "baz", [])
 
 
 @jsii.data_type_optionals(jsii_struct_bases=[])
 class _MyFirstStruct(jsii.compat.TypedDict, total=False):
     firstOptional: typing.List[str]
+    """
+    Stability:
+        deprecated
+    """
 
 @jsii.data_type(jsii_type="@scope/jsii-calc-lib.MyFirstStruct", jsii_struct_bases=[_MyFirstStruct])
 class MyFirstStruct(_MyFirstStruct):
-    """This is the first struct we have created in jsii."""
+    """This is the first struct we have created in jsii.
+
+    Stability:
+        deprecated
+    """
     anumber: jsii.Number
-    """An awesome number value."""
+    """An awesome number value.
+
+    Stability:
+        deprecated
+    """
 
     astring: str
-    """A string value."""
+    """A string value.
+
+    Stability:
+        deprecated
+    """
 
 @jsii.data_type(jsii_type="@scope/jsii-calc-lib.StructWithOnlyOptionals", jsii_struct_bases=[])
 class StructWithOnlyOptionals(jsii.compat.TypedDict, total=False):
-    """This is a struct with only optional properties."""
+    """This is a struct with only optional properties.
+
+    Stability:
+        deprecated
+    """
     optional1: str
-    """The first optional!"""
+    """The first optional!
+
+    Stability:
+        deprecated
+    """
 
     optional2: jsii.Number
+    """
+    Stability:
+        deprecated
+    """
 
     optional3: bool
+    """
+    Stability:
+        deprecated
+    """
 
 class Value(scope.jsii_calc_base.Base, metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-lib.Value"):
-    """Abstract class which represents a numeric value."""
+    """Abstract class which represents a numeric value.
+
+    Stability:
+        deprecated
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _ValueProxy
@@ -131,14 +223,22 @@ class Value(scope.jsii_calc_base.Base, metaclass=jsii.JSIIAbstractClass, jsii_ty
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            deprecated
+        """
         return jsii.invoke(self, "toString", [])
 
     @property
     @jsii.member(jsii_name="value")
     @abc.abstractmethod
     def value(self) -> jsii.Number:
-        """The value."""
+        """The value.
+
+        Stability:
+            deprecated
+        """
         ...
 
 
@@ -146,36 +246,59 @@ class _ValueProxy(Value, jsii.proxy_for(scope.jsii_calc_base.Base)):
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """The value."""
+        """The value.
+
+        Stability:
+            deprecated
+        """
         return jsii.get(self, "value")
 
 
 @jsii.implements(IDoublable)
 class Number(Value, metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-lib.Number"):
-    """Represents a concrete number."""
+    """Represents a concrete number.
+
+    Stability:
+        deprecated
+    """
     def __init__(self, value: jsii.Number) -> None:
         """Creates a Number object.
 
         Arguments:
             value: The number.
+
+        Stability:
+            deprecated
         """
         jsii.create(Number, self, [value])
 
     @property
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
-        """The number multiplied by 2."""
+        """The number multiplied by 2.
+
+        Stability:
+            deprecated
+        """
         return jsii.get(self, "doubleValue")
 
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """The number."""
+        """The number.
+
+        Stability:
+            deprecated
+        """
         return jsii.get(self, "value")
 
 
 class Operation(Value, metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-lib.Operation"):
-    """Represents an operation on values."""
+    """Represents an operation on values.
+
+    Stability:
+        deprecated
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _OperationProxy
@@ -186,14 +309,22 @@ class Operation(Value, metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-
     @jsii.member(jsii_name="toString")
     @abc.abstractmethod
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            deprecated
+        """
         ...
 
 
 class _OperationProxy(Operation, jsii.proxy_for(Value)):
     @jsii.member(jsii_name="toString")
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            deprecated
+        """
         return jsii.invoke(self, "toString", [])
 
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -230,6 +230,9 @@
       "abstract": true,
       "assembly": "jsii-calc",
       "base": "jsii-calc.AbstractClassBase",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClass",
       "initializer": {},
       "interfaces": [
@@ -243,6 +246,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1072
@@ -263,6 +269,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1068
@@ -278,6 +287,9 @@
       "name": "AbstractClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -294,6 +306,9 @@
     "jsii-calc.AbstractClassBase": {
       "abstract": true,
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClassBase",
       "initializer": {},
       "kind": "class",
@@ -305,6 +320,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -319,6 +337,9 @@
     },
     "jsii-calc.AbstractClassReturner": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AbstractClassReturner",
       "initializer": {},
       "kind": "class",
@@ -328,6 +349,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1090
@@ -340,6 +364,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1094
@@ -355,6 +382,9 @@
       "name": "AbstractClassReturner",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -371,11 +401,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.BinaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The \"+\" binary operation."
       },
       "fqn": "jsii-calc.Add",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -407,6 +439,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -426,6 +459,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -445,6 +479,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "The setters will validate\nthat the value set is of the expected type and throw otherwise.",
+        "stability": "experimental",
         "summary": "This class includes property for all types supported by jsii."
       },
       "fqn": "jsii-calc.AllTypes",
@@ -456,6 +491,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 207
@@ -471,6 +509,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 199
@@ -483,6 +524,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 194
@@ -506,6 +550,9 @@
       "name": "AllTypes",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -517,6 +564,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 154
@@ -532,6 +582,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 155
@@ -547,6 +600,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 153
@@ -557,6 +613,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 139
@@ -572,6 +631,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 45
@@ -582,6 +644,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 91
@@ -592,6 +657,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 174
@@ -602,6 +670,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 108
@@ -612,6 +683,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 124
@@ -627,6 +701,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 76
@@ -637,6 +714,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 60
@@ -647,6 +727,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 166
@@ -671,6 +754,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 167
@@ -698,6 +784,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 165
@@ -723,6 +812,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 160
@@ -738,6 +830,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 161
@@ -753,6 +848,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 159
@@ -763,6 +861,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 171
@@ -777,6 +878,9 @@
     },
     "jsii-calc.AllTypesEnum": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AllTypesEnum",
       "kind": "enum",
       "locationInModule": {
@@ -785,12 +889,21 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "MyEnumValue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "YourEnumValue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "ThisIsGreat"
         }
       ],
@@ -798,6 +911,9 @@
     },
     "jsii-calc.AllowedMethodNames": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AllowedMethodNames",
       "initializer": {},
       "kind": "class",
@@ -807,6 +923,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 602
@@ -829,6 +948,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay."
           },
           "locationInModule": {
@@ -851,6 +971,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 613
@@ -879,6 +1002,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay."
           },
           "locationInModule": {
@@ -906,6 +1030,9 @@
     },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AsyncVirtualMethods",
       "initializer": {},
       "kind": "class",
@@ -916,6 +1043,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 309
@@ -930,6 +1060,7 @@
         {
           "async": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Just calls \"overrideMeToo\"."
           },
           "locationInModule": {
@@ -947,6 +1078,7 @@
           "async": true,
           "docs": {
             "remarks": "This is a \"double promise\" situation, which\nmeans that callbacks are not going to be available immediate, but only\nafter an \"immediates\" cycle.",
+            "stability": "experimental",
             "summary": "This method calls the \"callMe\" async method indirectly, which will then invoke a virtual method."
           },
           "locationInModule": {
@@ -961,6 +1093,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 342
@@ -974,6 +1109,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 313
@@ -995,6 +1133,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 317
@@ -1011,6 +1152,9 @@
     },
     "jsii-calc.AugmentableClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.AugmentableClass",
       "initializer": {},
       "kind": "class",
@@ -1020,6 +1164,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1322
@@ -1027,6 +1174,9 @@
           "name": "methodOne"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1328
@@ -1041,11 +1191,13 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "Represents an operation with two operands."
       },
       "fqn": "jsii-calc.BinaryOperation",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -1080,6 +1232,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -1099,6 +1252,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Left-hand side operand."
           },
           "immutable": true,
@@ -1113,6 +1267,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Right-hand side operand."
           },
           "immutable": true,
@@ -1131,11 +1286,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "A calculator which maintains a current value and allows adding operations."
       },
       "fqn": "jsii-calc.Calculator",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a Calculator object."
         },
         "parameters": [
@@ -1159,6 +1316,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Adds a number to the current value."
           },
           "locationInModule": {
@@ -1177,6 +1335,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Multiplies the current value by a number."
           },
           "locationInModule": {
@@ -1195,6 +1354,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Negates the current value."
           },
           "locationInModule": {
@@ -1205,6 +1365,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Raises the current value by a power."
           },
           "locationInModule": {
@@ -1223,6 +1384,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns teh value of the union property (if defined)."
           },
           "locationInModule": {
@@ -1241,6 +1403,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the expression."
           },
           "immutable": true,
@@ -1256,6 +1419,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A log of all operations."
           },
           "immutable": true,
@@ -1275,6 +1439,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A map of per operation name of all operations performed."
           },
           "immutable": true,
@@ -1299,6 +1464,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The current value."
           },
           "locationInModule": {
@@ -1312,6 +1478,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The maximum value allows in this calculator."
           },
           "locationInModule": {
@@ -1326,6 +1493,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Example of a property that accepts a union of types."
           },
           "locationInModule": {
@@ -1356,6 +1524,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "Properties for Calculator."
       },
       "fqn": "jsii-calc.CalculatorProps",
@@ -1368,6 +1537,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -1381,6 +1553,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -1396,6 +1571,9 @@
     },
     "jsii-calc.ClassThatImplementsTheInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassThatImplementsTheInternalInterface",
       "initializer": {},
       "interfaces": [
@@ -1409,6 +1587,9 @@
       "name": "ClassThatImplementsTheInternalInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1564
@@ -1420,6 +1601,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1565
@@ -1431,6 +1615,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1566
@@ -1442,6 +1629,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1567
@@ -1455,6 +1645,9 @@
     },
     "jsii-calc.ClassThatImplementsThePrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassThatImplementsThePrivateInterface",
       "initializer": {},
       "interfaces": [
@@ -1468,6 +1661,9 @@
       "name": "ClassThatImplementsThePrivateInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1571
@@ -1479,6 +1675,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1572
@@ -1490,6 +1689,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1573
@@ -1501,6 +1703,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1574
@@ -1535,6 +1740,9 @@
     },
     "jsii-calc.ClassWithMutableObjectLiteralProperty": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ClassWithMutableObjectLiteralProperty",
       "initializer": {},
       "kind": "class",
@@ -1545,6 +1753,9 @@
       "name": "ClassWithMutableObjectLiteralProperty",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1110
@@ -1559,6 +1770,7 @@
     "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Class that implements interface properties automatically, but using a private constructor."
       },
       "fqn": "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
@@ -1572,6 +1784,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1137
@@ -1602,6 +1817,9 @@
       "name": "ClassWithPrivateConstructorAndAutomaticProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1614,6 +1832,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1141
@@ -1628,8 +1849,14 @@
     },
     "jsii-calc.ConstructorPassesThisOut": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ConstructorPassesThisOut",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "consumer",
@@ -1648,6 +1875,9 @@
     },
     "jsii-calc.Constructors": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Constructors",
       "initializer": {},
       "kind": "class",
@@ -1657,6 +1887,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1377
@@ -1670,6 +1903,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1381
@@ -1688,6 +1924,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1385
@@ -1706,6 +1945,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1361
@@ -1719,6 +1961,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1365
@@ -1732,6 +1977,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1369
@@ -1745,6 +1993,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1373
@@ -1767,6 +2018,9 @@
     },
     "jsii-calc.ConsumersOfThisCrazyTypeSystem": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ConsumersOfThisCrazyTypeSystem",
       "initializer": {},
       "kind": "class",
@@ -1776,6 +2030,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1578
@@ -1796,6 +2053,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1582
@@ -1820,8 +2080,14 @@
     },
     "jsii-calc.DefaultedConstructorArgument": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DefaultedConstructorArgument",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "arg1",
@@ -1854,6 +2120,9 @@
       "name": "DefaultedConstructorArgument",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1865,6 +2134,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -1876,6 +2148,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2034,6 +2309,9 @@
     },
     "jsii-calc.DerivedClassHasNoProperties.Base": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Base",
       "initializer": {},
       "kind": "class",
@@ -2045,6 +2323,9 @@
       "namespace": "DerivedClassHasNoProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 299
@@ -2059,6 +2340,9 @@
     "jsii-calc.DerivedClassHasNoProperties.Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.DerivedClassHasNoProperties.Base",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DerivedClassHasNoProperties.Derived",
       "initializer": {},
       "kind": "class",
@@ -2073,6 +2357,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "A struct which derives from another struct."
       },
       "fqn": "jsii-calc.DerivedStruct",
@@ -2088,6 +2373,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2100,6 +2388,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2113,6 +2404,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "An example of a non primitive property."
           },
           "immutable": true,
@@ -2128,6 +2420,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "This is optional."
           },
           "immutable": true,
@@ -2148,6 +2441,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2161,6 +2457,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2181,6 +2480,9 @@
     },
     "jsii-calc.DoNotOverridePrivates": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DoNotOverridePrivates",
       "initializer": {},
       "kind": "class",
@@ -2190,6 +2492,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1128
@@ -2205,6 +2510,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1120
@@ -2217,6 +2525,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1124
@@ -2234,6 +2545,7 @@
     "jsii-calc.DoNotRecognizeAnyAsOptional": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#284: do not recognize \"any\" as an optional argument."
       },
       "fqn": "jsii-calc.DoNotRecognizeAnyAsOptional",
@@ -2245,6 +2557,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1163
@@ -2295,6 +2610,7 @@
           "docs": {
             "remarks": "This will print out a friendly greeting intended for\nthe indicated person.",
             "returns": "A number that everyone knows very well",
+            "stability": "stable",
             "summary": "Greet the indicated person."
           },
           "locationInModule": {
@@ -2336,6 +2652,9 @@
     },
     "jsii-calc.DontComplainAboutVariadicAfterOptional": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DontComplainAboutVariadicAfterOptional",
       "initializer": {},
       "kind": "class",
@@ -2345,6 +2664,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1214
@@ -2378,6 +2700,9 @@
     },
     "jsii-calc.DoubleTrouble": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.DoubleTrouble",
       "initializer": {},
       "interfaces": [
@@ -2391,6 +2716,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -2407,6 +2733,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -2426,6 +2753,9 @@
     },
     "jsii-calc.EraseUndefinedHashValues": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.EraseUndefinedHashValues",
       "initializer": {},
       "kind": "class",
@@ -2437,6 +2767,7 @@
         {
           "docs": {
             "remarks": "Used to check that undefined/null hash values\nare being erased when sending values from native code to JS.",
+            "stability": "experimental",
             "summary": "Returns `true` if `key` is defined in `opts`."
           },
           "locationInModule": {
@@ -2467,6 +2798,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "We expect \"prop1\" to be erased."
           },
           "locationInModule": {
@@ -2483,6 +2815,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "We expect \"prop2\" to be erased."
           },
           "locationInModule": {
@@ -2503,6 +2836,9 @@
     "jsii-calc.EraseUndefinedHashValuesOptions": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.EraseUndefinedHashValuesOptions",
       "kind": "interface",
       "locationInModule": {
@@ -2513,6 +2849,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2526,6 +2865,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2674,8 +3016,14 @@
     },
     "jsii-calc.ExportedBaseClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ExportedBaseClass",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "success",
@@ -2693,6 +3041,9 @@
       "name": "ExportedBaseClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2708,6 +3059,9 @@
     "jsii-calc.ExtendsInternalInterface": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ExtendsInternalInterface",
       "kind": "interface",
       "locationInModule": {
@@ -2718,6 +3072,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2730,6 +3087,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2744,6 +3104,9 @@
     },
     "jsii-calc.GiveMeStructs": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.GiveMeStructs",
       "initializer": {},
       "kind": "class",
@@ -2754,6 +3117,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct."
           },
           "locationInModule": {
@@ -2777,6 +3141,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the boolean from a DerivedStruct struct."
           },
           "locationInModule": {
@@ -2800,6 +3165,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the \"anumber\" from a MyFirstStruct struct;"
           },
           "locationInModule": {
@@ -2825,6 +3191,9 @@
       "name": "GiveMeStructs",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -2841,6 +3210,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "These are some arguments you can pass to a method."
       },
       "fqn": "jsii-calc.Greetee",
@@ -2855,6 +3225,7 @@
           "abstract": true,
           "docs": {
             "default": "world",
+            "stability": "experimental",
             "summary": "The name of the greetee."
           },
           "immutable": true,
@@ -2872,6 +3243,9 @@
     },
     "jsii-calc.GreetingAugmenter": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.GreetingAugmenter",
       "initializer": {},
       "kind": "class",
@@ -2881,6 +3255,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 512
@@ -2905,6 +3282,9 @@
     },
     "jsii-calc.IAnotherPublicInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IAnotherPublicInterface",
       "kind": "interface",
       "locationInModule": {
@@ -2915,6 +3295,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1541
@@ -3017,6 +3400,9 @@
     },
     "jsii-calc.IExtendsPrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IExtendsPrivateInterface",
       "kind": "interface",
       "locationInModule": {
@@ -3027,6 +3413,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3044,6 +3433,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1516
@@ -3058,6 +3450,7 @@
     "jsii-calc.IFriendlier": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Even friendlier classes can implement this interface."
       },
       "fqn": "jsii-calc.IFriendlier",
@@ -3073,6 +3466,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -3090,6 +3484,7 @@
           "abstract": true,
           "docs": {
             "returns": "A goodbye blessing.",
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -3108,6 +3503,9 @@
     },
     "jsii-calc.IFriendlyRandomGenerator": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IFriendlyRandomGenerator",
       "interfaces": [
         "jsii-calc.IRandomNumberGenerator",
@@ -3123,6 +3521,7 @@
     "jsii-calc.IInterfaceImplementedByAbstractClass": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "awslabs/jsii#220 Abstract return type."
       },
       "fqn": "jsii-calc.IInterfaceImplementedByAbstractClass",
@@ -3135,6 +3534,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3150,6 +3552,7 @@
     "jsii-calc.IInterfaceThatShouldNotBeADataType": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."
       },
       "fqn": "jsii-calc.IInterfaceThatShouldNotBeADataType",
@@ -3165,6 +3568,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3179,6 +3585,9 @@
     },
     "jsii-calc.IInterfaceWithInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithInternal",
       "kind": "interface",
       "locationInModule": {
@@ -3188,6 +3597,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1480
@@ -3199,6 +3611,9 @@
     },
     "jsii-calc.IInterfaceWithMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithMethods",
       "kind": "interface",
       "locationInModule": {
@@ -3208,6 +3623,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1148
@@ -3219,6 +3637,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3234,6 +3655,7 @@
     "jsii-calc.IInterfaceWithOptionalMethodArguments": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."
       },
       "fqn": "jsii-calc.IInterfaceWithOptionalMethodArguments",
@@ -3245,6 +3667,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1051
@@ -3271,6 +3696,9 @@
     },
     "jsii-calc.IInterfaceWithProperties": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithProperties",
       "kind": "interface",
       "locationInModule": {
@@ -3281,6 +3709,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3293,6 +3724,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 567
@@ -3306,6 +3740,9 @@
     },
     "jsii-calc.IInterfaceWithPropertiesExtension": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IInterfaceWithPropertiesExtension",
       "interfaces": [
         "jsii-calc.IInterfaceWithProperties"
@@ -3319,6 +3756,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 571
@@ -3332,6 +3772,9 @@
     },
     "jsii-calc.IJSII417Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJSII417Derived",
       "interfaces": [
         "jsii-calc.IJSII417PublicBaseOfBase"
@@ -3344,6 +3787,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 37
@@ -3352,6 +3798,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 40
@@ -3363,6 +3812,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3377,6 +3829,9 @@
     },
     "jsii-calc.IJSII417PublicBaseOfBase": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJSII417PublicBaseOfBase",
       "kind": "interface",
       "locationInModule": {
@@ -3386,6 +3841,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 33
@@ -3397,6 +3855,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3411,6 +3872,9 @@
     },
     "jsii-calc.IJsii487External": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii487External",
       "kind": "interface",
       "locationInModule": {
@@ -3421,6 +3885,9 @@
     },
     "jsii-calc.IJsii487External2": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii487External2",
       "kind": "interface",
       "locationInModule": {
@@ -3431,6 +3898,9 @@
     },
     "jsii-calc.IJsii496": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IJsii496",
       "kind": "interface",
       "locationInModule": {
@@ -3441,6 +3911,9 @@
     },
     "jsii-calc.IMutableObjectLiteral": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IMutableObjectLiteral",
       "kind": "interface",
       "locationInModule": {
@@ -3451,6 +3924,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1106
@@ -3464,6 +3940,9 @@
     },
     "jsii-calc.INonInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.INonInternalInterface",
       "interfaces": [
         "jsii-calc.IAnotherPublicInterface"
@@ -3477,6 +3956,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1547
@@ -3488,6 +3970,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1551
@@ -3501,6 +3986,9 @@
     },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPrivatelyImplemented",
       "kind": "interface",
       "locationInModule": {
@@ -3511,6 +3999,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3525,6 +4016,9 @@
     },
     "jsii-calc.IPublicInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPublicInterface",
       "kind": "interface",
       "locationInModule": {
@@ -3534,6 +4028,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1339
@@ -3550,6 +4047,9 @@
     },
     "jsii-calc.IPublicInterface2": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IPublicInterface2",
       "kind": "interface",
       "locationInModule": {
@@ -3559,6 +4059,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1343
@@ -3576,6 +4079,7 @@
     "jsii-calc.IRandomNumberGenerator": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Generates random numbers."
       },
       "fqn": "jsii-calc.IRandomNumberGenerator",
@@ -3589,6 +4093,7 @@
           "abstract": true,
           "docs": {
             "returns": "A random number.",
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -3607,6 +4112,9 @@
     },
     "jsii-calc.IReturnsNumber": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.IReturnsNumber",
       "kind": "interface",
       "locationInModule": {
@@ -3616,6 +4124,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 619
@@ -3632,6 +4143,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3689,6 +4203,9 @@
     },
     "jsii-calc.ImplementInternalInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementInternalInterface",
       "initializer": {},
       "kind": "class",
@@ -3699,6 +4216,9 @@
       "name": "ImplementInternalInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1524
@@ -3712,6 +4232,9 @@
     },
     "jsii-calc.ImplementsInterfaceWithInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsInterfaceWithInternal",
       "initializer": {},
       "interfaces": [
@@ -3724,6 +4247,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1487
@@ -3737,6 +4263,9 @@
     "jsii-calc.ImplementsInterfaceWithInternalSubclass": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.ImplementsInterfaceWithInternal",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsInterfaceWithInternalSubclass",
       "initializer": {},
       "kind": "class",
@@ -3748,6 +4277,9 @@
     },
     "jsii-calc.ImplementsPrivateInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplementsPrivateInterface",
       "initializer": {},
       "kind": "class",
@@ -3758,6 +4290,9 @@
       "name": "ImplementsPrivateInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1528
@@ -3772,6 +4307,9 @@
     "jsii-calc.ImplictBaseOfBase": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.ImplictBaseOfBase",
       "interfaces": [
         "@scope/jsii-calc-base.BaseProps"
@@ -3785,6 +4323,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3800,6 +4341,9 @@
     "jsii-calc.InbetweenClass": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.PublicClass",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InbetweenClass",
       "initializer": {},
       "interfaces": [
@@ -3812,6 +4356,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1346
@@ -3829,6 +4376,9 @@
     },
     "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
       "initializer": {},
       "kind": "class",
@@ -3840,6 +4390,9 @@
       "namespace": "InterfaceInNamespaceIncludesClasses",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1038
@@ -3855,6 +4408,9 @@
     "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
       "kind": "interface",
       "locationInModule": {
@@ -3866,6 +4422,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3881,6 +4440,9 @@
     "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello",
       "kind": "interface",
       "locationInModule": {
@@ -3892,6 +4454,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -3907,8 +4472,14 @@
     "jsii-calc.JSII417Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.JSII417PublicBaseOfBase",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSII417Derived",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "property",
@@ -3925,6 +4496,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 23
@@ -3932,6 +4506,9 @@
           "name": "bar"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 26
@@ -3942,6 +4519,9 @@
       "name": "JSII417Derived",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -3957,6 +4537,9 @@
     },
     "jsii-calc.JSII417PublicBaseOfBase": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSII417PublicBaseOfBase",
       "initializer": {},
       "kind": "class",
@@ -3966,6 +4549,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 11
@@ -3979,6 +4565,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/erasures.ts",
             "line": 14
@@ -3989,6 +4578,9 @@
       "name": "JSII417PublicBaseOfBase",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/erasures.ts",
@@ -4003,6 +4595,9 @@
     },
     "jsii-calc.JSObjectLiteralForInterface": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralForInterface",
       "initializer": {},
       "kind": "class",
@@ -4012,6 +4607,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 496
@@ -4024,6 +4622,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 502
@@ -4040,6 +4641,9 @@
     },
     "jsii-calc.JSObjectLiteralToNative": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralToNative",
       "initializer": {},
       "kind": "class",
@@ -4049,6 +4653,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 221
@@ -4065,6 +4672,9 @@
     },
     "jsii-calc.JSObjectLiteralToNativeClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JSObjectLiteralToNativeClass",
       "initializer": {},
       "kind": "class",
@@ -4075,6 +4685,9 @@
       "name": "JSObjectLiteralToNativeClass",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 230
@@ -4085,6 +4698,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 231
@@ -4098,6 +4714,9 @@
     },
     "jsii-calc.JavaReservedWords": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.JavaReservedWords",
       "initializer": {},
       "kind": "class",
@@ -4107,6 +4726,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 715
@@ -4114,6 +4736,9 @@
           "name": "abstract"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 718
@@ -4121,6 +4746,9 @@
           "name": "assert"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 721
@@ -4128,6 +4756,9 @@
           "name": "boolean"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 724
@@ -4135,6 +4766,9 @@
           "name": "break"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 727
@@ -4142,6 +4776,9 @@
           "name": "byte"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 730
@@ -4149,6 +4786,9 @@
           "name": "case"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 733
@@ -4156,6 +4796,9 @@
           "name": "catch"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 736
@@ -4163,6 +4806,9 @@
           "name": "char"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 739
@@ -4170,6 +4816,9 @@
           "name": "class"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 742
@@ -4177,6 +4826,9 @@
           "name": "const"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 745
@@ -4184,6 +4836,9 @@
           "name": "continue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 748
@@ -4191,6 +4846,9 @@
           "name": "default"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 754
@@ -4198,6 +4856,9 @@
           "name": "do"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 751
@@ -4205,6 +4866,9 @@
           "name": "double"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 757
@@ -4212,6 +4876,9 @@
           "name": "else"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 760
@@ -4219,6 +4886,9 @@
           "name": "enum"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 763
@@ -4226,6 +4896,9 @@
           "name": "extends"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 766
@@ -4233,6 +4906,9 @@
           "name": "false"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 769
@@ -4240,6 +4916,9 @@
           "name": "final"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 772
@@ -4247,6 +4926,9 @@
           "name": "finally"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 775
@@ -4254,6 +4936,9 @@
           "name": "float"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 778
@@ -4261,6 +4946,9 @@
           "name": "for"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 781
@@ -4268,6 +4956,9 @@
           "name": "goto"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 784
@@ -4275,6 +4966,9 @@
           "name": "if"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 787
@@ -4282,6 +4976,9 @@
           "name": "implements"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 790
@@ -4289,6 +4986,9 @@
           "name": "import"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 793
@@ -4296,6 +4996,9 @@
           "name": "instanceof"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 796
@@ -4303,6 +5006,9 @@
           "name": "int"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 799
@@ -4310,6 +5016,9 @@
           "name": "interface"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 802
@@ -4317,6 +5026,9 @@
           "name": "long"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 805
@@ -4324,6 +5036,9 @@
           "name": "native"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 808
@@ -4331,6 +5046,9 @@
           "name": "new"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 811
@@ -4338,6 +5056,9 @@
           "name": "null"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 814
@@ -4345,6 +5066,9 @@
           "name": "package"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 817
@@ -4352,6 +5076,9 @@
           "name": "private"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 820
@@ -4359,6 +5086,9 @@
           "name": "protected"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 823
@@ -4366,6 +5096,9 @@
           "name": "public"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 826
@@ -4373,6 +5106,9 @@
           "name": "return"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 829
@@ -4380,6 +5116,9 @@
           "name": "short"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 832
@@ -4387,6 +5126,9 @@
           "name": "static"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 835
@@ -4394,6 +5136,9 @@
           "name": "strictfp"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 838
@@ -4401,6 +5146,9 @@
           "name": "super"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 841
@@ -4408,6 +5156,9 @@
           "name": "switch"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 844
@@ -4415,6 +5166,9 @@
           "name": "synchronized"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 847
@@ -4422,6 +5176,9 @@
           "name": "this"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 850
@@ -4429,6 +5186,9 @@
           "name": "throw"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 853
@@ -4436,6 +5196,9 @@
           "name": "throws"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 856
@@ -4443,6 +5206,9 @@
           "name": "transient"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 859
@@ -4450,6 +5216,9 @@
           "name": "true"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 862
@@ -4457,6 +5226,9 @@
           "name": "try"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 865
@@ -4464,6 +5236,9 @@
           "name": "void"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 868
@@ -4474,6 +5249,9 @@
       "name": "JavaReservedWords",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 871
@@ -4487,6 +5265,9 @@
     },
     "jsii-calc.Jsii487Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Jsii487Derived",
       "initializer": {},
       "interfaces": [
@@ -4502,6 +5283,9 @@
     },
     "jsii-calc.Jsii496Derived": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Jsii496Derived",
       "initializer": {},
       "interfaces": [
@@ -4517,6 +5301,7 @@
     "jsii-calc.JsiiAgent": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Host runtime version should be set via JSII_AGENT."
       },
       "fqn": "jsii-calc.JsiiAgent",
@@ -4530,6 +5315,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the value of the JSII_AGENT environment variable."
           },
           "immutable": true,
@@ -4550,6 +5336,7 @@
       "assembly": "jsii-calc",
       "datatype": true,
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#298: show default values in sphinx documentation, and respect newlines."
       },
       "fqn": "jsii-calc.LoadBalancedFargateServiceProps",
@@ -4565,6 +5352,7 @@
           "docs": {
             "default": "80",
             "remarks": "Corresponds to container port mapping.",
+            "stability": "experimental",
             "summary": "The container port of the application load balancer attached to your Fargate service."
           },
           "immutable": true,
@@ -4583,6 +5371,7 @@
           "docs": {
             "default": "256",
             "remarks": "This default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "experimental",
             "summary": "The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments."
           },
           "immutable": true,
@@ -4601,6 +5390,7 @@
           "docs": {
             "default": "512",
             "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)\n\n1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)\n\n2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)\n\nBetween 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)\n\nBetween 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "experimental",
             "summary": "The amount (in MiB) of memory used by the task."
           },
           "immutable": true,
@@ -4618,6 +5408,7 @@
           "abstract": true,
           "docs": {
             "default": "true",
+            "stability": "experimental",
             "summary": "Determines whether the Application Load Balancer will be internet-facing."
           },
           "immutable": true,
@@ -4635,6 +5426,7 @@
           "abstract": true,
           "docs": {
             "default": "false",
+            "stability": "experimental",
             "summary": "Determines whether your Fargate Service will be assigned a public IP address."
           },
           "immutable": true,
@@ -4654,11 +5446,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.BinaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The \"*\" binary operation."
       },
       "fqn": "jsii-calc.Multiply",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a BinaryOperation."
         },
         "parameters": [
@@ -4694,6 +5488,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -4710,6 +5505,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -4726,6 +5522,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns another random number."
           },
           "locationInModule": {
@@ -4742,6 +5539,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -4761,6 +5559,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -4780,10 +5579,14 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.UnaryOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The negation operation (\"-value\")."
       },
       "fqn": "jsii-calc.Negate",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "operand",
@@ -4804,6 +5607,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say farewell."
           },
           "locationInModule": {
@@ -4820,6 +5624,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say goodbye."
           },
           "locationInModule": {
@@ -4836,6 +5641,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Say hello!"
           },
           "locationInModule": {
@@ -4852,6 +5658,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -4871,6 +5678,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -4889,6 +5697,7 @@
     "jsii-calc.NodeStandardLibrary": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Test fixture to verify that jsii modules can use the node standard library."
       },
       "fqn": "jsii-calc.NodeStandardLibrary",
@@ -4902,6 +5711,7 @@
         {
           "docs": {
             "returns": "\"6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50\"",
+            "stability": "experimental",
             "summary": "Uses node.js \"crypto\" module to calculate sha256 of a string."
           },
           "locationInModule": {
@@ -4919,6 +5729,7 @@
           "async": true,
           "docs": {
             "returns": "\"Hello, resource!\"",
+            "stability": "experimental",
             "summary": "Reads a local resource file (resource.txt) asynchronously."
           },
           "locationInModule": {
@@ -4935,6 +5746,7 @@
         {
           "docs": {
             "returns": "\"Hello, resource! SYNC!\"",
+            "stability": "experimental",
             "summary": "Sync version of fsReadFile."
           },
           "locationInModule": {
@@ -4953,6 +5765,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the current os.platform() from the \"os\" node module."
           },
           "immutable": true,
@@ -4970,10 +5783,14 @@
     "jsii-calc.NullShouldBeTreatedAsUndefined": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "jsii#282, aws-cdk#157: null should be treated as \"undefined\"."
       },
       "fqn": "jsii-calc.NullShouldBeTreatedAsUndefined",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "_param1",
@@ -4997,6 +5814,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1180
@@ -5013,6 +5833,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1186
@@ -5028,6 +5851,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1201
@@ -5038,6 +5864,9 @@
       "name": "NullShouldBeTreatedAsUndefined",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1172
@@ -5053,6 +5882,9 @@
     "jsii-calc.NullShouldBeTreatedAsUndefinedData": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.NullShouldBeTreatedAsUndefinedData",
       "kind": "interface",
       "locationInModule": {
@@ -5063,6 +5895,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5080,6 +5915,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5096,10 +5934,14 @@
     "jsii-calc.NumberGenerator": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "This allows us to test that a reference can be stored for objects that implement interfaces."
       },
       "fqn": "jsii-calc.NumberGenerator",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "generator",
@@ -5116,6 +5958,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 489
@@ -5136,6 +5981,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 485
@@ -5151,6 +5999,9 @@
       "name": "NumberGenerator",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 481
@@ -5165,6 +6016,7 @@
     "jsii-calc.ObjectRefsInCollections": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Verify that object references can be passed inside collections."
       },
       "fqn": "jsii-calc.ObjectRefsInCollections",
@@ -5177,6 +6029,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the sum of all values."
           },
           "locationInModule": {
@@ -5205,6 +6058,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Returns the sum of all values in a map."
           },
           "locationInModule": {
@@ -5251,6 +6105,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "deprecated",
             "summary": "Doo wop that thing."
           },
           "locationInModule": {
@@ -5264,8 +6119,14 @@
     },
     "jsii-calc.OptionalConstructorArgument": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalConstructorArgument",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "arg1",
@@ -5296,6 +6157,9 @@
       "name": "OptionalConstructorArgument",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5307,6 +6171,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5318,6 +6185,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5334,6 +6204,9 @@
     "jsii-calc.OptionalStruct": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalStruct",
       "kind": "interface",
       "locationInModule": {
@@ -5344,6 +6217,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5359,8 +6235,14 @@
     },
     "jsii-calc.OptionalStructConsumer": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OptionalStructConsumer",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "optionalStruct",
@@ -5379,6 +6261,9 @@
       "name": "OptionalStructConsumer",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5390,6 +6275,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5405,6 +6293,9 @@
     },
     "jsii-calc.OverrideReturnsObject": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.OverrideReturnsObject",
       "initializer": {},
       "kind": "class",
@@ -5414,6 +6305,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 625
@@ -5439,6 +6333,9 @@
     "jsii-calc.PartiallyInitializedThisConsumer": {
       "abstract": true,
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PartiallyInitializedThisConsumer",
       "initializer": {},
       "kind": "class",
@@ -5449,6 +6346,9 @@
       "methods": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1592
@@ -5485,6 +6385,9 @@
     },
     "jsii-calc.Polymorphism": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Polymorphism",
       "initializer": {},
       "kind": "class",
@@ -5494,6 +6397,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 471
@@ -5520,11 +6426,13 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "The power operation."
       },
       "fqn": "jsii-calc.Power",
       "initializer": {
         "docs": {
+          "stability": "experimental",
           "summary": "Creates a Power operation."
         },
         "parameters": [
@@ -5557,6 +6465,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The base of the power."
           },
           "immutable": true,
@@ -5571,6 +6480,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -5586,6 +6496,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The number of times to multiply."
           },
           "immutable": true,
@@ -5602,6 +6513,9 @@
     },
     "jsii-calc.PublicClass": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PublicClass",
       "initializer": {},
       "kind": "class",
@@ -5611,6 +6525,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1336
@@ -5622,6 +6539,9 @@
     },
     "jsii-calc.PythonReservedWords": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.PythonReservedWords",
       "initializer": {},
       "kind": "class",
@@ -5631,6 +6551,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 876
@@ -5638,6 +6561,9 @@
           "name": "and"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 878
@@ -5645,6 +6571,9 @@
           "name": "as"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 880
@@ -5652,6 +6581,9 @@
           "name": "assert"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 882
@@ -5659,6 +6591,9 @@
           "name": "async"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 884
@@ -5666,6 +6601,9 @@
           "name": "await"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 886
@@ -5673,6 +6611,9 @@
           "name": "break"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 888
@@ -5680,6 +6621,9 @@
           "name": "class"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 890
@@ -5687,6 +6631,9 @@
           "name": "continue"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 892
@@ -5694,6 +6641,9 @@
           "name": "def"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 894
@@ -5701,6 +6651,9 @@
           "name": "del"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 896
@@ -5708,6 +6661,9 @@
           "name": "elif"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 898
@@ -5715,6 +6671,9 @@
           "name": "else"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 900
@@ -5722,6 +6681,9 @@
           "name": "except"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 902
@@ -5729,6 +6691,9 @@
           "name": "finally"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 904
@@ -5736,6 +6701,9 @@
           "name": "for"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 906
@@ -5743,6 +6711,9 @@
           "name": "from"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 908
@@ -5750,6 +6721,9 @@
           "name": "global"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 910
@@ -5757,6 +6731,9 @@
           "name": "if"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 912
@@ -5764,6 +6741,9 @@
           "name": "import"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 914
@@ -5771,6 +6751,9 @@
           "name": "in"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 916
@@ -5778,6 +6761,9 @@
           "name": "is"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 918
@@ -5785,6 +6771,9 @@
           "name": "lambda"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 920
@@ -5792,6 +6781,9 @@
           "name": "nonlocal"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 922
@@ -5799,6 +6791,9 @@
           "name": "not"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 924
@@ -5806,6 +6801,9 @@
           "name": "or"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 926
@@ -5813,6 +6811,9 @@
           "name": "pass"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 928
@@ -5820,6 +6821,9 @@
           "name": "raise"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 930
@@ -5827,6 +6831,9 @@
           "name": "return"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 932
@@ -5834,6 +6841,9 @@
           "name": "try"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 934
@@ -5841,6 +6851,9 @@
           "name": "while"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 936
@@ -5848,6 +6861,9 @@
           "name": "with"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 938
@@ -5860,6 +6876,7 @@
     "jsii-calc.ReferenceEnumFromScopedPackage": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "See awslabs/jsii#138."
       },
       "fqn": "jsii-calc.ReferenceEnumFromScopedPackage",
@@ -5871,6 +6888,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1013
@@ -5884,6 +6904,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1017
@@ -5902,6 +6925,9 @@
       "name": "ReferenceEnumFromScopedPackage",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1011
@@ -5919,6 +6945,7 @@
       "docs": {
         "returns": "an instance of an un-exported class that extends `ExportedBaseClass`, declared as `IPrivatelyImplemented`.",
         "see": "https://github.com/awslabs/jsii/issues/320",
+        "stability": "experimental",
         "summary": "Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class."
       },
       "fqn": "jsii-calc.ReturnsPrivateImplementationOfInterface",
@@ -5931,6 +6958,9 @@
       "name": "ReturnsPrivateImplementationOfInterface",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -5945,6 +6975,9 @@
     },
     "jsii-calc.RuntimeTypeChecking": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.RuntimeTypeChecking",
       "initializer": {},
       "kind": "class",
@@ -5954,6 +6987,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 271
@@ -5984,6 +7020,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 277
@@ -6001,6 +7040,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Used to verify verification of number of method arguments."
           },
           "locationInModule": {
@@ -6037,6 +7077,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "JSII clients can instantiate 2 different strongly-typed wrappers for the same\nobject. Unfortunately, this will break object equality, but if we didn't do\nthis it would break runtime type checks in the JVM or CLR.",
+        "stability": "experimental",
         "summary": "Test that a single instance can be returned under two different FQNs."
       },
       "fqn": "jsii-calc.SingleInstanceTwoTypes",
@@ -6048,6 +7089,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1400
@@ -6060,6 +7104,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1404
@@ -6211,6 +7258,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "https://github.com/awslabs/aws-cdk/issues/2304",
+        "stability": "experimental",
         "summary": "This is used to validate the ability to use `this` from within a static context."
       },
       "fqn": "jsii-calc.StaticContext",
@@ -6221,6 +7269,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1647
@@ -6237,6 +7288,9 @@
       "name": "StaticContext",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1655
@@ -6251,8 +7305,14 @@
     },
     "jsii-calc.Statics": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Statics",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "value",
@@ -6270,6 +7330,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static method."
           },
           "locationInModule": {
@@ -6296,6 +7357,9 @@
           "static": true
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 671
@@ -6313,6 +7377,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Constants may also use all-caps."
           },
           "immutable": true,
@@ -6328,6 +7393,9 @@
         },
         {
           "const": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6342,6 +7410,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static property."
           },
           "immutable": true,
@@ -6358,6 +7427,7 @@
         {
           "const": true,
           "docs": {
+            "stability": "experimental",
             "summary": "Constants can also use camelCase."
           },
           "immutable": true,
@@ -6378,6 +7448,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Jsdocs for static getter. Jsdocs for static setter."
           },
           "locationInModule": {
@@ -6391,6 +7462,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 709
@@ -6402,6 +7476,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6416,6 +7493,9 @@
     },
     "jsii-calc.StringEnum": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.StringEnum",
       "kind": "enum",
       "locationInModule": {
@@ -6424,12 +7504,21 @@
       },
       "members": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "A"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "B"
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "name": "C"
         }
       ],
@@ -6437,6 +7526,9 @@
     },
     "jsii-calc.StripInternal": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.StripInternal",
       "initializer": {},
       "kind": "class",
@@ -6447,6 +7539,9 @@
       "name": "StripInternal",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1448
@@ -6462,10 +7557,15 @@
       "assembly": "jsii-calc",
       "base": "jsii-calc.composition.CompositeOperation",
       "docs": {
+        "stability": "experimental",
         "summary": "An operation that sums multiple values."
       },
       "fqn": "jsii-calc.Sum",
-      "initializer": {},
+      "initializer": {
+        "docs": {
+          "stability": "experimental"
+        }
+      },
       "kind": "class",
       "locationInModule": {
         "filename": "lib/calculator.ts",
@@ -6475,6 +7575,7 @@
       "properties": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -6490,6 +7591,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The parts to sum."
           },
           "locationInModule": {
@@ -6510,6 +7612,9 @@
     },
     "jsii-calc.SyncVirtualMethods": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.SyncVirtualMethods",
       "initializer": {},
       "kind": "class",
@@ -6520,6 +7625,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 360
@@ -6532,6 +7640,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 348
@@ -6544,6 +7655,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 400
@@ -6559,6 +7673,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 372
@@ -6574,6 +7691,9 @@
           ]
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 413
@@ -6586,6 +7706,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 404
@@ -6598,6 +7721,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 384
@@ -6610,6 +7736,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 376
@@ -6622,6 +7751,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 364
@@ -6642,6 +7774,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 417
@@ -6660,6 +7795,9 @@
       "name": "SyncVirtualMethods",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6671,6 +7809,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 411
@@ -6681,6 +7822,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 352
@@ -6691,6 +7835,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 390
@@ -6701,6 +7848,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 370
@@ -6711,6 +7861,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 398
@@ -6724,6 +7877,9 @@
     },
     "jsii-calc.Thrower": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.Thrower",
       "initializer": {},
       "kind": "class",
@@ -6733,6 +7889,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 631
@@ -6747,10 +7906,14 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "An operation on a single operand."
       },
       "fqn": "jsii-calc.UnaryOperation",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "operand",
@@ -6768,6 +7931,9 @@
       "name": "UnaryOperation",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
@@ -6783,6 +7949,9 @@
     "jsii-calc.UnionProperties": {
       "assembly": "jsii-calc",
       "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UnionProperties",
       "kind": "interface",
       "locationInModule": {
@@ -6793,6 +7962,9 @@
       "properties": [
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6817,6 +7989,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6841,6 +8016,9 @@
     },
     "jsii-calc.UseBundledDependency": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UseBundledDependency",
       "initializer": {},
       "kind": "class",
@@ -6850,6 +8028,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 947
@@ -6867,6 +8048,7 @@
     "jsii-calc.UseCalcBase": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Depend on a type from jsii-calc-base as a test for awslabs/jsii#128."
       },
       "fqn": "jsii-calc.UseCalcBase",
@@ -6878,6 +8060,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 996
@@ -6894,8 +8079,14 @@
     },
     "jsii-calc.UsesInterfaceWithProperties": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.UsesInterfaceWithProperties",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "name": "obj",
@@ -6912,6 +8103,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 579
@@ -6924,6 +8118,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 588
@@ -6944,6 +8141,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 583
@@ -6967,6 +8167,9 @@
       "name": "UsesInterfaceWithProperties",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -6981,8 +8184,14 @@
     },
     "jsii-calc.VariadicMethod": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.VariadicMethod",
       "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
         "parameters": [
           {
             "docs": {
@@ -7004,6 +8213,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 654
@@ -7047,6 +8259,9 @@
     },
     "jsii-calc.VirtualMethodPlayground": {
       "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
       "fqn": "jsii-calc.VirtualMethodPlayground",
       "initializer": {},
       "kind": "class",
@@ -7057,6 +8272,9 @@
       "methods": [
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 451
@@ -7077,6 +8295,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 455
@@ -7098,6 +8319,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 433
@@ -7119,6 +8343,9 @@
         },
         {
           "async": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 424
@@ -7139,6 +8366,9 @@
           }
         },
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 443
@@ -7166,6 +8396,7 @@
       "assembly": "jsii-calc",
       "docs": {
         "remarks": "- Implement `overrideMe` (method does not have to do anything).\n- Invoke `callMe`\n- Verify that `methodWasCalled` is `true`.",
+        "stability": "experimental",
         "summary": "This test is used to validate the runtimes can return correctly from a void callback."
       },
       "fqn": "jsii-calc.VoidCallback",
@@ -7177,6 +8408,9 @@
       },
       "methods": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1678
@@ -7185,6 +8419,9 @@
         },
         {
           "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
           "locationInModule": {
             "filename": "lib/compliance.ts",
             "line": 1682
@@ -7196,6 +8433,9 @@
       "name": "VoidCallback",
       "properties": [
         {
+          "docs": {
+            "stability": "experimental"
+          },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/compliance.ts",
@@ -7213,6 +8453,7 @@
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.Operation",
       "docs": {
+        "stability": "experimental",
         "summary": "Abstract operation composed from an expression of other operations."
       },
       "fqn": "jsii-calc.composition.CompositeOperation",
@@ -7225,6 +8466,7 @@
       "methods": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "String representation of the value."
           },
           "locationInModule": {
@@ -7246,6 +8488,7 @@
         {
           "abstract": true,
           "docs": {
+            "stability": "experimental",
             "summary": "The expression that this operation consists of. Must be implemented by derived classes."
           },
           "immutable": true,
@@ -7260,6 +8503,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The value."
           },
           "immutable": true,
@@ -7275,6 +8519,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A set of postfixes to include in a decorated .toString()."
           },
           "locationInModule": {
@@ -7293,6 +8538,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "A set of prefixes to include in a decorated .toString()."
           },
           "locationInModule": {
@@ -7311,6 +8557,7 @@
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "The .toString() style."
           },
           "locationInModule": {
@@ -7327,6 +8574,7 @@
     "jsii-calc.composition.CompositeOperation.CompositionStringStyle": {
       "assembly": "jsii-calc",
       "docs": {
+        "stability": "experimental",
         "summary": "Style of .toString() output for CompositeOperation."
       },
       "fqn": "jsii-calc.composition.CompositeOperation.CompositionStringStyle",
@@ -7338,12 +8586,14 @@
       "members": [
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Normal string expression."
           },
           "name": "Normal"
         },
         {
           "docs": {
+            "stability": "experimental",
             "summary": "Decorated string expression."
           },
           "name": "Decorated"
@@ -7354,5 +8604,5 @@
     }
   },
   "version": "0.11.0",
-  "fingerprint": "aNWCih3NfgXU4mll5c+zKXj3ekSyaT9S+67MAugCfNo="
+  "fingerprint": "eOHyVzmCXMA46bGWMkxa9to4jM7N/B7DGm3TvKR6tNw="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AbstractClass), fullyQualifiedName: "jsii-calc.AbstractClass")]
     public abstract class AbstractClass : AbstractClassBase, IIInterfaceImplementedByAbstractClass
     {
@@ -17,14 +18,17 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "propFromInterface", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string PropFromInterface
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "abstractMethod", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"name\",\"type\":{\"primitive\":\"string\"}}]")]
         public abstract string AbstractMethod(string name);
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "nonAbstractMethod", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double NonAbstractMethod()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBase.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AbstractClassBase), fullyQualifiedName: "jsii-calc.AbstractClassBase")]
     public abstract class AbstractClassBase : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "abstractProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string AbstractProperty
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(AbstractClassBase), fullyQualifiedName: "jsii-calc.AbstractClassBase")]
     internal sealed class AbstractClassBaseProxy : AbstractClassBase
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "abstractProperty", typeJson: "{\"primitive\":\"string\"}")]
         public override string AbstractProperty
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(AbstractClass), fullyQualifiedName: "jsii-calc.AbstractClass")]
     internal sealed class AbstractClassProxy : AbstractClass
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "abstractProperty", typeJson: "{\"primitive\":\"string\"}")]
         public override string AbstractProperty
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "abstractMethod", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"name\",\"type\":{\"primitive\":\"string\"}}]")]
         public override string AbstractMethod(string name)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AbstractClassReturner), fullyQualifiedName: "jsii-calc.AbstractClassReturner")]
     public class AbstractClassReturner : DeputyBase
     {
@@ -17,18 +18,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "returnAbstractFromProperty", typeJson: "{\"fqn\":\"jsii-calc.AbstractClassBase\"}")]
         public virtual AbstractClassBase ReturnAbstractFromProperty
         {
             get => GetInstanceProperty<AbstractClassBase>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeAbstract", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.AbstractClass\"}}")]
         public virtual AbstractClass GiveMeAbstract()
         {
             return InvokeInstanceMethod<AbstractClass>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IInterfaceImplementedByAbstractClass\"}}")]
         public virtual IIInterfaceImplementedByAbstractClass GiveMeInterface()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Add.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Add.cs
@@ -4,12 +4,14 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The "+" binary operation.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Add), fullyQualifiedName: "jsii-calc.Add", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public class Add : BinaryOperation
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
+        /// <remarks>stability: Experimental</remarks>
         public Add(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
@@ -23,6 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
         public override double Value
         {
@@ -30,6 +33,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public override string ToString()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
@@ -10,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// The setters will validate
     /// that the value set is of the expected type and throw otherwise.
+    /// stability: Experimental
     /// </remarks>
     [JsiiClass(nativeType: typeof(AllTypes), fullyQualifiedName: "jsii-calc.AllTypes")]
     public class AllTypes : DeputyBase
@@ -26,12 +27,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "enumPropertyValue", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double EnumPropertyValue
         {
             get => GetInstanceProperty<double>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anyArrayProperty", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         public virtual object[] AnyArrayProperty
         {
@@ -39,6 +42,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anyMapProperty", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         public virtual IDictionary<string, object> AnyMapProperty
         {
@@ -46,6 +50,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anyProperty", typeJson: "{\"primitive\":\"any\"}")]
         public virtual object AnyProperty
         {
@@ -53,6 +58,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arrayProperty", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         public virtual string[] ArrayProperty
         {
@@ -60,6 +66,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "booleanProperty", typeJson: "{\"primitive\":\"boolean\"}")]
         public virtual bool BooleanProperty
         {
@@ -67,6 +74,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "dateProperty", typeJson: "{\"primitive\":\"date\"}")]
         public virtual DateTime DateProperty
         {
@@ -74,6 +82,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "enumProperty", typeJson: "{\"fqn\":\"jsii-calc.AllTypesEnum\"}")]
         public virtual AllTypesEnum EnumProperty
         {
@@ -81,6 +90,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "jsonProperty", typeJson: "{\"primitive\":\"json\"}")]
         public virtual JObject JsonProperty
         {
@@ -88,6 +98,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "mapProperty", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Number\"}}}")]
         public virtual IDictionary<string, Number> MapProperty
         {
@@ -95,6 +106,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "numberProperty", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double NumberProperty
         {
@@ -102,6 +114,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "stringProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string StringProperty
         {
@@ -109,6 +122,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unionArrayProperty", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"union\":{\"types\":[{\"primitive\":\"number\"},{\"fqn\":\"@scope/jsii-calc-lib.Value\"}]}}}}")]
         public virtual object[] UnionArrayProperty
         {
@@ -116,6 +130,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unionMapProperty", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"@scope/jsii-calc-lib.Number\"}]}}}}")]
         public virtual IDictionary<string, object> UnionMapProperty
         {
@@ -123,6 +138,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unionProperty", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.Multiply\"},{\"fqn\":\"@scope/jsii-calc-lib.Number\"}]}}")]
         public virtual object UnionProperty
         {
@@ -130,6 +146,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unknownArrayProperty", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         public virtual object[] UnknownArrayProperty
         {
@@ -137,6 +154,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unknownMapProperty", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         public virtual IDictionary<string, object> UnknownMapProperty
         {
@@ -144,6 +162,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unknownProperty", typeJson: "{\"primitive\":\"any\"}")]
         public virtual object UnknownProperty
         {
@@ -151,6 +170,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalEnumValue", typeJson: "{\"fqn\":\"jsii-calc.StringEnum\"}", isOptional: true)]
         public virtual StringEnum? OptionalEnumValue
         {
@@ -158,18 +178,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "anyIn", parametersJson: "[{\"name\":\"inp\",\"type\":{\"primitive\":\"any\"}}]")]
         public virtual void AnyIn(object inp)
         {
             InvokeInstanceVoidMethod(new object[]{inp});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "anyOut", returnsJson: "{\"type\":{\"primitive\":\"any\"}}")]
         public virtual object AnyOut()
         {
             return InvokeInstanceMethod<object>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "enumMethod", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.StringEnum\"}}", parametersJson: "[{\"name\":\"value\",\"type\":{\"fqn\":\"jsii-calc.StringEnum\"}}]")]
         public virtual StringEnum EnumMethod(StringEnum value)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypesEnum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypesEnum.cs
@@ -2,13 +2,17 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiEnum(nativeType: typeof(AllTypesEnum), fullyQualifiedName: "jsii-calc.AllTypesEnum")]
     public enum AllTypesEnum
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "MyEnumValue")]
         MyEnumValue,
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "YourEnumValue")]
         YourEnumValue,
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "ThisIsGreat")]
         ThisIsGreat
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllowedMethodNames.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllowedMethodNames.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AllowedMethodNames), fullyQualifiedName: "jsii-calc.AllowedMethodNames")]
     public class AllowedMethodNames : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "getBar", parametersJson: "[{\"name\":\"_p1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"_p2\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void GetBar(string _p1, double _p2)
         {
@@ -24,12 +26,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "getFoo", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"withParam\",\"type\":{\"primitive\":\"string\"}}]")]
         public virtual string GetFoo(string withParam)
         {
             return InvokeInstanceMethod<string>(new object[]{withParam});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "setBar", parametersJson: "[{\"name\":\"_x\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"_y\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"_z\",\"type\":{\"primitive\":\"boolean\"}}]")]
         public virtual void SetBar(string _x, double _y, bool _z)
         {
@@ -37,6 +41,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "setFoo", parametersJson: "[{\"name\":\"_x\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"_y\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void SetFoo(string _x, double _y)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AsyncVirtualMethods.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AsyncVirtualMethods.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AsyncVirtualMethods), fullyQualifiedName: "jsii-calc.AsyncVirtualMethods")]
     public class AsyncVirtualMethods : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "callMe", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isAsync: true)]
         public virtual double CallMe()
         {
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Just calls "overrideMeToo".</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "callMe2", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isAsync: true)]
         public virtual double CallMe2()
         {
@@ -35,6 +38,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// This is a "double promise" situation, which
         /// means that callbacks are not going to be available immediate, but only
         /// after an "immediates" cycle.
+        /// stability: Experimental
         /// </remarks>
         [JsiiMethod(name: "callMeDoublePromise", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isAsync: true)]
         public virtual double CallMeDoublePromise()
@@ -42,18 +46,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "dontOverrideMe", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double DontOverrideMe()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMe", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"mult\",\"type\":{\"primitive\":\"number\"}}]", isAsync: true)]
         public virtual double OverrideMe(double mult)
         {
             return InvokeInstanceMethod<double>(new object[]{mult});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMeToo", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isAsync: true)]
         public virtual double OverrideMeToo()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AugmentableClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AugmentableClass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AugmentableClass), fullyQualifiedName: "jsii-calc.AugmentableClass")]
     public class AugmentableClass : DeputyBase
     {
@@ -17,12 +18,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "methodOne")]
         public virtual void MethodOne()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "methodTwo")]
         public virtual void MethodTwo()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperation.cs
@@ -4,12 +4,14 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Represents an operation with two operands.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(BinaryOperation), fullyQualifiedName: "jsii-calc.BinaryOperation", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public abstract class BinaryOperation : Operation, IIFriendly
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
+        /// <remarks>stability: Experimental</remarks>
         protected BinaryOperation(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
@@ -23,6 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Left-hand side operand.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "lhs", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Lhs
         {
@@ -30,6 +33,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Right-hand side operand.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "rhs", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Rhs
         {
@@ -37,6 +41,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Hello()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Represents an operation with two operands.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(BinaryOperation), fullyQualifiedName: "jsii-calc.BinaryOperation")]
     internal sealed class BinaryOperationProxy : BinaryOperation
     {
@@ -11,14 +12,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public override double Value
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
+        [System.Obsolete()]
         public override string ToString()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A calculator which maintains a current value and allows adding operations.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Calculator), fullyQualifiedName: "jsii-calc.Calculator", parametersJson: "[{\"name\":\"props\",\"type\":{\"fqn\":\"jsii-calc.CalculatorProps\"},\"optional\":true}]")]
     public class Calculator : CompositeOperation_
     {
         /// <summary>Creates a Calculator object.</summary>
         /// <param name = "props">Initialization properties.</param>
+        /// <remarks>stability: Experimental</remarks>
         public Calculator(ICalculatorProps props): base(new DeputyProps(new object[]{props}))
         {
         }
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the expression.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public override Value_ Expression
         {
@@ -31,6 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>A log of all operations.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operationsLog", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}")]
         public virtual Value_[] OperationsLog
         {
@@ -38,6 +42,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>A map of per operation name of all operations performed.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operationsMap", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}}")]
         public virtual IDictionary<string, Value_[]> OperationsMap
         {
@@ -45,6 +50,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The current value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "curr", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Curr
         {
@@ -53,6 +59,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The maximum value allows in this calculator.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "maxValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         public virtual double? MaxValue
         {
@@ -61,6 +68,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Example of a property that accepts a union of types.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "unionProperty", typeJson: "{\"union\":{\"types\":[{\"fqn\":\"jsii-calc.Add\"},{\"fqn\":\"jsii-calc.Multiply\"},{\"fqn\":\"jsii-calc.Power\"}]}}", isOptional: true)]
         public virtual object UnionProperty
         {
@@ -69,6 +77,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Adds a number to the current value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "add", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void Add(double value)
         {
@@ -76,6 +85,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Multiplies the current value by a number.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "mul", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void Mul(double value)
         {
@@ -83,6 +93,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Negates the current value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "neg")]
         public virtual void Neg()
         {
@@ -90,6 +101,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Raises the current value by a power.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "pow", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void Pow(double value)
         {
@@ -97,6 +109,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns teh value of the union property (if defined).</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readUnionValue", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double ReadUnionValue()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Properties for Calculator.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class CalculatorProps : ICalculatorProps
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "initialValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]
         public double? InitialValue
         {
@@ -13,6 +15,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "maximumValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]
         public double? MaximumValue
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Properties for Calculator.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ICalculatorProps), fullyQualifiedName: "jsii-calc.CalculatorProps")]
     internal sealed class CalculatorPropsProxy : DeputyBase, ICalculatorProps
     {
@@ -10,12 +11,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "initialValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         public double? InitialValue
         {
             get => GetInstanceProperty<double? >();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "maximumValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         public double? MaximumValue
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassThatImplementsTheInternalInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsTheInternalInterface")]
     public class ClassThatImplementsTheInternalInterface : DeputyBase, IINonInternalInterface
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string A
         {
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "b", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string B
         {
@@ -31,6 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "c", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string C
         {
@@ -38,6 +42,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "d", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string D
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassThatImplementsThePrivateInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsThePrivateInterface")]
     public class ClassThatImplementsThePrivateInterface : DeputyBase, IINonInternalInterface
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string A
         {
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "b", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string B
         {
@@ -31,6 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "c", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string C
         {
@@ -38,6 +42,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "e", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string E
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassWithMutableObjectLiteralProperty), fullyQualifiedName: "jsii-calc.ClassWithMutableObjectLiteralProperty")]
     public class ClassWithMutableObjectLiteralProperty : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "mutableObject", typeJson: "{\"fqn\":\"jsii-calc.IMutableObjectLiteral\"}")]
         public virtual IIMutableObjectLiteral MutableObject
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithPrivateConstructorAndAutomaticProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithPrivateConstructorAndAutomaticProperties.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Class that implements interface properties automatically, but using a private constructor.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassWithPrivateConstructorAndAutomaticProperties), fullyQualifiedName: "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties")]
     public class ClassWithPrivateConstructorAndAutomaticProperties : DeputyBase, IIInterfaceWithProperties
     {
@@ -14,12 +15,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readOnlyString", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string ReadOnlyString
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readWriteString", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string ReadWriteString
         {
@@ -27,6 +30,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "create", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties\"}}", parametersJson: "[{\"name\":\"readOnlyString\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"readWriteString\",\"type\":{\"primitive\":\"string\"}}]")]
         public static ClassWithPrivateConstructorAndAutomaticProperties Create(string readOnlyString, string readWriteString)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConstructorPassesThisOut.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConstructorPassesThisOut.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ConstructorPassesThisOut), fullyQualifiedName: "jsii-calc.ConstructorPassesThisOut", parametersJson: "[{\"name\":\"consumer\",\"type\":{\"fqn\":\"jsii-calc.PartiallyInitializedThisConsumer\"}}]")]
     public class ConstructorPassesThisOut : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public ConstructorPassesThisOut(PartiallyInitializedThisConsumer consumer): base(new DeputyProps(new object[]{consumer}))
         {
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Constructors.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Constructors.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Constructors), fullyQualifiedName: "jsii-calc.Constructors")]
     public class Constructors : DeputyBase
     {
@@ -17,42 +18,49 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
         public static IIPublicInterface HiddenInterface()
         {
             return InvokeStaticMethod<IIPublicInterface>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
         public static IIPublicInterface[] HiddenInterfaces()
         {
             return InvokeStaticMethod<IIPublicInterface[]>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenSubInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
         public static IIPublicInterface[] HiddenSubInterfaces()
         {
             return InvokeStaticMethod<IIPublicInterface[]>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeClass", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.PublicClass\"}}")]
         public static PublicClass MakeClass()
         {
             return InvokeStaticMethod<PublicClass>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
         public static IIPublicInterface MakeInterface()
         {
             return InvokeStaticMethod<IIPublicInterface>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterface2", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface2\"}}")]
         public static IIPublicInterface2 MakeInterface2()
         {
             return InvokeStaticMethod<IIPublicInterface2>(typeof(Constructors), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
         public static IIPublicInterface[] MakeInterfaces()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ConsumersOfThisCrazyTypeSystem), fullyQualifiedName: "jsii-calc.ConsumersOfThisCrazyTypeSystem")]
     public class ConsumersOfThisCrazyTypeSystem : DeputyBase
     {
@@ -17,12 +18,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumeAnotherPublicInterface", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IAnotherPublicInterface\"}}]")]
         public virtual string ConsumeAnotherPublicInterface(IIAnotherPublicInterface obj)
         {
             return InvokeInstanceMethod<string>(new object[]{obj});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumeNonInternalInterface", returnsJson: "{\"type\":{\"primitive\":\"any\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.INonInternalInterface\"}}]")]
         public virtual object ConsumeNonInternalInterface(IINonInternalInterface obj)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DefaultedConstructorArgument.cs
@@ -3,9 +3,11 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DefaultedConstructorArgument), fullyQualifiedName: "jsii-calc.DefaultedConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"},\"optional\":true},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
     public class DefaultedConstructorArgument : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public DefaultedConstructorArgument(double? arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))
         {
         }
@@ -18,18 +20,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg1", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double Arg1
         {
             get => GetInstanceProperty<double>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg3", typeJson: "{\"primitive\":\"date\"}")]
         public virtual DateTime Arg3
         {
             get => GetInstanceProperty<DateTime>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg2", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public virtual string Arg2
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedClassHasNoProperties/Base.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedClassHasNoProperties/Base.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Base), fullyQualifiedName: "jsii-calc.DerivedClassHasNoProperties.Base")]
     public class Base : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "prop", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string Prop
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedClassHasNoProperties/Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedClassHasNoProperties/Derived.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Derived), fullyQualifiedName: "jsii-calc.DerivedClassHasNoProperties.Derived")]
     public class Derived : Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties.Base
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A struct which derives from another struct.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class DerivedStruct : IDerivedStruct
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherRequired", typeJson: "{\"primitive\":\"date\"}", isOverride: true)]
         public DateTime AnotherRequired
         {
@@ -16,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bool", typeJson: "{\"primitive\":\"boolean\"}", isOverride: true)]
         public bool Bool
         {
@@ -24,6 +27,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>An example of a non primitive property.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}", isOverride: true)]
         public DoubleTrouble NonPrimitive
         {
@@ -32,6 +36,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>This is optional.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true, isOverride: true)]
         public IDictionary<string, Value_> AnotherOptional
         {
@@ -39,6 +44,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalAny", typeJson: "{\"primitive\":\"any\"}", isOptional: true, isOverride: true)]
         public object OptionalAny
         {
@@ -46,6 +52,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalArray", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true, isOverride: true)]
         public string[] OptionalArray
         {
@@ -54,7 +61,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>An awesome number value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "anumber", typeJson: "{\"primitive\":\"number\"}", isOverride: true)]
+        [System.Obsolete()]
         public double Anumber
         {
             get;
@@ -62,14 +71,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>A string value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "astring", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        [System.Obsolete()]
         public string Astring
         {
             get;
             set;
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "firstOptional", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true, isOverride: true)]
+        [System.Obsolete()]
         public string[] FirstOptional
         {
             get;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A struct which derives from another struct.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IDerivedStruct), fullyQualifiedName: "jsii-calc.DerivedStruct")]
     internal sealed class DerivedStructProxy : DeputyBase, IDerivedStruct
     {
@@ -13,12 +14,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherRequired", typeJson: "{\"primitive\":\"date\"}")]
         public DateTime AnotherRequired
         {
             get => GetInstanceProperty<DateTime>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bool", typeJson: "{\"primitive\":\"boolean\"}")]
         public bool Bool
         {
@@ -26,6 +29,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>An example of a non primitive property.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
         public DoubleTrouble NonPrimitive
         {
@@ -33,18 +37,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>This is optional.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true)]
         public IDictionary<string, Value_> AnotherOptional
         {
             get => GetInstanceProperty<IDictionary<string, Value_>>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalAny", typeJson: "{\"primitive\":\"any\"}", isOptional: true)]
         public object OptionalAny
         {
             get => GetInstanceProperty<object>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalArray", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true)]
         public string[] OptionalArray
         {
@@ -52,20 +59,26 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>An awesome number value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "anumber", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public double Anumber
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>A string value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "astring", typeJson: "{\"primitive\":\"string\"}")]
+        [System.Obsolete()]
         public string Astring
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "firstOptional", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true)]
+        [System.Obsolete()]
         public string[] FirstOptional
         {
             get => GetInstanceProperty<string[]>();

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotOverridePrivates.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DoNotOverridePrivates), fullyQualifiedName: "jsii-calc.DoNotOverridePrivates")]
     public class DoNotOverridePrivates : DeputyBase
     {
@@ -17,18 +18,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "changePrivatePropertyValue", parametersJson: "[{\"name\":\"newValue\",\"type\":{\"primitive\":\"string\"}}]")]
         public virtual void ChangePrivatePropertyValue(string newValue)
         {
             InvokeInstanceVoidMethod(new object[]{newValue});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "privateMethodValue", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string PrivateMethodValue()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "privatePropertyValue", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string PrivatePropertyValue()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotRecognizeAnyAsOptional.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoNotRecognizeAnyAsOptional.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#284: do not recognize "any" as an optional argument.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DoNotRecognizeAnyAsOptional), fullyQualifiedName: "jsii-calc.DoNotRecognizeAnyAsOptional")]
     public class DoNotRecognizeAnyAsOptional : DeputyBase
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "method", parametersJson: "[{\"name\":\"_requiredAny\",\"type\":{\"primitive\":\"any\"}},{\"name\":\"_optionalAny\",\"type\":{\"primitive\":\"any\"},\"optional\":true},{\"name\":\"_optionalString\",\"type\":{\"primitive\":\"string\"},\"optional\":true}]")]
         public virtual void Method(object _requiredAny, object _optionalAny, string _optionalString)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
@@ -31,6 +31,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// This will print out a friendly greeting intended for
         /// the indicated person.
+        /// stability: Stable
         /// </remarks>
         [JsiiMethod(name: "greet", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"greetee\",\"type\":{\"fqn\":\"jsii-calc.Greetee\"},\"optional\":true}]")]
         public virtual double Greet(IGreetee greetee)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DontComplainAboutVariadicAfterOptional.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DontComplainAboutVariadicAfterOptional), fullyQualifiedName: "jsii-calc.DontComplainAboutVariadicAfterOptional")]
     public class DontComplainAboutVariadicAfterOptional : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "optionalAndVariadic", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"optional\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"things\",\"variadic\":true,\"type\":{\"primitive\":\"string\"}}]")]
         public virtual string OptionalAndVariadic(string optional, string things)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoubleTrouble.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoubleTrouble.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DoubleTrouble), fullyQualifiedName: "jsii-calc.DoubleTrouble")]
     public class DoubleTrouble : DeputyBase, IIFriendlyRandomGenerator
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Hello()
         {
@@ -25,6 +27,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns another random number.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "next", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isOverride: true)]
         public virtual double Next()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValues.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValues.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(EraseUndefinedHashValues), fullyQualifiedName: "jsii-calc.EraseUndefinedHashValues")]
     public class EraseUndefinedHashValues : DeputyBase
     {
@@ -21,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// Used to check that undefined/null hash values
         /// are being erased when sending values from native code to JS.
+        /// stability: Experimental
         /// </remarks>
         [JsiiMethod(name: "doesKeyExist", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"opts\",\"type\":{\"fqn\":\"jsii-calc.EraseUndefinedHashValuesOptions\"}},{\"name\":\"key\",\"type\":{\"primitive\":\"string\"}}]")]
         public static bool DoesKeyExist(IEraseUndefinedHashValuesOptions opts, string key)
@@ -29,6 +31,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>We expect "prop1" to be erased.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "prop1IsNull", returnsJson: "{\"type\":{\"primitive\":\"any\"}}")]
         public static object Prop1IsNull()
         {
@@ -36,6 +39,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>We expect "prop2" to be erased.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "prop2IsUndefined", returnsJson: "{\"type\":{\"primitive\":\"any\"}}")]
         public static object Prop2IsUndefined()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class EraseUndefinedHashValuesOptions : IEraseUndefinedHashValuesOptions
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option1", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string Option1
         {
@@ -12,6 +14,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option2", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string Option2
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptionsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptionsProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IEraseUndefinedHashValuesOptions), fullyQualifiedName: "jsii-calc.EraseUndefinedHashValuesOptions")]
     internal sealed class EraseUndefinedHashValuesOptionsProxy : DeputyBase, IEraseUndefinedHashValuesOptions
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option1", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string Option1
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option2", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string Option2
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExportedBaseClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExportedBaseClass.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ExportedBaseClass), fullyQualifiedName: "jsii-calc.ExportedBaseClass", parametersJson: "[{\"name\":\"success\",\"type\":{\"primitive\":\"boolean\"}}]")]
     public class ExportedBaseClass : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public ExportedBaseClass(bool success): base(new DeputyProps(new object[]{success}))
         {
         }
@@ -17,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "success", typeJson: "{\"primitive\":\"boolean\"}")]
         public virtual bool Success
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class ExtendsInternalInterface : IExtendsInternalInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "boom", typeJson: "{\"primitive\":\"boolean\"}", isOverride: true)]
         public bool Boom
         {
@@ -12,6 +14,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "prop", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
         public string Prop
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterfaceProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IExtendsInternalInterface), fullyQualifiedName: "jsii-calc.ExtendsInternalInterface")]
     internal sealed class ExtendsInternalInterfaceProxy : DeputyBase, IExtendsInternalInterface
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "boom", typeJson: "{\"primitive\":\"boolean\"}")]
         public bool Boom
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "prop", typeJson: "{\"primitive\":\"string\"}")]
         public string Prop
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GiveMeStructs.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GiveMeStructs.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(GiveMeStructs), fullyQualifiedName: "jsii-calc.GiveMeStructs")]
     public class GiveMeStructs : DeputyBase
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "structLiteral", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.StructWithOnlyOptionals\"}")]
         public virtual IStructWithOnlyOptionals StructLiteral
         {
@@ -25,6 +27,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "derivedToFirst", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.MyFirstStruct\"}}", parametersJson: "[{\"name\":\"derived\",\"type\":{\"fqn\":\"jsii-calc.DerivedStruct\"}}]")]
         public virtual IMyFirstStruct DerivedToFirst(IDerivedStruct derived)
         {
@@ -32,6 +35,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the boolean from a DerivedStruct struct.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readDerivedNonPrimitive", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.DoubleTrouble\"}}", parametersJson: "[{\"name\":\"derived\",\"type\":{\"fqn\":\"jsii-calc.DerivedStruct\"}}]")]
         public virtual DoubleTrouble ReadDerivedNonPrimitive(IDerivedStruct derived)
         {
@@ -39,6 +43,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the "anumber" from a MyFirstStruct struct;</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readFirstNumber", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"first\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.MyFirstStruct\"}}]")]
         public virtual double ReadFirstNumber(IMyFirstStruct first)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
@@ -3,11 +3,15 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>These are some arguments you can pass to a method.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class Greetee : IGreetee
     {
         /// <summary>The name of the greetee.</summary>
-        /// <remarks>default: world</remarks>
+        /// <remarks>
+        /// default: world
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "name", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string Name
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreeteeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreeteeProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>These are some arguments you can pass to a method.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IGreetee), fullyQualifiedName: "jsii-calc.Greetee")]
     internal sealed class GreeteeProxy : DeputyBase, IGreetee
     {
@@ -11,7 +12,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The name of the greetee.</summary>
-        /// <remarks>default: world</remarks>
+        /// <remarks>
+        /// default: world
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "name", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string Name
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(GreetingAugmenter), fullyQualifiedName: "jsii-calc.GreetingAugmenter")]
     public class GreetingAugmenter : DeputyBase
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "betterGreeting", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"friendly\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}]")]
         public virtual string BetterGreeting(IIFriendly friendly)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIAnotherPublicInterface), fullyQualifiedName: "jsii-calc.IAnotherPublicInterface")]
     internal sealed class IAnotherPublicInterfaceProxy : DeputyBase, IIAnotherPublicInterface
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"string\"}")]
         public string A
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ICalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ICalculatorProps.cs
@@ -3,15 +3,18 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Properties for Calculator.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(ICalculatorProps), fullyQualifiedName: "jsii-calc.CalculatorProps")]
     public interface ICalculatorProps
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "initialValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         double? InitialValue
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "maximumValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         double? MaximumValue
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
@@ -6,15 +6,18 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>A struct which derives from another struct.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IDerivedStruct), fullyQualifiedName: "jsii-calc.DerivedStruct")]
     public interface IDerivedStruct : IMyFirstStruct
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherRequired", typeJson: "{\"primitive\":\"date\"}")]
         DateTime AnotherRequired
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bool", typeJson: "{\"primitive\":\"boolean\"}")]
         bool Bool
         {
@@ -22,6 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>An example of a non primitive property.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
         DoubleTrouble NonPrimitive
         {
@@ -29,18 +33,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>This is optional.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true)]
         IDictionary<string, Value_> AnotherOptional
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalAny", typeJson: "{\"primitive\":\"any\"}", isOptional: true)]
         object OptionalAny
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalArray", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}", isOptional: true)]
         string[] OptionalArray
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IEraseUndefinedHashValuesOptions.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IEraseUndefinedHashValuesOptions.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IEraseUndefinedHashValuesOptions), fullyQualifiedName: "jsii-calc.EraseUndefinedHashValuesOptions")]
     public interface IEraseUndefinedHashValuesOptions
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option1", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string Option1
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option2", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string Option2
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsInternalInterface.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IExtendsInternalInterface), fullyQualifiedName: "jsii-calc.ExtendsInternalInterface")]
     public interface IExtendsInternalInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "boom", typeJson: "{\"primitive\":\"boolean\"}")]
         bool Boom
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "prop", typeJson: "{\"primitive\":\"string\"}")]
         string Prop
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsPrivateInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsPrivateInterfaceProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIExtendsPrivateInterface), fullyQualifiedName: "jsii-calc.IExtendsPrivateInterface")]
     internal sealed class IExtendsPrivateInterfaceProxy : DeputyBase, IIExtendsPrivateInterface
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "moreThings", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         public string[] MoreThings
         {
             get => GetInstanceProperty<string[]>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "private", typeJson: "{\"primitive\":\"string\"}")]
         public string Private
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even friendlier classes can implement this interface.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendlier), fullyQualifiedName: "jsii-calc.IFriendlier")]
     internal sealed class IFriendlierProxy : DeputyBase, IIFriendlier
     {
@@ -11,6 +12,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say farewell.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "farewell", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public string Farewell()
         {
@@ -19,6 +21,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Say goodbye.</summary>
         /// <returns>A goodbye blessing.</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "goodbye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public string Goodbye()
         {
@@ -26,7 +29,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        [System.Obsolete()]
         public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendlyRandomGenerator), fullyQualifiedName: "jsii-calc.IFriendlyRandomGenerator")]
     internal sealed class IFriendlyRandomGeneratorProxy : DeputyBase, IIFriendlyRandomGenerator
     {
@@ -11,6 +12,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Returns another random number.</summary>
         /// <returns>A random number.</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "next", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public double Next()
         {
@@ -18,7 +20,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        [System.Obsolete()]
         public string Hello()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IGreetee.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IGreetee.cs
@@ -3,11 +3,15 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>These are some arguments you can pass to a method.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IGreetee), fullyQualifiedName: "jsii-calc.Greetee")]
     public interface IGreetee
     {
         /// <summary>The name of the greetee.</summary>
-        /// <remarks>default: world</remarks>
+        /// <remarks>
+        /// default: world
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "name", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string Name
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIAnotherPublicInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIAnotherPublicInterface.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIAnotherPublicInterface), fullyQualifiedName: "jsii-calc.IAnotherPublicInterface")]
     public interface IIAnotherPublicInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"string\"}")]
         string A
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIExtendsPrivateInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIExtendsPrivateInterface.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIExtendsPrivateInterface), fullyQualifiedName: "jsii-calc.IExtendsPrivateInterface")]
     public interface IIExtendsPrivateInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "moreThings", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         string[] MoreThings
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "private", typeJson: "{\"primitive\":\"string\"}")]
         string Private
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlier.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlier.cs
@@ -4,14 +4,17 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even friendlier classes can implement this interface.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIFriendlier), fullyQualifiedName: "jsii-calc.IFriendlier")]
     public interface IIFriendlier : IIFriendly
     {
         /// <summary>Say farewell.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "farewell", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         string Farewell();
         /// <summary>Say goodbye.</summary>
         /// <returns>A goodbye blessing.</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "goodbye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         string Goodbye();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlyRandomGenerator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlyRandomGenerator.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIFriendlyRandomGenerator), fullyQualifiedName: "jsii-calc.IFriendlyRandomGenerator")]
     public interface IIFriendlyRandomGenerator : IIRandomNumberGenerator, IIFriendly
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceImplementedByAbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceImplementedByAbstractClass.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>awslabs/jsii#220 Abstract return type.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceImplementedByAbstractClass), fullyQualifiedName: "jsii-calc.IInterfaceImplementedByAbstractClass")]
     public interface IIInterfaceImplementedByAbstractClass
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "propFromInterface", typeJson: "{\"primitive\":\"string\"}")]
         string PropFromInterface
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceThatShouldNotBeADataType), fullyQualifiedName: "jsii-calc.IInterfaceThatShouldNotBeADataType")]
     public interface IIInterfaceThatShouldNotBeADataType : IIInterfaceWithMethods
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "otherValue", typeJson: "{\"primitive\":\"string\"}")]
         string OtherValue
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithInternal.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithInternal.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithInternal), fullyQualifiedName: "jsii-calc.IInterfaceWithInternal")]
     public interface IIInterfaceWithInternal
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "visible")]
         void Visible();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithMethods.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithMethods.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithMethods), fullyQualifiedName: "jsii-calc.IInterfaceWithMethods")]
     public interface IIInterfaceWithMethods
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         string Value
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "doThings")]
         void DoThings();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithOptionalMethodArguments.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithOptionalMethodArguments.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithOptionalMethodArguments), fullyQualifiedName: "jsii-calc.IInterfaceWithOptionalMethodArguments")]
     public interface IIInterfaceWithOptionalMethodArguments
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"},\"optional\":true}]")]
         void Hello(string arg1, double? arg2);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithProperties.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithProperties), fullyQualifiedName: "jsii-calc.IInterfaceWithProperties")]
     public interface IIInterfaceWithProperties
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readOnlyString", typeJson: "{\"primitive\":\"string\"}")]
         string ReadOnlyString
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readWriteString", typeJson: "{\"primitive\":\"string\"}")]
         string ReadWriteString
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithPropertiesExtension.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithPropertiesExtension.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithPropertiesExtension), fullyQualifiedName: "jsii-calc.IInterfaceWithPropertiesExtension")]
     public interface IIInterfaceWithPropertiesExtension : IIInterfaceWithProperties
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417Derived.cs
@@ -2,17 +2,21 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJSII417Derived), fullyQualifiedName: "jsii-calc.IJSII417Derived")]
     public interface IIJSII417Derived : IIJSII417PublicBaseOfBase
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "property", typeJson: "{\"primitive\":\"string\"}")]
         string Property
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "bar")]
         void Bar();
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "baz")]
         void Baz();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417PublicBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417PublicBaseOfBase.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJSII417PublicBaseOfBase), fullyQualifiedName: "jsii-calc.IJSII417PublicBaseOfBase")]
     public interface IIJSII417PublicBaseOfBase
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "hasRoot", typeJson: "{\"primitive\":\"boolean\"}")]
         bool HasRoot
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "foo")]
         void Foo();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJsii487External), fullyQualifiedName: "jsii-calc.IJsii487External")]
     public interface IIJsii487External
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External2.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii487External2.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJsii487External2), fullyQualifiedName: "jsii-calc.IJsii487External2")]
     public interface IIJsii487External2
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii496.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJsii496.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJsii496), fullyQualifiedName: "jsii-calc.IJsii496")]
     public interface IIJsii496
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIMutableObjectLiteral.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIMutableObjectLiteral.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIMutableObjectLiteral), fullyQualifiedName: "jsii-calc.IMutableObjectLiteral")]
     public interface IIMutableObjectLiteral
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         string Value
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IINonInternalInterface), fullyQualifiedName: "jsii-calc.INonInternalInterface")]
     public interface IINonInternalInterface : IIAnotherPublicInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "b", typeJson: "{\"primitive\":\"string\"}")]
         string B
         {
@@ -12,6 +14,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "c", typeJson: "{\"primitive\":\"string\"}")]
         string C
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPrivatelyImplemented.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPrivatelyImplemented.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIPrivatelyImplemented), fullyQualifiedName: "jsii-calc.IPrivatelyImplemented")]
     public interface IIPrivatelyImplemented
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "success", typeJson: "{\"primitive\":\"boolean\"}")]
         bool Success
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPublicInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPublicInterface.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIPublicInterface), fullyQualifiedName: "jsii-calc.IPublicInterface")]
     public interface IIPublicInterface
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "bye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         string Bye();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPublicInterface2.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIPublicInterface2.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIPublicInterface2), fullyQualifiedName: "jsii-calc.IPublicInterface2")]
     public interface IIPublicInterface2
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "ciao", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         string Ciao();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIRandomNumberGenerator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIRandomNumberGenerator.cs
@@ -3,11 +3,13 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Generates random numbers.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIRandomNumberGenerator), fullyQualifiedName: "jsii-calc.IRandomNumberGenerator")]
     public interface IIRandomNumberGenerator
     {
         /// <summary>Returns another random number.</summary>
         /// <returns>A random number.</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "next", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         double Next();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
@@ -3,15 +3,18 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIReturnsNumber), fullyQualifiedName: "jsii-calc.IReturnsNumber")]
     public interface IIReturnsNumber
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "numberProp", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
         Number NumberProp
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "obtainNumber", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}}")]
         IIDoublable ObtainNumber();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IImplictBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IImplictBaseOfBase.cs
@@ -4,9 +4,11 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IImplictBaseOfBase), fullyQualifiedName: "jsii-calc.ImplictBaseOfBase")]
     public interface IImplictBaseOfBase : IBaseProps
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "goo", typeJson: "{\"primitive\":\"date\"}")]
         DateTime Goo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClassProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>awslabs/jsii#220 Abstract return type.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceImplementedByAbstractClass), fullyQualifiedName: "jsii-calc.IInterfaceImplementedByAbstractClass")]
     internal sealed class IInterfaceImplementedByAbstractClassProxy : DeputyBase, IIInterfaceImplementedByAbstractClass
     {
@@ -10,6 +11,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "propFromInterface", typeJson: "{\"primitive\":\"string\"}")]
         public string PropFromInterface
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceThatShouldNotBeADataType), fullyQualifiedName: "jsii-calc.IInterfaceThatShouldNotBeADataType")]
     internal sealed class IInterfaceThatShouldNotBeADataTypeProxy : DeputyBase, IIInterfaceThatShouldNotBeADataType
     {
@@ -10,18 +11,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "otherValue", typeJson: "{\"primitive\":\"string\"}")]
         public string OtherValue
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         public string Value
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "doThings")]
         public void DoThings()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithInternalProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithInternalProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithInternal), fullyQualifiedName: "jsii-calc.IInterfaceWithInternal")]
     internal sealed class IInterfaceWithInternalProxy : DeputyBase, IIInterfaceWithInternal
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "visible")]
         public void Visible()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithMethods), fullyQualifiedName: "jsii-calc.IInterfaceWithMethods")]
     internal sealed class IInterfaceWithMethodsProxy : DeputyBase, IIInterfaceWithMethods
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         public string Value
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "doThings")]
         public void DoThings()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithOptionalMethodArguments), fullyQualifiedName: "jsii-calc.IInterfaceWithOptionalMethodArguments")]
     internal sealed class IInterfaceWithOptionalMethodArgumentsProxy : DeputyBase, IIInterfaceWithOptionalMethodArguments
     {
@@ -10,6 +11,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"number\"},\"optional\":true}]")]
         public void Hello(string arg1, double? arg2)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithPropertiesExtension), fullyQualifiedName: "jsii-calc.IInterfaceWithPropertiesExtension")]
     internal sealed class IInterfaceWithPropertiesExtensionProxy : DeputyBase, IIInterfaceWithPropertiesExtension
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         public double Foo
         {
@@ -16,12 +18,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readOnlyString", typeJson: "{\"primitive\":\"string\"}")]
         public string ReadOnlyString
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readWriteString", typeJson: "{\"primitive\":\"string\"}")]
         public string ReadWriteString
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithProperties), fullyQualifiedName: "jsii-calc.IInterfaceWithProperties")]
     internal sealed class IInterfaceWithPropertiesProxy : DeputyBase, IIInterfaceWithProperties
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readOnlyString", typeJson: "{\"primitive\":\"string\"}")]
         public string ReadOnlyString
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readWriteString", typeJson: "{\"primitive\":\"string\"}")]
         public string ReadWriteString
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417DerivedProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417DerivedProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJSII417Derived), fullyQualifiedName: "jsii-calc.IJSII417Derived")]
     internal sealed class IJSII417DerivedProxy : DeputyBase, IIJSII417Derived
     {
@@ -9,30 +10,35 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "property", typeJson: "{\"primitive\":\"string\"}")]
         public string Property
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "hasRoot", typeJson: "{\"primitive\":\"boolean\"}")]
         public bool HasRoot
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "bar")]
         public void Bar()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "baz")]
         public void Baz()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "foo")]
         public void Foo()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417PublicBaseOfBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417PublicBaseOfBaseProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJSII417PublicBaseOfBase), fullyQualifiedName: "jsii-calc.IJSII417PublicBaseOfBase")]
     internal sealed class IJSII417PublicBaseOfBaseProxy : DeputyBase, IIJSII417PublicBaseOfBase
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "hasRoot", typeJson: "{\"primitive\":\"boolean\"}")]
         public bool HasRoot
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "foo")]
         public void Foo()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii487External2), fullyQualifiedName: "jsii-calc.IJsii487External2")]
     internal sealed class IJsii487External2Proxy : DeputyBase, IIJsii487External2
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii487External), fullyQualifiedName: "jsii-calc.IJsii487External")]
     internal sealed class IJsii487ExternalProxy : DeputyBase, IIJsii487External
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii496), fullyQualifiedName: "jsii-calc.IJsii496")]
     internal sealed class IJsii496Proxy : DeputyBase, IIJsii496
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ILoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ILoadBalancedFargateServiceProps.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(ILoadBalancedFargateServiceProps), fullyQualifiedName: "jsii-calc.LoadBalancedFargateServiceProps")]
     public interface ILoadBalancedFargateServiceProps
     {
@@ -10,6 +11,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// Corresponds to container port mapping.
         /// default: 80
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "containerPort", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         double? ContainerPort
@@ -21,6 +23,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 256
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "cpu", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string Cpu
@@ -45,6 +48,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// 
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 512
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "memoryMiB", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string MemoryMiB
@@ -53,7 +57,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether the Application Load Balancer will be internet-facing.</summary>
-        /// <remarks>default: true</remarks>
+        /// <remarks>
+        /// default: true
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicLoadBalancer", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
         bool? PublicLoadBalancer
         {
@@ -61,7 +68,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
-        /// <remarks>default: false</remarks>
+        /// <remarks>
+        /// default: false
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicTasks", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
         bool? PublicTasks
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteralProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteralProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIMutableObjectLiteral), fullyQualifiedName: "jsii-calc.IMutableObjectLiteral")]
     internal sealed class IMutableObjectLiteralProxy : DeputyBase, IIMutableObjectLiteral
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         public string Value
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IINonInternalInterface), fullyQualifiedName: "jsii-calc.INonInternalInterface")]
     internal sealed class INonInternalInterfaceProxy : DeputyBase, IINonInternalInterface
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "b", typeJson: "{\"primitive\":\"string\"}")]
         public string B
         {
@@ -16,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "c", typeJson: "{\"primitive\":\"string\"}")]
         public string C
         {
@@ -23,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"string\"}")]
         public string A
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INullShouldBeTreatedAsUndefinedData.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INullShouldBeTreatedAsUndefinedData.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(INullShouldBeTreatedAsUndefinedData), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefinedData")]
     public interface INullShouldBeTreatedAsUndefinedData
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arrayWithThreeElementsAndUndefinedAsSecondArgument", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         object[] ArrayWithThreeElementsAndUndefinedAsSecondArgument
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "thisShouldBeUndefined", typeJson: "{\"primitive\":\"any\"}", isOptional: true)]
         object ThisShouldBeUndefined
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalStruct.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IOptionalStruct), fullyQualifiedName: "jsii-calc.OptionalStruct")]
     public interface IOptionalStruct
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "field", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         string Field
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPrivatelyImplementedProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPrivatelyImplementedProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPrivatelyImplemented), fullyQualifiedName: "jsii-calc.IPrivatelyImplemented")]
     internal sealed class IPrivatelyImplementedProxy : DeputyBase, IIPrivatelyImplemented
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "success", typeJson: "{\"primitive\":\"boolean\"}")]
         public bool Success
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterface2Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterface2Proxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPublicInterface2), fullyQualifiedName: "jsii-calc.IPublicInterface2")]
     internal sealed class IPublicInterface2Proxy : DeputyBase, IIPublicInterface2
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "ciao", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public string Ciao()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterfaceProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPublicInterface), fullyQualifiedName: "jsii-calc.IPublicInterface")]
     internal sealed class IPublicInterfaceProxy : DeputyBase, IIPublicInterface
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "bye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public string Bye()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Generates random numbers.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIRandomNumberGenerator), fullyQualifiedName: "jsii-calc.IRandomNumberGenerator")]
     internal sealed class IRandomNumberGeneratorProxy : DeputyBase, IIRandomNumberGenerator
     {
@@ -12,6 +13,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Returns another random number.</summary>
         /// <returns>A random number.</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "next", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public double Next()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIReturnsNumber), fullyQualifiedName: "jsii-calc.IReturnsNumber")]
     internal sealed class IReturnsNumberProxy : DeputyBase, IIReturnsNumber
     {
@@ -10,12 +11,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "numberProp", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
         public Number NumberProp
         {
             get => GetInstanceProperty<Number>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "obtainNumber", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}}")]
         public IIDoublable ObtainNumber()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IUnionProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IUnionProperties.cs
@@ -2,15 +2,18 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IUnionProperties), fullyQualifiedName: "jsii-calc.UnionProperties")]
     public interface IUnionProperties
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bar", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.AllTypes\"}]}}")]
         object Bar
         {
             get;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"}]}}", isOptional: true)]
         object Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementInternalInterface.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementInternalInterface), fullyQualifiedName: "jsii-calc.ImplementInternalInterface")]
     public class ImplementInternalInterface : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "prop", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string Prop
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternal.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternal.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementsInterfaceWithInternal), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternal")]
     public class ImplementsInterfaceWithInternal : DeputyBase, IIInterfaceWithInternal
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "visible", isOverride: true)]
         public virtual void Visible()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternalSubclass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternalSubclass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementsInterfaceWithInternalSubclass), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternalSubclass")]
     public class ImplementsInterfaceWithInternalSubclass : ImplementsInterfaceWithInternal
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsPrivateInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsPrivateInterface.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementsPrivateInterface), fullyQualifiedName: "jsii-calc.ImplementsPrivateInterface")]
     public class ImplementsPrivateInterface : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "private", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string Private
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
@@ -4,9 +4,11 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class ImplictBaseOfBase : IImplictBaseOfBase
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "goo", typeJson: "{\"primitive\":\"date\"}", isOverride: true)]
         public DateTime Goo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IImplictBaseOfBase), fullyQualifiedName: "jsii-calc.ImplictBaseOfBase")]
     internal sealed class ImplictBaseOfBaseProxy : DeputyBase, IImplictBaseOfBase
     {
@@ -11,6 +12,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "goo", typeJson: "{\"primitive\":\"date\"}")]
         public DateTime Goo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InbetweenClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InbetweenClass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(InbetweenClass), fullyQualifiedName: "jsii-calc.InbetweenClass")]
     public class InbetweenClass : PublicClass, IIPublicInterface2
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "ciao", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Ciao()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Foo.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Foo.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Foo), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo")]
     public class Foo : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClas
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bar", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public virtual string Bar
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Hello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Hello.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class Hello : Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.IHello
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}", isOverride: true)]
         public double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/HelloProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/HelloProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IHello), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello")]
     internal sealed class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.IHello
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClas
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         public double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/IHello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/IHello.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IHello), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello")]
     public interface IHello
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/Hello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/Hello.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class Hello : Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface.IHello
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}", isOverride: true)]
         public double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/HelloProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/HelloProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IHello), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello")]
     internal sealed class HelloProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface.IHello
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterfac
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         public double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/IHello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/IHello.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IHello), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello")]
     public interface IHello
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]
         double Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417Derived.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSII417Derived), fullyQualifiedName: "jsii-calc.JSII417Derived", parametersJson: "[{\"name\":\"property\",\"type\":{\"primitive\":\"string\"}}]")]
     public class JSII417Derived : JSII417PublicBaseOfBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public JSII417Derived(string property): base(new DeputyProps(new object[]{property}))
         {
         }
@@ -17,18 +19,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "property", typeJson: "{\"primitive\":\"string\"}")]
         protected virtual string Property
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "bar")]
         public virtual void Bar()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "baz")]
         public virtual void Baz()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417PublicBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417PublicBaseOfBase.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSII417PublicBaseOfBase), fullyQualifiedName: "jsii-calc.JSII417PublicBaseOfBase")]
     public class JSII417PublicBaseOfBase : DeputyBase
     {
@@ -17,18 +18,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "hasRoot", typeJson: "{\"primitive\":\"boolean\"}")]
         public virtual bool HasRoot
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInstance", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.JSII417PublicBaseOfBase\"}}")]
         public static JSII417PublicBaseOfBase MakeInstance()
         {
             return InvokeStaticMethod<JSII417PublicBaseOfBase>(typeof(JSII417PublicBaseOfBase), new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "foo")]
         public virtual void Foo()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralForInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralForInterface.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSObjectLiteralForInterface), fullyQualifiedName: "jsii-calc.JSObjectLiteralForInterface")]
     public class JSObjectLiteralForInterface : DeputyBase
     {
@@ -18,12 +19,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeFriendly", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}")]
         public virtual IIFriendly GiveMeFriendly()
         {
             return InvokeInstanceMethod<IIFriendly>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeFriendlyGenerator", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IFriendlyRandomGenerator\"}}")]
         public virtual IIFriendlyRandomGenerator GiveMeFriendlyGenerator()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNative.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNative.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSObjectLiteralToNative), fullyQualifiedName: "jsii-calc.JSObjectLiteralToNative")]
     public class JSObjectLiteralToNative : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "returnLiteral", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.JSObjectLiteralToNativeClass\"}}")]
         public virtual JSObjectLiteralToNativeClass ReturnLiteral()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNativeClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNativeClass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSObjectLiteralToNativeClass), fullyQualifiedName: "jsii-calc.JSObjectLiteralToNativeClass")]
     public class JSObjectLiteralToNativeClass : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "propA", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string PropA
         {
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "propB", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double PropB
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JavaReservedWords.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JavaReservedWords.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JavaReservedWords), fullyQualifiedName: "jsii-calc.JavaReservedWords")]
     public class JavaReservedWords : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "while", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string While
         {
@@ -24,312 +26,364 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "abstract")]
         public virtual void Abstract()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "assert")]
         public virtual void Assert()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "boolean")]
         public virtual void Boolean()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "break")]
         public virtual void Break()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "byte")]
         public virtual void Byte()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "case")]
         public virtual void Case()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "catch")]
         public virtual void Catch()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "char")]
         public virtual void Char()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "class")]
         public virtual void Class()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "const")]
         public virtual void Const()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "continue")]
         public virtual void Continue()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "default")]
         public virtual void Default()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "do")]
         public virtual void Do()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "double")]
         public virtual void Double()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "else")]
         public virtual void Else()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "enum")]
         public virtual void Enum()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "extends")]
         public virtual void Extends()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "false")]
         public virtual void False()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "final")]
         public virtual void Final()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "finally")]
         public virtual void Finally()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "float")]
         public virtual void Float()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "for")]
         public virtual void For()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "goto")]
         public virtual void Goto()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "if")]
         public virtual void If()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "implements")]
         public virtual void Implements()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "import")]
         public virtual void Import()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "instanceof")]
         public virtual void Instanceof()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "int")]
         public virtual void Int()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "interface")]
         public virtual void Interface()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "long")]
         public virtual void Long()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "native")]
         public virtual void Native()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "new")]
         public virtual void New()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "null")]
         public virtual void Null()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "package")]
         public virtual void Package()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "private")]
         public virtual void Private()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "protected")]
         public virtual void Protected()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "public")]
         public virtual void Public()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "return")]
         public virtual void Return()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "short")]
         public virtual void Short()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "static")]
         public virtual void Static()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "strictfp")]
         public virtual void Strictfp()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "super")]
         public virtual void Super()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "switch")]
         public virtual void Switch()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "synchronized")]
         public virtual void Synchronized()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "this")]
         public virtual void This()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "throw")]
         public virtual void Throw()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "throws")]
         public virtual void Throws()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "transient")]
         public virtual void Transient()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "true")]
         public virtual void True()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "try")]
         public virtual void Try()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "void")]
         public virtual void Void()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "volatile")]
         public virtual void Volatile()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Jsii487Derived), fullyQualifiedName: "jsii-calc.Jsii487Derived")]
     public class Jsii487Derived : DeputyBase, IIJsii487External2, IIJsii487External
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Jsii496Derived), fullyQualifiedName: "jsii-calc.Jsii496Derived")]
     public class Jsii496Derived : DeputyBase, IIJsii496
     {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JsiiAgent_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JsiiAgent_.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Host runtime version should be set via JSII_AGENT.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JsiiAgent_), fullyQualifiedName: "jsii-calc.JsiiAgent")]
     public class JsiiAgent_ : DeputyBase
     {
@@ -19,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the value of the JSII_AGENT environment variable.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "jsiiAgent", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public static string JsiiAgent
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class LoadBalancedFargateServiceProps : ILoadBalancedFargateServiceProps
     {
@@ -10,6 +11,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// Corresponds to container port mapping.
         /// default: 80
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "containerPort", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]
         public double? ContainerPort
@@ -22,6 +24,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 256
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "cpu", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string Cpu
@@ -47,6 +50,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// 
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 512
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "memoryMiB", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string MemoryMiB
@@ -56,7 +60,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether the Application Load Balancer will be internet-facing.</summary>
-        /// <remarks>default: true</remarks>
+        /// <remarks>
+        /// default: true
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicLoadBalancer", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true, isOverride: true)]
         public bool? PublicLoadBalancer
         {
@@ -65,7 +72,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
-        /// <remarks>default: false</remarks>
+        /// <remarks>
+        /// default: false
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicTasks", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true, isOverride: true)]
         public bool? PublicTasks
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ILoadBalancedFargateServiceProps), fullyQualifiedName: "jsii-calc.LoadBalancedFargateServiceProps")]
     internal sealed class LoadBalancedFargateServicePropsProxy : DeputyBase, ILoadBalancedFargateServiceProps
     {
@@ -14,6 +15,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// Corresponds to container port mapping.
         /// default: 80
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "containerPort", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
         public double? ContainerPort
@@ -25,6 +27,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <remarks>
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 256
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "cpu", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string Cpu
@@ -49,6 +52,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// 
         /// This default is set in the underlying FargateTaskDefinition construct.
         /// default: 512
+        /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "memoryMiB", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string MemoryMiB
@@ -57,7 +61,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether the Application Load Balancer will be internet-facing.</summary>
-        /// <remarks>default: true</remarks>
+        /// <remarks>
+        /// default: true
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicLoadBalancer", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
         public bool? PublicLoadBalancer
         {
@@ -65,7 +72,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Determines whether your Fargate Service will be assigned a public IP address.</summary>
-        /// <remarks>default: false</remarks>
+        /// <remarks>
+        /// default: false
+        /// stability: Experimental
+        /// </remarks>
         [JsiiProperty(name: "publicTasks", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
         public bool? PublicTasks
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Multiply.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Multiply.cs
@@ -4,12 +4,14 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The "*" binary operation.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Multiply), fullyQualifiedName: "jsii-calc.Multiply", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public class Multiply : BinaryOperation, IIFriendlier, IIRandomNumberGenerator
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
+        /// <remarks>stability: Experimental</remarks>
         public Multiply(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
@@ -23,6 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
         public override double Value
         {
@@ -30,6 +33,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say farewell.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "farewell", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Farewell()
         {
@@ -37,6 +41,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say goodbye.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "goodbye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Goodbye()
         {
@@ -44,6 +49,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns another random number.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "next", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isOverride: true)]
         public virtual double Next()
         {
@@ -51,6 +57,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public override string ToString()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Negate.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Negate.cs
@@ -4,9 +4,11 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The negation operation ("-value").</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Negate), fullyQualifiedName: "jsii-calc.Negate", parametersJson: "[{\"name\":\"operand\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public class Negate : UnaryOperation, IIFriendlier
     {
+        /// <remarks>stability: Experimental</remarks>
         public Negate(Value_ operand): base(new DeputyProps(new object[]{operand}))
         {
         }
@@ -20,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
         public override double Value
         {
@@ -27,6 +30,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say farewell.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "farewell", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Farewell()
         {
@@ -34,6 +38,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say goodbye.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "goodbye", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Goodbye()
         {
@@ -41,6 +46,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Say hello!</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public virtual string Hello()
         {
@@ -48,6 +54,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public override string ToString()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NodeStandardLibrary.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NodeStandardLibrary.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Test fixture to verify that jsii modules can use the node standard library.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(NodeStandardLibrary), fullyQualifiedName: "jsii-calc.NodeStandardLibrary")]
     public class NodeStandardLibrary : DeputyBase
     {
@@ -19,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the current os.platform() from the "os" node module.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "osPlatform", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string OsPlatform
         {
@@ -27,6 +29,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Uses node.js "crypto" module to calculate sha256 of a string.</summary>
         /// <returns>"6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "cryptoSha256", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string CryptoSha256()
         {
@@ -35,6 +38,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Reads a local resource file (resource.txt) asynchronously.</summary>
         /// <returns>"Hello, resource!"</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "fsReadFile", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isAsync: true)]
         public virtual string FsReadFile()
         {
@@ -43,6 +47,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Sync version of fsReadFile.</summary>
         /// <returns>"Hello, resource! SYNC!"</returns>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "fsReadFileSync", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string FsReadFileSync()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>jsii#282, aws-cdk#157: null should be treated as "undefined".</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(NullShouldBeTreatedAsUndefined), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefined", parametersJson: "[{\"name\":\"_param1\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"optional\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
     public class NullShouldBeTreatedAsUndefined : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public NullShouldBeTreatedAsUndefined(string _param1, object optional): base(new DeputyProps(new object[]{_param1, optional}))
         {
         }
@@ -18,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "changeMeToUndefined", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public virtual string ChangeMeToUndefined
         {
@@ -25,18 +28,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeUndefined", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
         public virtual void GiveMeUndefined(object value)
         {
             InvokeInstanceVoidMethod(new object[]{value});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeUndefinedInsideAnObject", parametersJson: "[{\"name\":\"input\",\"type\":{\"fqn\":\"jsii-calc.NullShouldBeTreatedAsUndefinedData\"}}]")]
         public virtual void GiveMeUndefinedInsideAnObject(INullShouldBeTreatedAsUndefinedData input)
         {
             InvokeInstanceVoidMethod(new object[]{input});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "verifyPropertyIsUndefined")]
         public virtual void VerifyPropertyIsUndefined()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class NullShouldBeTreatedAsUndefinedData : INullShouldBeTreatedAsUndefinedData
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arrayWithThreeElementsAndUndefinedAsSecondArgument", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}", isOverride: true)]
         public object[] ArrayWithThreeElementsAndUndefinedAsSecondArgument
         {
@@ -12,6 +14,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "thisShouldBeUndefined", typeJson: "{\"primitive\":\"any\"}", isOptional: true, isOverride: true)]
         public object ThisShouldBeUndefined
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedDataProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedDataProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(INullShouldBeTreatedAsUndefinedData), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefinedData")]
     internal sealed class NullShouldBeTreatedAsUndefinedDataProxy : DeputyBase, INullShouldBeTreatedAsUndefinedData
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arrayWithThreeElementsAndUndefinedAsSecondArgument", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}")]
         public object[] ArrayWithThreeElementsAndUndefinedAsSecondArgument
         {
             get => GetInstanceProperty<object[]>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "thisShouldBeUndefined", typeJson: "{\"primitive\":\"any\"}", isOptional: true)]
         public object ThisShouldBeUndefined
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NumberGenerator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NumberGenerator.cs
@@ -3,9 +3,11 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>This allows us to test that a reference can be stored for objects that implement interfaces.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(NumberGenerator), fullyQualifiedName: "jsii-calc.NumberGenerator", parametersJson: "[{\"name\":\"generator\",\"type\":{\"fqn\":\"jsii-calc.IRandomNumberGenerator\"}}]")]
     public class NumberGenerator : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public NumberGenerator(IIRandomNumberGenerator generator): base(new DeputyProps(new object[]{generator}))
         {
         }
@@ -18,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "generator", typeJson: "{\"fqn\":\"jsii-calc.IRandomNumberGenerator\"}")]
         public virtual IIRandomNumberGenerator Generator
         {
@@ -25,12 +28,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "isSameGenerator", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"gen\",\"type\":{\"fqn\":\"jsii-calc.IRandomNumberGenerator\"}}]")]
         public virtual bool IsSameGenerator(IIRandomNumberGenerator gen)
         {
             return InvokeInstanceMethod<bool>(new object[]{gen});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "nextTimes100", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double NextTimes100()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ObjectRefsInCollections.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ObjectRefsInCollections.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Verify that object references can be passed inside collections.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ObjectRefsInCollections), fullyQualifiedName: "jsii-calc.ObjectRefsInCollections")]
     public class ObjectRefsInCollections : DeputyBase
     {
@@ -21,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the sum of all values.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sumFromArray", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"values\",\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}]")]
         public virtual double SumFromArray(Value_[] values)
         {
@@ -28,6 +30,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Returns the sum of all values in a map.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sumFromMap", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"values\",\"type\":{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}]")]
         public virtual double SumFromMap(IDictionary<string, Value_> values)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Old.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Old.cs
@@ -21,7 +21,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Doo wop that thing.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "doAThing")]
+        [System.Obsolete()]
         public virtual void DoAThing()
         {
             InvokeInstanceVoidMethod(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalConstructorArgument.cs
@@ -3,9 +3,11 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(OptionalConstructorArgument), fullyQualifiedName: "jsii-calc.OptionalConstructorArgument", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
     public class OptionalConstructorArgument : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public OptionalConstructorArgument(double arg1, string arg2, DateTime? arg3): base(new DeputyProps(new object[]{arg1, arg2, arg3}))
         {
         }
@@ -18,18 +20,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg1", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double Arg1
         {
             get => GetInstanceProperty<double>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg2", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string Arg2
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arg3", typeJson: "{\"primitive\":\"date\"}", isOptional: true)]
         public virtual DateTime? Arg3
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class OptionalStruct : IOptionalStruct
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "field", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
         public string Field
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(OptionalStructConsumer), fullyQualifiedName: "jsii-calc.OptionalStructConsumer", parametersJson: "[{\"name\":\"optionalStruct\",\"type\":{\"fqn\":\"jsii-calc.OptionalStruct\"},\"optional\":true}]")]
     public class OptionalStructConsumer : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public OptionalStructConsumer(IOptionalStruct optionalStruct): base(new DeputyProps(new object[]{optionalStruct}))
         {
         }
@@ -17,12 +19,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "parameterWasUndefined", typeJson: "{\"primitive\":\"boolean\"}")]
         public virtual bool ParameterWasUndefined
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "fieldValue", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public virtual string FieldValue
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IOptionalStruct), fullyQualifiedName: "jsii-calc.OptionalStruct")]
     internal sealed class OptionalStructProxy : DeputyBase, IOptionalStruct
     {
@@ -9,6 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "field", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
         public string Field
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OverrideReturnsObject.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OverrideReturnsObject.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(OverrideReturnsObject), fullyQualifiedName: "jsii-calc.OverrideReturnsObject")]
     public class OverrideReturnsObject : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "test", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IReturnsNumber\"}}]")]
         public virtual double Test(IIReturnsNumber obj)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumer.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(PartiallyInitializedThisConsumer), fullyQualifiedName: "jsii-calc.PartiallyInitializedThisConsumer")]
     public abstract class PartiallyInitializedThisConsumer : DeputyBase
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumePartiallyInitializedThis", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.ConstructorPassesThisOut\"}},{\"name\":\"dt\",\"type\":{\"primitive\":\"date\"}},{\"name\":\"ev\",\"type\":{\"fqn\":\"jsii-calc.AllTypesEnum\"}}]")]
         public abstract string ConsumePartiallyInitializedThis(ConstructorPassesThisOut obj, DateTime dt, AllTypesEnum ev);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumerProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumerProxy.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(PartiallyInitializedThisConsumer), fullyQualifiedName: "jsii-calc.PartiallyInitializedThisConsumer")]
     internal sealed class PartiallyInitializedThisConsumerProxy : PartiallyInitializedThisConsumer
     {
@@ -10,6 +11,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumePartiallyInitializedThis", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.ConstructorPassesThisOut\"}},{\"name\":\"dt\",\"type\":{\"primitive\":\"date\"}},{\"name\":\"ev\",\"type\":{\"fqn\":\"jsii-calc.AllTypesEnum\"}}]")]
         public override string ConsumePartiallyInitializedThis(ConstructorPassesThisOut obj, DateTime dt, AllTypesEnum ev)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Polymorphism.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Polymorphism.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Polymorphism), fullyQualifiedName: "jsii-calc.Polymorphism")]
     public class Polymorphism : DeputyBase
     {
@@ -18,6 +19,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sayHello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"friendly\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}]")]
         public virtual string SayHello(IIFriendly friendly)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Power.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Power.cs
@@ -5,12 +5,14 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The power operation.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Power), fullyQualifiedName: "jsii-calc.Power", parametersJson: "[{\"name\":\"base\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"pow\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public class Power : CompositeOperation_
     {
         /// <summary>Creates a Power operation.</summary>
         /// <param name = "@base">The base of the power.</param>
         /// <param name = "pow">The number of times to multiply.</param>
+        /// <remarks>stability: Experimental</remarks>
         public Power(Value_ @base, Value_ pow): base(new DeputyProps(new object[]{@base, pow}))
         {
         }
@@ -24,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The base of the power.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "base", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Base
         {
@@ -31,6 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public override Value_ Expression
         {
@@ -38,6 +42,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The number of times to multiply.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "pow", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Pow
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PublicClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PublicClass.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(PublicClass), fullyQualifiedName: "jsii-calc.PublicClass")]
     public class PublicClass : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello")]
         public virtual void Hello()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PythonReservedWords.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PythonReservedWords.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(PythonReservedWords), fullyQualifiedName: "jsii-calc.PythonReservedWords")]
     public class PythonReservedWords : DeputyBase
     {
@@ -17,192 +18,224 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "and")]
         public virtual void And()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "as")]
         public virtual void As()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "assert")]
         public virtual void Assert()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "async")]
         public virtual void Async()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "await")]
         public virtual void Await()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "break")]
         public virtual void Break()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "class")]
         public virtual void Class()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "continue")]
         public virtual void Continue()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "def")]
         public virtual void Def()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "del")]
         public virtual void Del()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "elif")]
         public virtual void Elif()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "else")]
         public virtual void Else()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "except")]
         public virtual void Except()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "finally")]
         public virtual void Finally()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "for")]
         public virtual void For()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "from")]
         public virtual void From()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "global")]
         public virtual void Global()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "if")]
         public virtual void If()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "import")]
         public virtual void Import()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "in")]
         public virtual void In()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "is")]
         public virtual void Is()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "lambda")]
         public virtual void Lambda()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "nonlocal")]
         public virtual void Nonlocal()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "not")]
         public virtual void Not()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "or")]
         public virtual void Or()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "pass")]
         public virtual void Pass()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "raise")]
         public virtual void Raise()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "return")]
         public virtual void Return()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "try")]
         public virtual void Try()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "while")]
         public virtual void While()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "with")]
         public virtual void With()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "yield")]
         public virtual void Yield()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReferenceEnumFromScopedPackage.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReferenceEnumFromScopedPackage.cs
@@ -4,6 +4,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>See awslabs/jsii#138.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ReferenceEnumFromScopedPackage), fullyQualifiedName: "jsii-calc.ReferenceEnumFromScopedPackage")]
     public class ReferenceEnumFromScopedPackage : DeputyBase
     {
@@ -19,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"}", isOptional: true)]
         public virtual EnumFromScopedModule? Foo
         {
@@ -26,12 +28,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "loadFoo", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"},\"optional\":true}")]
         public virtual EnumFromScopedModule? LoadFoo()
         {
             return InvokeInstanceMethod<EnumFromScopedModule? >(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "saveFoo", parametersJson: "[{\"name\":\"value\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"}}]")]
         public virtual void SaveFoo(EnumFromScopedModule value)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsPrivateImplementationOfInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsPrivateImplementationOfInterface.cs
@@ -3,7 +3,10 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Helps ensure the JSII kernel &amp; runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.</summary>
-    /// <remarks>https://github.com/awslabs/jsii/issues/320 </remarks>
+    /// <remarks>
+    /// stability: Experimental
+    /// https://github.com/awslabs/jsii/issues/320 
+    /// </remarks>
     [JsiiClass(nativeType: typeof(ReturnsPrivateImplementationOfInterface), fullyQualifiedName: "jsii-calc.ReturnsPrivateImplementationOfInterface")]
     public class ReturnsPrivateImplementationOfInterface : DeputyBase
     {
@@ -19,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "privateImplementation", typeJson: "{\"fqn\":\"jsii-calc.IPrivatelyImplemented\"}")]
         public virtual IIPrivatelyImplemented PrivateImplementation
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/RuntimeTypeChecking.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(RuntimeTypeChecking), fullyQualifiedName: "jsii-calc.RuntimeTypeChecking")]
     public class RuntimeTypeChecking : DeputyBase
     {
@@ -18,12 +19,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "methodWithDefaultedArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"},\"optional\":true},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"},\"optional\":true},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
         public virtual void MethodWithDefaultedArguments(double? arg1, string arg2, DateTime? arg3)
         {
             InvokeInstanceVoidMethod(new object[]{arg1, arg2, arg3});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "methodWithOptionalAnyArgument", parametersJson: "[{\"name\":\"arg\",\"type\":{\"primitive\":\"any\"},\"optional\":true}]")]
         public virtual void MethodWithOptionalAnyArgument(object arg)
         {
@@ -31,6 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Used to verify verification of number of method arguments.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "methodWithOptionalArguments", parametersJson: "[{\"name\":\"arg1\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"arg2\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"arg3\",\"type\":{\"primitive\":\"date\"},\"optional\":true}]")]
         public virtual void MethodWithOptionalArguments(double arg1, string arg2, DateTime? arg3)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingleInstanceTwoTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingleInstanceTwoTypes.cs
@@ -7,6 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// JSII clients can instantiate 2 different strongly-typed wrappers for the same
     /// object. Unfortunately, this will break object equality, but if we didn't do
     /// this it would break runtime type checks in the JVM or CLR.
+    /// stability: Experimental
     /// </remarks>
     [JsiiClass(nativeType: typeof(SingleInstanceTwoTypes), fullyQualifiedName: "jsii-calc.SingleInstanceTwoTypes")]
     public class SingleInstanceTwoTypes : DeputyBase
@@ -23,12 +24,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "interface1", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.InbetweenClass\"}}")]
         public virtual InbetweenClass Interface1()
         {
             return InvokeInstanceMethod<InbetweenClass>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "interface2", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
         public virtual IIPublicInterface Interface2()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StaticContext.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StaticContext.cs
@@ -3,7 +3,10 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>This is used to validate the ability to use `this` from within a static context.</summary>
-    /// <remarks>https://github.com/awslabs/aws-cdk/issues/2304</remarks>
+    /// <remarks>
+    /// https://github.com/awslabs/aws-cdk/issues/2304
+    /// stability: Experimental
+    /// </remarks>
     [JsiiClass(nativeType: typeof(StaticContext), fullyQualifiedName: "jsii-calc.StaticContext")]
     public class StaticContext : DeputyBase
     {
@@ -15,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "staticVariable", typeJson: "{\"primitive\":\"boolean\"}")]
         public static bool StaticVariable
         {
@@ -22,6 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetStaticProperty(typeof(StaticContext), value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "canAccessStaticContext", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}")]
         public static bool CanAccessStaticContext()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Statics.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Statics.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Statics), fullyQualifiedName: "jsii-calc.Statics", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"string\"}}]")]
     public class Statics : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public Statics(string value): base(new DeputyProps(new object[]{value}))
         {
         }
@@ -19,6 +21,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>Constants may also use all-caps.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "BAR", typeJson: "{\"primitive\":\"number\"}")]
         public static double BAR
         {
@@ -26,6 +29,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         = GetStaticProperty<double>(typeof(Statics));
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "ConstObj", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
         public static DoubleTrouble ConstObj
         {
@@ -34,6 +38,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         = GetStaticProperty<DoubleTrouble>(typeof(Statics));
         /// <summary>Jsdocs for static property.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "Foo", typeJson: "{\"primitive\":\"string\"}")]
         public static string Foo
         {
@@ -42,6 +47,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         = GetStaticProperty<string>(typeof(Statics));
         /// <summary>Constants can also use camelCase.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "zooBar", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         public static IDictionary<string, string> ZooBar
         {
@@ -50,6 +56,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         = GetStaticProperty<IDictionary<string, string>>(typeof(Statics));
         /// <summary>Jsdocs for static getter. Jsdocs for static setter.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "instance", typeJson: "{\"fqn\":\"jsii-calc.Statics\"}")]
         public static Statics Instance
         {
@@ -57,6 +64,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetStaticProperty(typeof(Statics), value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonConstStatic", typeJson: "{\"primitive\":\"number\"}")]
         public static double NonConstStatic
         {
@@ -64,6 +72,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetStaticProperty(typeof(Statics), value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string Value
         {
@@ -72,12 +81,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <summary>Jsdocs for static method.</summary>
         /// <param name = "name">The name of the person to say hello to.</param>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "staticMethod", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"name\",\"type\":{\"primitive\":\"string\"}}]")]
         public static string StaticMethod(string name)
         {
             return InvokeStaticMethod<string>(typeof(Statics), new object[]{name});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "justMethod", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string JustMethod()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StringEnum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StringEnum.cs
@@ -2,13 +2,17 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiEnum(nativeType: typeof(StringEnum), fullyQualifiedName: "jsii-calc.StringEnum")]
     public enum StringEnum
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "A")]
         A,
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "B")]
         B,
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "C")]
         C
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StripInternal.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StripInternal.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(StripInternal), fullyQualifiedName: "jsii-calc.StripInternal")]
     public class StripInternal : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "youSeeMe", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string YouSeeMe
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Sum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Sum.cs
@@ -5,9 +5,11 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation that sums multiple values.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Sum), fullyQualifiedName: "jsii-calc.Sum")]
     public class Sum : CompositeOperation_
     {
+        /// <remarks>stability: Experimental</remarks>
         public Sum(): base(new DeputyProps(new object[]{}))
         {
         }
@@ -21,6 +23,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public override Value_ Expression
         {
@@ -28,6 +31,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The parts to sum.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "parts", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}")]
         public virtual Value_[] Parts
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SyncVirtualMethods.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SyncVirtualMethods.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(SyncVirtualMethods), fullyQualifiedName: "jsii-calc.SyncVirtualMethods")]
     public class SyncVirtualMethods : DeputyBase
     {
@@ -17,12 +18,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string ReadonlyProperty
         {
             get => GetInstanceProperty<string>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "a", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double A
         {
@@ -30,6 +33,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "callerIsProperty", typeJson: "{\"primitive\":\"number\"}")]
         public virtual double CallerIsProperty
         {
@@ -37,6 +41,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "otherProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string OtherProperty
         {
@@ -44,6 +49,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "theProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string TheProperty
         {
@@ -51,6 +57,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "valueOfOtherProperty", typeJson: "{\"primitive\":\"string\"}")]
         public virtual string ValueOfOtherProperty
         {
@@ -58,60 +65,70 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set => SetInstanceProperty(value);
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "callerIsAsync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", isAsync: true)]
         public virtual double CallerIsAsync()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "callerIsMethod", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double CallerIsMethod()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "modifyOtherProperty", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"string\"}}]")]
         public virtual void ModifyOtherProperty(string value)
         {
             InvokeInstanceVoidMethod(new object[]{value});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "modifyValueOfTheProperty", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"string\"}}]")]
         public virtual void ModifyValueOfTheProperty(string value)
         {
             InvokeInstanceVoidMethod(new object[]{value});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readA", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
         public virtual double ReadA()
         {
             return InvokeInstanceMethod<double>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "retrieveOtherProperty", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string RetrieveOtherProperty()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "retrieveReadOnlyProperty", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string RetrieveReadOnlyProperty()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "retrieveValueOfTheProperty", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string RetrieveValueOfTheProperty()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "virtualMethod", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"n\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual double VirtualMethod(double n)
         {
             return InvokeInstanceMethod<double>(new object[]{n});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "writeA", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual void WriteA(double value)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Thrower.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Thrower.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Thrower), fullyQualifiedName: "jsii-calc.Thrower")]
     public class Thrower : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "throwError")]
         public virtual void ThrowError()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperation.cs
@@ -4,9 +4,11 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation on a single operand.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(UnaryOperation), fullyQualifiedName: "jsii-calc.UnaryOperation", parametersJson: "[{\"name\":\"operand\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
     public abstract class UnaryOperation : Operation
     {
+        /// <remarks>stability: Experimental</remarks>
         protected UnaryOperation(Value_ operand): base(new DeputyProps(new object[]{operand}))
         {
         }
@@ -19,6 +21,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operand", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Operand
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
@@ -3,6 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation on a single operand.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(UnaryOperation), fullyQualifiedName: "jsii-calc.UnaryOperation")]
     internal sealed class UnaryOperationProxy : UnaryOperation
     {
@@ -11,14 +12,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        [System.Obsolete()]
         public override double Value
         {
             get => GetInstanceProperty<double>();
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
+        [System.Obsolete()]
         public override string ToString()
         {
             return InvokeInstanceMethod<string>(new object[]{});

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
     public class UnionProperties : IUnionProperties
     {
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bar", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.AllTypes\"}]}}", isOverride: true)]
         public object Bar
         {
@@ -12,6 +14,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"}]}}", isOptional: true, isOverride: true)]
         public object Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IUnionProperties), fullyQualifiedName: "jsii-calc.UnionProperties")]
     internal sealed class UnionPropertiesProxy : DeputyBase, IUnionProperties
     {
@@ -9,12 +10,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bar", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.AllTypes\"}]}}")]
         public object Bar
         {
             get => GetInstanceProperty<object>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"}]}}", isOptional: true)]
         public object Foo
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseBundledDependency.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseBundledDependency.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(UseBundledDependency), fullyQualifiedName: "jsii-calc.UseBundledDependency")]
     public class UseBundledDependency : DeputyBase
     {
@@ -17,6 +18,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "value", returnsJson: "{\"type\":{\"primitive\":\"any\"}}")]
         public virtual object Value()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseCalcBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseCalcBase.cs
@@ -4,6 +4,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(UseCalcBase), fullyQualifiedName: "jsii-calc.UseCalcBase")]
     public class UseCalcBase : DeputyBase
     {
@@ -19,6 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hello", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-base.Base\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base Hello()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UsesInterfaceWithProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UsesInterfaceWithProperties.cs
@@ -2,9 +2,11 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(UsesInterfaceWithProperties), fullyQualifiedName: "jsii-calc.UsesInterfaceWithProperties", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IInterfaceWithProperties\"}}]")]
     public class UsesInterfaceWithProperties : DeputyBase
     {
+        /// <remarks>stability: Experimental</remarks>
         public UsesInterfaceWithProperties(IIInterfaceWithProperties obj): base(new DeputyProps(new object[]{obj}))
         {
         }
@@ -17,24 +19,28 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "obj", typeJson: "{\"fqn\":\"jsii-calc.IInterfaceWithProperties\"}")]
         public virtual IIInterfaceWithProperties Obj
         {
             get => GetInstanceProperty<IIInterfaceWithProperties>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "justRead", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
         public virtual string JustRead()
         {
             return InvokeInstanceMethod<string>(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readStringAndNumber", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"ext\",\"type\":{\"fqn\":\"jsii-calc.IInterfaceWithPropertiesExtension\"}}]")]
         public virtual string ReadStringAndNumber(IIInterfaceWithPropertiesExtension ext)
         {
             return InvokeInstanceMethod<string>(new object[]{ext});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "writeAndRead", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"string\"}}]")]
         public virtual string WriteAndRead(string value)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicMethod.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicMethod.cs
@@ -2,10 +2,12 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(VariadicMethod), fullyQualifiedName: "jsii-calc.VariadicMethod", parametersJson: "[{\"name\":\"prefix\",\"variadic\":true,\"type\":{\"primitive\":\"number\"}}]")]
     public class VariadicMethod : DeputyBase
     {
         /// <param name = "prefix">a prefix that will be use for all values returned by `#asArray`.</param>
+        /// <remarks>stability: Experimental</remarks>
         public VariadicMethod(double prefix): base(new DeputyProps(new object[]{prefix}))
         {
         }
@@ -20,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <param name = "first">the first element of the array to be returned (after the `prefix` provided at construction time).</param>
         /// <param name = "others">other elements to be included in the array.</param>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "asArray", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"number\"}}}}", parametersJson: "[{\"name\":\"first\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"others\",\"variadic\":true,\"type\":{\"primitive\":\"number\"}}]")]
         public virtual double[] AsArray(double first, double others)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VirtualMethodPlayground.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VirtualMethodPlayground.cs
@@ -2,6 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(VirtualMethodPlayground), fullyQualifiedName: "jsii-calc.VirtualMethodPlayground")]
     public class VirtualMethodPlayground : DeputyBase
     {
@@ -17,30 +18,35 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMeAsync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"index\",\"type\":{\"primitive\":\"number\"}}]", isAsync: true)]
         public virtual double OverrideMeAsync(double index)
         {
             return InvokeInstanceMethod<double>(new object[]{index});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMeSync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"index\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual double OverrideMeSync(double index)
         {
             return InvokeInstanceMethod<double>(new object[]{index});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "parallelSumAsync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"count\",\"type\":{\"primitive\":\"number\"}}]", isAsync: true)]
         public virtual double ParallelSumAsync(double count)
         {
             return InvokeInstanceMethod<double>(new object[]{count});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "serialSumAsync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"count\",\"type\":{\"primitive\":\"number\"}}]", isAsync: true)]
         public virtual double SerialSumAsync(double count)
         {
             return InvokeInstanceMethod<double>(new object[]{count});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sumSync", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"count\",\"type\":{\"primitive\":\"number\"}}]")]
         public virtual double SumSync(double count)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallback.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallback.cs
@@ -7,6 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// - Implement `overrideMe` (method does not have to do anything).
     /// - Invoke `callMe`
     /// - Verify that `methodWasCalled` is `true`.
+    /// stability: Experimental
     /// </remarks>
     [JsiiClass(nativeType: typeof(VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
     public abstract class VoidCallback : DeputyBase
@@ -23,18 +24,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "methodWasCalled", typeJson: "{\"primitive\":\"boolean\"}")]
         public virtual bool MethodWasCalled
         {
             get => GetInstanceProperty<bool>();
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "callMe")]
         public virtual void CallMe()
         {
             InvokeInstanceVoidMethod(new object[]{});
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMe")]
         protected abstract void OverrideMe();
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
@@ -7,6 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// - Implement `overrideMe` (method does not have to do anything).
     /// - Invoke `callMe`
     /// - Verify that `methodWasCalled` is `true`.
+    /// stability: Experimental
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
     internal sealed class VoidCallbackProxy : VoidCallback
@@ -15,6 +16,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "overrideMe")]
         protected override void OverrideMe()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation/CompositionStringStyle.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation/CompositionStringStyle.cs
@@ -3,13 +3,16 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation
 {
     /// <summary>Style of .toString() output for CompositeOperation.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiEnum(nativeType: typeof(CompositionStringStyle), fullyQualifiedName: "jsii-calc.composition.CompositeOperation.CompositionStringStyle")]
     public enum CompositionStringStyle
     {
         /// <summary>Normal string expression.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "Normal")]
         Normal,
         /// <summary>Decorated string expression.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiEnumMember(name: "Decorated")]
         Decorated
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
@@ -4,6 +4,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition
 {
     /// <summary>Abstract operation composed from an expression of other operations.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(CompositeOperation_), fullyQualifiedName: "jsii-calc.composition.CompositeOperation")]
     internal sealed class CompositeOperationProxy : CompositeOperation_
     {
@@ -12,6 +13,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public override Value_ Expression
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation_.cs
@@ -5,6 +5,7 @@ using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition
 {
     /// <summary>Abstract operation composed from an expression of other operations.</summary>
+    /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(CompositeOperation_), fullyQualifiedName: "jsii-calc.composition.CompositeOperation")]
     public abstract class CompositeOperation_ : Operation
     {
@@ -21,6 +22,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
         public virtual Value_ Expression
         {
@@ -28,6 +30,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>The value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
         public override double Value
         {
@@ -35,6 +38,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>A set of postfixes to include in a decorated .toString().</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "decorationPostfixes", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         public virtual string[] DecorationPostfixes
         {
@@ -43,6 +47,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>A set of prefixes to include in a decorated .toString().</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "decorationPrefixes", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"string\"}}}")]
         public virtual string[] DecorationPrefixes
         {
@@ -51,6 +56,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>The .toString() style.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "stringStyle", typeJson: "{\"fqn\":\"jsii-calc.composition.CompositeOperation.CompositionStringStyle\"}")]
         public virtual CompositionStringStyle StringStyle
         {
@@ -59,6 +65,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         }
 
         /// <summary>String representation of the value.</summary>
+        /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "toString", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", isOverride: true)]
         public override string ToString()
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClass")
 public abstract class AbstractClass extends software.amazon.jsii.tests.calculator.AbstractClassBase implements software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass {
     protected AbstractClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,13 +15,25 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public abstract java.lang.String abstractMethod(final java.lang.String name);
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number nonAbstractMethod() {
         return this.jsiiCall("nonAbstractMethod", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getPropFromInterface() {
         return this.jsiiGet("propFromInterface", java.lang.String.class);
     }
@@ -30,16 +46,28 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getPropFromInterface() {
             return this.jsiiGet("propFromInterface", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getAbstractProperty() {
             return this.jsiiGet("abstractProperty", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String abstractMethod(final java.lang.String name) {
             return this.jsiiCall("abstractMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassBase")
 public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject {
     protected AbstractClassBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getAbstractProperty() {
         return this.jsiiGet("abstractProperty", java.lang.String.class);
     }
@@ -23,7 +31,11 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getAbstractProperty() {
             return this.jsiiGet("abstractProperty", java.lang.String.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassReturner")
 public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
     protected AbstractClassReturner(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,14 +15,26 @@ public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.AbstractClass giveMeAbstract() {
         return this.jsiiCall("giveMeAbstract", software.amazon.jsii.tests.calculator.AbstractClass.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass giveMeInterface() {
         return this.jsiiCall("giveMeInterface", software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.AbstractClassBase getReturnAbstractFromProperty() {
         return this.jsiiGet("returnAbstractFromProperty", software.amazon.jsii.tests.calculator.AbstractClassBase.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * The "+" binary operation.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Add")
 public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
     protected Add(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,9 +15,12 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
     /**
      * Creates a BinaryOperation.
      * 
+     * EXPERIMENTAL
+     * 
      * @param lhs Left-hand side operand.
      * @param rhs Right-hand side operand.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Add(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
@@ -22,7 +28,10 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
 
     /**
      * String representation of the value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
@@ -30,8 +39,11 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
 
     /**
      * The value.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -5,8 +5,11 @@ package software.amazon.jsii.tests.calculator;
  * 
  * The setters will validate
  * that the value set is of the expected type and throw otherwise.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AllTypes")
 public class AllTypes extends software.amazon.jsii.JsiiObject {
     protected AllTypes(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -17,178 +20,350 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void anyIn(@javax.annotation.Nullable final java.lang.Object inp) {
         this.jsiiCall("anyIn", Void.class, new Object[] { inp });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object anyOut() {
         return this.jsiiCall("anyOut", java.lang.Object.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.StringEnum enumMethod(final software.amazon.jsii.tests.calculator.StringEnum value) {
         return this.jsiiCall("enumMethod", software.amazon.jsii.tests.calculator.StringEnum.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getEnumPropertyValue() {
         return this.jsiiGet("enumPropertyValue", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getAnyArrayProperty() {
         return this.jsiiGet("anyArrayProperty", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setAnyArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("anyArrayProperty", java.util.Objects.requireNonNull(value, "anyArrayProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getAnyMapProperty() {
         return this.jsiiGet("anyMapProperty", java.util.Map.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setAnyMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("anyMapProperty", java.util.Objects.requireNonNull(value, "anyMapProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object getAnyProperty() {
         return this.jsiiGet("anyProperty", java.lang.Object.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setAnyProperty(@javax.annotation.Nullable final java.lang.Object value) {
         this.jsiiSet("anyProperty", java.util.Objects.requireNonNull(value, "anyProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getArrayProperty() {
         return this.jsiiGet("arrayProperty", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setArrayProperty(final java.util.List<java.lang.String> value) {
         this.jsiiSet("arrayProperty", java.util.Objects.requireNonNull(value, "arrayProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean getBooleanProperty() {
         return this.jsiiGet("booleanProperty", java.lang.Boolean.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setBooleanProperty(final java.lang.Boolean value) {
         this.jsiiSet("booleanProperty", java.util.Objects.requireNonNull(value, "booleanProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.time.Instant getDateProperty() {
         return this.jsiiGet("dateProperty", java.time.Instant.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setDateProperty(final java.time.Instant value) {
         this.jsiiSet("dateProperty", java.util.Objects.requireNonNull(value, "dateProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.AllTypesEnum getEnumProperty() {
         return this.jsiiGet("enumProperty", software.amazon.jsii.tests.calculator.AllTypesEnum.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setEnumProperty(final software.amazon.jsii.tests.calculator.AllTypesEnum value) {
         this.jsiiSet("enumProperty", java.util.Objects.requireNonNull(value, "enumProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public com.fasterxml.jackson.databind.node.ObjectNode getJsonProperty() {
         return this.jsiiGet("jsonProperty", com.fasterxml.jackson.databind.node.ObjectNode.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setJsonProperty(final com.fasterxml.jackson.databind.node.ObjectNode value) {
         this.jsiiSet("jsonProperty", java.util.Objects.requireNonNull(value, "jsonProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> getMapProperty() {
         return this.jsiiGet("mapProperty", java.util.Map.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setMapProperty(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> value) {
         this.jsiiSet("mapProperty", java.util.Objects.requireNonNull(value, "mapProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getNumberProperty() {
         return this.jsiiGet("numberProperty", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setNumberProperty(final java.lang.Number value) {
         this.jsiiSet("numberProperty", java.util.Objects.requireNonNull(value, "numberProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getStringProperty() {
         return this.jsiiGet("stringProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setStringProperty(final java.lang.String value) {
         this.jsiiSet("stringProperty", java.util.Objects.requireNonNull(value, "stringProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getUnionArrayProperty() {
         return this.jsiiGet("unionArrayProperty", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("unionArrayProperty", java.util.Objects.requireNonNull(value, "unionArrayProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getUnionMapProperty() {
         return this.jsiiGet("unionMapProperty", java.util.Map.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unionMapProperty", java.util.Objects.requireNonNull(value, "unionMapProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(final java.lang.String value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(final java.lang.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(final software.amazon.jsii.tests.calculator.lib.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getUnknownArrayProperty() {
         return this.jsiiGet("unknownArrayProperty", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnknownArrayProperty(final java.util.List<java.lang.Object> value) {
         this.jsiiSet("unknownArrayProperty", java.util.Objects.requireNonNull(value, "unknownArrayProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getUnknownMapProperty() {
         return this.jsiiGet("unknownMapProperty", java.util.Map.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnknownMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unknownMapProperty", java.util.Objects.requireNonNull(value, "unknownMapProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object getUnknownProperty() {
         return this.jsiiGet("unknownProperty", java.lang.Object.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnknownProperty(@javax.annotation.Nullable final java.lang.Object value) {
         this.jsiiSet("unknownProperty", java.util.Objects.requireNonNull(value, "unknownProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.StringEnum getOptionalEnumValue() {
         return this.jsiiGet("optionalEnumValue", software.amazon.jsii.tests.calculator.StringEnum.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setOptionalEnumValue(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.StringEnum value) {
         this.jsiiSet("optionalEnumValue", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypesEnum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypesEnum.java
@@ -1,9 +1,25 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AllTypesEnum")
 public enum AllTypesEnum {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     MyEnumValue,
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     YourEnumValue,
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     ThisIsGreat,
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AllowedMethodNames")
 public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
     protected AllowedMethodNames(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,24 +15,38 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void getBar(final java.lang.String _p1, final java.lang.Number _p2) {
         this.jsiiCall("getBar", Void.class, new Object[] { java.util.Objects.requireNonNull(_p1, "_p1 is required"), java.util.Objects.requireNonNull(_p2, "_p2 is required") });
     }
 
     /**
      * getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getFoo(final java.lang.String withParam) {
         return this.jsiiCall("getFoo", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(withParam, "withParam is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setBar(final java.lang.String _x, final java.lang.Number _y, final java.lang.Boolean _z) {
         this.jsiiCall("setBar", Void.class, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required"), java.util.Objects.requireNonNull(_z, "_z is required") });
     }
 
     /**
      * setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setFoo(final java.lang.String _x, final java.lang.Number _y) {
         this.jsiiCall("setFoo", Void.class, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AsyncVirtualMethods")
 public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     protected AsyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,13 +15,20 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number callMe() {
         return this.jsiiAsyncCall("callMe", java.lang.Number.class);
     }
 
     /**
      * Just calls "overrideMeToo".
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number callMe2() {
         return this.jsiiAsyncCall("callMe2", java.lang.Number.class);
     }
@@ -28,19 +39,34 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * This is a "double promise" situation, which
      * means that callbacks are not going to be available immediate, but only
      * after an "immediates" cycle.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number callMeDoublePromise() {
         return this.jsiiAsyncCall("callMeDoublePromise", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number dontOverrideMe() {
         return this.jsiiCall("dontOverrideMe", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMe(final java.lang.Number mult) {
         return this.jsiiAsyncCall("overrideMe", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(mult, "mult is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMeToo() {
         return this.jsiiAsyncCall("overrideMeToo", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AugmentableClass")
 public class AugmentableClass extends software.amazon.jsii.JsiiObject {
     protected AugmentableClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class AugmentableClass extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodOne() {
         this.jsiiCall("methodOne", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodTwo() {
         this.jsiiCall("methodTwo", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Represents an operation with two operands.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.BinaryOperation")
 public abstract class BinaryOperation extends software.amazon.jsii.tests.calculator.lib.Operation implements software.amazon.jsii.tests.calculator.lib.IFriendly {
     protected BinaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,9 +15,12 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
     /**
      * Creates a BinaryOperation.
      * 
+     * EXPERIMENTAL
+     * 
      * @param lhs Left-hand side operand.
      * @param rhs Right-hand side operand.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
@@ -22,7 +28,10 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
 
     /**
      * Say hello!
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
@@ -30,14 +39,20 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
 
     /**
      * Left-hand side operand.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getLhs() {
         return this.jsiiGet("lhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * Right-hand side operand.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getRhs() {
         return this.jsiiGet("rhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
@@ -54,6 +69,8 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
          * The value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
@@ -61,6 +78,8 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
         /**
          * Say hello!
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);
@@ -69,6 +88,8 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
         /**
          * String representation of the value.
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * A calculator which maintains a current value and allows adding operations.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Calculator")
 public class Calculator extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
     protected Calculator(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,15 +15,21 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
     /**
      * Creates a Calculator object.
      * 
+     * EXPERIMENTAL
+     * 
      * @param props Initialization properties.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Calculator(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.CalculatorProps props) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props });
     }
     /**
      * Creates a Calculator object.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Calculator() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
@@ -28,78 +37,111 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
 
     /**
      * Adds a number to the current value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void add(final java.lang.Number value) {
         this.jsiiCall("add", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
      * Multiplies the current value by a number.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void mul(final java.lang.Number value) {
         this.jsiiCall("mul", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
      * Negates the current value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void neg() {
         this.jsiiCall("neg", Void.class);
     }
 
     /**
      * Raises the current value by a power.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void pow(final java.lang.Number value) {
         this.jsiiCall("pow", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
     /**
      * Returns teh value of the union property (if defined).
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number readUnionValue() {
         return this.jsiiCall("readUnionValue", java.lang.Number.class);
     }
 
     /**
      * Returns the expression.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * A log of all operations.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getOperationsLog() {
         return this.jsiiGet("operationsLog", java.util.List.class);
     }
 
     /**
      * A map of per operation name of all operations performed.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.util.List<software.amazon.jsii.tests.calculator.lib.Value>> getOperationsMap() {
         return this.jsiiGet("operationsMap", java.util.Map.class);
     }
 
     /**
      * The current value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getCurr() {
         return this.jsiiGet("curr", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * The current value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setCurr(final software.amazon.jsii.tests.calculator.lib.Value value) {
         this.jsiiSet("curr", java.util.Objects.requireNonNull(value, "curr is required"));
     }
 
     /**
      * The maximum value allows in this calculator.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Number getMaxValue() {
         return this.jsiiGet("maxValue", java.lang.Number.class);
@@ -107,14 +149,20 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
 
     /**
      * The maximum value allows in this calculator.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setMaxValue(@javax.annotation.Nullable final java.lang.Number value) {
         this.jsiiSet("maxValue", value);
     }
 
     /**
      * Example of a property that accepts a union of types.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
@@ -122,21 +170,30 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
 
     /**
      * Example of a property that accepts a union of types.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Add value) {
         this.jsiiSet("unionProperty", value);
     }
 
     /**
      * Example of a property that accepts a union of types.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", value);
     }
 
     /**
      * Example of a property that accepts a union of types.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Power value) {
         this.jsiiSet("unionProperty", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -2,15 +2,27 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Properties for Calculator.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getInitialValue();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getMaximumValue();
 
     /**
      * @return a {@link Builder} of {@link CalculatorProps}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -18,6 +30,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link CalculatorProps}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.Number _initialValue;
@@ -29,6 +42,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withInitialValue(@javax.annotation.Nullable final java.lang.Number value) {
             this._initialValue = value;
             return this;
@@ -38,6 +52,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withMaximumValue(@javax.annotation.Nullable final java.lang.Number value) {
             this._maximumValue = value;
             return this;
@@ -48,6 +63,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link CalculatorProps}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public CalculatorProps build() {
             return new CalculatorProps() {
                 @javax.annotation.Nullable
@@ -85,13 +101,21 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Number getInitialValue() {
             return this.jsiiGet("initialValue", java.lang.Number.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Number getMaximumValue() {
             return this.jsiiGet("maximumValue", java.lang.Number.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsTheInternalInterface")
 public class ClassThatImplementsTheInternalInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
     protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,40 +15,72 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getA() {
         return this.jsiiGet("a", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setA(final java.lang.String value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getB() {
         return this.jsiiGet("b", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setB(final java.lang.String value) {
         this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getC() {
         return this.jsiiGet("c", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setC(final java.lang.String value) {
         this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getD() {
         return this.jsiiGet("d", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setD(final java.lang.String value) {
         this.jsiiSet("d", java.util.Objects.requireNonNull(value, "d is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsThePrivateInterface")
 public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
     protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,40 +15,72 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getA() {
         return this.jsiiGet("a", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setA(final java.lang.String value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getB() {
         return this.jsiiGet("b", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setB(final java.lang.String value) {
         this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getC() {
         return this.jsiiGet("c", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setC(final java.lang.String value) {
         this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getE() {
         return this.jsiiGet("e", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setE(final java.lang.String value) {
         this.jsiiSet("e", java.util.Objects.requireNonNull(value, "e is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithMutableObjectLiteralProperty")
 public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.JsiiObject {
     protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IMutableObjectLiteral getMutableObject() {
         return this.jsiiGet("mutableObject", software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setMutableObject(final software.amazon.jsii.tests.calculator.IMutableObjectLiteral value) {
         this.jsiiSet("mutableObject", java.util.Objects.requireNonNull(value, "mutableObject is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
@@ -2,29 +2,48 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Class that implements interface properties automatically, but using a private constructor.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties")
 public class ClassWithPrivateConstructorAndAutomaticProperties extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
     protected ClassWithPrivateConstructorAndAutomaticProperties(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties create(final java.lang.String readOnlyString, final java.lang.String readWriteString) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, "create", software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, new Object[] { java.util.Objects.requireNonNull(readOnlyString, "readOnlyString is required"), java.util.Objects.requireNonNull(readWriteString, "readWriteString is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getReadOnlyString() {
         return this.jsiiGet("readOnlyString", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getReadWriteString() {
         return this.jsiiGet("readWriteString", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setReadWriteString(final java.lang.String value) {
         this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -1,11 +1,19 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ConstructorPassesThisOut")
 public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
     protected ConstructorPassesThisOut(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ConstructorPassesThisOut(final software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(consumer, "consumer is required") });

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Constructors")
 public class Constructors extends software.amazon.jsii.JsiiObject {
     protected Constructors(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,30 +15,58 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.IPublicInterface hiddenInterface() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterface", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenInterfaces() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterfaces", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenSubInterfaces() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenSubInterfaces", java.util.List.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.PublicClass makeClass() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeClass", software.amazon.jsii.tests.calculator.PublicClass.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.IPublicInterface makeInterface() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterface", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.IPublicInterface2 makeInterface2() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterface2", software.amazon.jsii.tests.calculator.IPublicInterface2.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> makeInterfaces() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterfaces", java.util.List.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ConsumersOfThisCrazyTypeSystem")
 public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObject {
     protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String consumeAnotherPublicInterface(final software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
         return this.jsiiCall("consumeAnotherPublicInterface", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
         return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -1,36 +1,68 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DefaultedConstructorArgument")
 public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObject {
     protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getArg1() {
         return this.jsiiGet("arg1", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.String getArg2() {
         return this.jsiiGet("arg2", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DerivedClassHasNoProperties.Base")
 public class Base extends software.amazon.jsii.JsiiObject {
     protected Base(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class Base extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getProp() {
         return this.jsiiGet("prop", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setProp(final java.lang.String value) {
         this.jsiiSet("prop", java.util.Objects.requireNonNull(value, "prop is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DerivedClassHasNoProperties.Derived")
 public class Derived extends software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base {
     protected Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -2,25 +2,51 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * A struct which derives from another struct.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.lib.MyFirstStruct {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.time.Instant getAnotherRequired();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getBool();
     /**
      * An example of a non primitive property.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive();
     /**
      * This is optional.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getOptionalAny();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.List<java.lang.String> getOptionalArray();
 
     /**
      * @return a {@link Builder} of {@link DerivedStruct}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -28,6 +54,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
     /**
      * A builder for {@link DerivedStruct}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.time.Instant _anotherRequired;
         private java.lang.Boolean _bool;
@@ -48,6 +75,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withAnotherRequired(final java.time.Instant value) {
             this._anotherRequired = java.util.Objects.requireNonNull(value, "anotherRequired is required");
             return this;
@@ -57,6 +85,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withBool(final java.lang.Boolean value) {
             this._bool = java.util.Objects.requireNonNull(value, "bool is required");
             return this;
@@ -66,6 +95,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value An example of a non primitive property.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withNonPrimitive(final software.amazon.jsii.tests.calculator.DoubleTrouble value) {
             this._nonPrimitive = java.util.Objects.requireNonNull(value, "nonPrimitive is required");
             return this;
@@ -75,6 +105,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value This is optional.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withAnotherOptional(@javax.annotation.Nullable final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value) {
             this._anotherOptional = value;
             return this;
@@ -84,6 +115,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withOptionalAny(@javax.annotation.Nullable final java.lang.Object value) {
             this._optionalAny = value;
             return this;
@@ -93,6 +125,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withOptionalArray(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this._optionalArray = value;
             return this;
@@ -102,6 +135,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value An awesome number value.
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withAnumber(final java.lang.Number value) {
             this._anumber = java.util.Objects.requireNonNull(value, "anumber is required");
             return this;
@@ -111,6 +146,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value A string value.
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withAstring(final java.lang.String value) {
             this._astring = java.util.Objects.requireNonNull(value, "astring is required");
             return this;
@@ -120,6 +157,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @param value the value to be set
          * @return {@code this}
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder withFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
             this._firstOptional = value;
             return this;
@@ -130,6 +169,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @return a new instance of {@link DerivedStruct}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public DerivedStruct build() {
             return new DerivedStruct() {
                 private final java.time.Instant $anotherRequired = java.util.Objects.requireNonNull(_anotherRequired, "anotherRequired is required");
@@ -218,40 +258,62 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.time.Instant getAnotherRequired() {
             return this.jsiiGet("anotherRequired", java.time.Instant.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getBool() {
             return this.jsiiGet("bool", java.lang.Boolean.class);
         }
 
         /**
          * An example of a non primitive property.
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive() {
             return this.jsiiGet("nonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class);
         }
 
         /**
          * This is optional.
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
             return this.jsiiGet("anotherOptional", java.util.Map.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Object getOptionalAny() {
             return this.jsiiGet("optionalAny", java.lang.Object.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.util.List<java.lang.String> getOptionalArray() {
             return this.jsiiGet("optionalArray", java.util.List.class);
@@ -261,6 +323,8 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * An awesome number value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getAnumber() {
             return this.jsiiGet("anumber", java.lang.Number.class);
         }
@@ -269,11 +333,17 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * A string value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.String getAstring() {
             return this.jsiiGet("astring", java.lang.String.class);
         }
 
+        /**
+         */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @javax.annotation.Nullable
         public java.util.List<java.lang.String> getFirstOptional() {
             return this.jsiiGet("firstOptional", java.util.List.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoNotOverridePrivates")
 public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
     protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,14 +15,26 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void changePrivatePropertyValue(final java.lang.String newValue) {
         this.jsiiCall("changePrivatePropertyValue", Void.class, new Object[] { java.util.Objects.requireNonNull(newValue, "newValue is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String privateMethodValue() {
         return this.jsiiCall("privateMethodValue", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String privatePropertyValue() {
         return this.jsiiCall("privatePropertyValue", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * jsii#284: do not recognize "any" as an optional argument.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoNotRecognizeAnyAsOptional")
 public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject {
     protected DoNotRecognizeAnyAsOptional(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -14,14 +17,26 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny, @javax.annotation.Nullable final java.lang.String _optionalString) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny, _optionalString });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
@@ -29,6 +29,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * @return A number that everyone knows very well
      * @param greetee The person to be greeted.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public java.lang.Number greet(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Greetee greetee) {
         return this.jsiiCall("greet", java.lang.Number.class, new Object[] { greetee });
     }
@@ -41,6 +42,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * 
      * @return A number that everyone knows very well
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public java.lang.Number greet() {
         return this.jsiiCall("greet", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DontComplainAboutVariadicAfterOptional")
 public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii.JsiiObject {
     protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String optionalAndVariadic(@javax.annotation.Nullable final java.lang.String optional, final java.lang.String... things) {
         return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { optional }), java.util.Arrays.<Object>stream(things)).toArray(Object[]::new));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoubleTrouble")
 public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator {
     protected DoubleTrouble(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -13,7 +17,10 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
 
     /**
      * Say hello!
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
@@ -21,7 +28,10 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
 
     /**
      * Returns another random number.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.EraseUndefinedHashValues")
 public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
     protected EraseUndefinedHashValues(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -16,14 +20,20 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * 
      * Used to check that undefined/null hash values
      * are being erased when sending values from native code to JS.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.Boolean doesKeyExist(final software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions opts, final java.lang.String key) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "doesKeyExist", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(opts, "opts is required"), java.util.Objects.requireNonNull(key, "key is required") });
     }
 
     /**
      * We expect "prop1" to be erased.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public static java.lang.Object prop1IsNull() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop1IsNull", java.lang.Object.class);
@@ -31,7 +41,10 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
 
     /**
      * We expect "prop2" to be erased.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public static java.lang.Object prop2IsUndefined() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop2IsUndefined", java.lang.Object.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -1,13 +1,26 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOption1();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOption2();
 
     /**
      * @return a {@link Builder} of {@link EraseUndefinedHashValuesOptions}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -15,6 +28,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
     /**
      * A builder for {@link EraseUndefinedHashValuesOptions}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.String _option1;
@@ -26,6 +40,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withOption1(@javax.annotation.Nullable final java.lang.String value) {
             this._option1 = value;
             return this;
@@ -35,6 +50,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withOption2(@javax.annotation.Nullable final java.lang.String value) {
             this._option2 = value;
             return this;
@@ -45,6 +61,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
          * @return a new instance of {@link EraseUndefinedHashValuesOptions}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public EraseUndefinedHashValuesOptions build() {
             return new EraseUndefinedHashValuesOptions() {
                 @javax.annotation.Nullable
@@ -82,13 +99,21 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getOption1() {
             return this.jsiiGet("option1", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getOption2() {
             return this.jsiiGet("option2", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -1,16 +1,28 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ExportedBaseClass")
 public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
     protected ExportedBaseClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExportedBaseClass(final java.lang.Boolean success) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(success, "success is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean getSuccess() {
         return this.jsiiGet("success", java.lang.Boolean.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -1,13 +1,26 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getBoom();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getProp();
 
     /**
      * @return a {@link Builder} of {@link ExtendsInternalInterface}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -15,6 +28,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
     /**
      * A builder for {@link ExtendsInternalInterface}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.lang.Boolean _boom;
         private java.lang.String _prop;
@@ -24,6 +38,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withBoom(final java.lang.Boolean value) {
             this._boom = java.util.Objects.requireNonNull(value, "boom is required");
             return this;
@@ -33,6 +48,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withProp(final java.lang.String value) {
             this._prop = java.util.Objects.requireNonNull(value, "prop is required");
             return this;
@@ -43,6 +59,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
          * @return a new instance of {@link ExtendsInternalInterface}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public ExtendsInternalInterface build() {
             return new ExtendsInternalInterface() {
                 private final java.lang.Boolean $boom = java.util.Objects.requireNonNull(_boom, "boom is required");
@@ -78,12 +95,20 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getBoom() {
             return this.jsiiGet("boom", java.lang.Boolean.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getProp() {
             return this.jsiiGet("prop", java.lang.String.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.GiveMeStructs")
 public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
     protected GiveMeStructs(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -13,25 +17,38 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
 
     /**
      * Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("derivedToFirst", software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
     /**
      * Returns the boolean from a DerivedStruct struct.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("readDerivedNonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
     /**
      * Returns the "anumber" from a MyFirstStruct struct;
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number readFirstNumber(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {
         return this.jsiiCall("readFirstNumber", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(first, "first is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals getStructLiteral() {
         return this.jsiiGet("structLiteral", software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -2,19 +2,26 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * These are some arguments you can pass to a method.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Greetee extends software.amazon.jsii.JsiiSerializable {
     /**
      * The name of the greetee.
      * 
      * Default: world
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getName();
 
     /**
      * @return a {@link Builder} of {@link Greetee}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -22,6 +29,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link Greetee}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.String _name;
@@ -31,6 +39,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
          * @param value The name of the greetee.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withName(@javax.annotation.Nullable final java.lang.String value) {
             this._name = value;
             return this;
@@ -41,6 +50,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link Greetee}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Greetee build() {
             return new Greetee() {
                 @javax.annotation.Nullable
@@ -74,8 +84,11 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
          * The name of the greetee.
          * 
          * Default: world
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getName() {
             return this.jsiiGet("name", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.GreetingAugmenter")
 public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
     protected GreetingAugmenter(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String betterGreeting(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
         return this.jsiiCall("betterGreeting", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -1,8 +1,19 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getA();
+    /**
+     * EXPERIMENTAL
+     */
     void setA(final java.lang.String value);
 
     /**
@@ -13,12 +24,20 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getA() {
             return this.jsiiGet("a", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setA(final java.lang.String value) {
             this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
@@ -1,9 +1,24 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.List<java.lang.String> getMoreThings();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getPrivate();
+    /**
+     * EXPERIMENTAL
+     */
     void setPrivate(final java.lang.String value);
 
     /**
@@ -14,17 +29,29 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.util.List<java.lang.String> getMoreThings() {
             return this.jsiiGet("moreThings", java.util.List.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getPrivate() {
             return this.jsiiGet("private", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setPrivate(final java.lang.String value) {
             this.jsiiSet("private", java.util.Objects.requireNonNull(value, "private is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -2,18 +2,27 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Even friendlier classes can implement this interface.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.lib.IFriendly {
     /**
      * Say farewell.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String farewell();
     /**
      * Say goodbye.
      * 
+     * EXPERIMENTAL
+     * 
      * @return A goodbye blessing.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String goodbye();
 
     /**
@@ -26,7 +35,10 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
 
         /**
          * Say farewell.
+         * 
+         * EXPERIMENTAL
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String farewell() {
             return this.jsiiCall("farewell", java.lang.String.class);
@@ -35,8 +47,11 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
         /**
          * Say goodbye.
          * 
+         * EXPERIMENTAL
+         * 
          * @return A goodbye blessing.
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String goodbye() {
             return this.jsiiCall("goodbye", java.lang.String.class);
@@ -45,6 +60,8 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
         /**
          * Say hello!
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IRandomNumberGenerator, software.amazon.jsii.tests.calculator.lib.IFriendly {
 
     /**
@@ -14,8 +18,11 @@ public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSeria
         /**
          * Returns another random number.
          * 
+         * EXPERIMENTAL
+         * 
          * @return A random number.
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.Number next() {
             return this.jsiiCall("next", java.lang.Number.class);
@@ -24,6 +31,8 @@ public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSeria
         /**
          * Say hello!
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
@@ -2,9 +2,16 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * awslabs/jsii#220 Abstract return type.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceImplementedByAbstractClass extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getPropFromInterface();
 
     /**
@@ -15,7 +22,11 @@ public interface IInterfaceImplementedByAbstractClass extends software.amazon.js
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getPropFromInterface() {
             return this.jsiiGet("propFromInterface", java.lang.String.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -2,9 +2,16 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IInterfaceWithMethods {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOtherValue();
 
     /**
@@ -15,16 +22,28 @@ public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getOtherValue() {
             return this.jsiiGet("otherValue", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void doThings() {
             this.jsiiCall("doThings", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
@@ -1,7 +1,15 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithInternal extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void visible();
 
     /**
@@ -12,6 +20,10 @@ public interface IInterfaceWithInternal extends software.amazon.jsii.JsiiSeriali
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void visible() {
             this.jsiiCall("visible", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -1,8 +1,20 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getValue();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void doThings();
 
     /**
@@ -13,11 +25,19 @@ public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializ
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void doThings() {
             this.jsiiCall("doThings", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -2,10 +2,21 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithOptionalMethodArguments extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1, @javax.annotation.Nullable final java.lang.Number arg2);
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1);
 
     /**
@@ -16,11 +27,19 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void hello(final java.lang.String arg1, @javax.annotation.Nullable final java.lang.Number arg2) {
             this.jsiiCall("hello", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), arg2 });
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void hello(final java.lang.String arg1) {
             this.jsiiCall("hello", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required") });

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -1,9 +1,24 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getReadOnlyString();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getReadWriteString();
+    /**
+     * EXPERIMENTAL
+     */
     void setReadWriteString(final java.lang.String value);
 
     /**
@@ -14,17 +29,29 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getReadOnlyString() {
             return this.jsiiGet("readOnlyString", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setReadWriteString(final java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -1,8 +1,19 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getFoo();
+    /**
+     * EXPERIMENTAL
+     */
     void setFoo(final java.lang.Number value);
 
     /**
@@ -13,27 +24,47 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setFoo(final java.lang.Number value) {
             this.jsiiSet("foo", java.util.Objects.requireNonNull(value, "foo is required"));
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getReadOnlyString() {
             return this.jsiiGet("readOnlyString", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setReadWriteString(final java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
@@ -1,9 +1,25 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getProperty();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void bar();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void baz();
 
     /**
@@ -14,26 +30,46 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getProperty() {
             return this.jsiiGet("property", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getHasRoot() {
             return this.jsiiGet("hasRoot", java.lang.Boolean.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void bar() {
             this.jsiiCall("bar", Void.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void baz() {
             this.jsiiCall("baz", Void.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void foo() {
             this.jsiiCall("foo", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
@@ -1,8 +1,20 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getHasRoot();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void foo();
 
     /**
@@ -13,11 +25,19 @@ public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSeria
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getHasRoot() {
             return this.jsiiGet("hasRoot", java.lang.Boolean.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public void foo() {
             this.jsiiCall("foo", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJsii487External extends software.amazon.jsii.JsiiSerializable {
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJsii487External2 extends software.amazon.jsii.JsiiSerializable {
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJsii496 extends software.amazon.jsii.JsiiSerializable {
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
@@ -1,8 +1,19 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getValue();
+    /**
+     * EXPERIMENTAL
+     */
     void setValue(final java.lang.String value);
 
     /**
@@ -13,12 +24,20 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setValue(final java.lang.String value) {
             this.jsiiSet("value", java.util.Objects.requireNonNull(value, "value is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -1,10 +1,28 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IAnotherPublicInterface {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getB();
+    /**
+     * EXPERIMENTAL
+     */
     void setB(final java.lang.String value);
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getC();
+    /**
+     * EXPERIMENTAL
+     */
     void setC(final java.lang.String value);
 
     /**
@@ -15,32 +33,56 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getB() {
             return this.jsiiGet("b", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setB(final java.lang.String value) {
             this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getC() {
             return this.jsiiGet("c", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setC(final java.lang.String value) {
             this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getA() {
             return this.jsiiGet("a", java.lang.String.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public void setA(final java.lang.String value) {
             this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
@@ -1,7 +1,15 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getSuccess();
 
     /**
@@ -12,7 +20,11 @@ public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializ
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getSuccess() {
             return this.jsiiGet("success", java.lang.Boolean.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
@@ -1,7 +1,15 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String bye();
 
     /**
@@ -12,6 +20,10 @@ public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable 
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String bye() {
             return this.jsiiCall("bye", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
@@ -1,7 +1,15 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String ciao();
 
     /**
@@ -12,6 +20,10 @@ public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String ciao() {
             return this.jsiiCall("ciao", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -2,14 +2,20 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Generates random numbers.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSerializable {
     /**
      * Returns another random number.
      * 
+     * EXPERIMENTAL
+     * 
      * @return A random number.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number next();
 
     /**
@@ -23,8 +29,11 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
         /**
          * Returns another random number.
          * 
+         * EXPERIMENTAL
+         * 
          * @return A random number.
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.Number next() {
             return this.jsiiCall("next", java.lang.Number.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -1,8 +1,20 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.lib.Number getNumberProp();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
 
     /**
@@ -13,11 +25,19 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public software.amazon.jsii.tests.calculator.lib.Number getNumberProp() {
             return this.jsiiGet("numberProp", software.amazon.jsii.tests.calculator.lib.Number.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber() {
             return this.jsiiCall("obtainNumber", software.amazon.jsii.tests.calculator.lib.IDoublable.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementInternalInterface")
 public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject {
     protected ImplementInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject 
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getProp() {
         return this.jsiiGet("prop", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setProp(final java.lang.String value) {
         this.jsiiSet("prop", java.util.Objects.requireNonNull(value, "prop is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsInterfaceWithInternal")
 public class ImplementsInterfaceWithInternal extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithInternal {
     protected ImplementsInterfaceWithInternal(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class ImplementsInterfaceWithInternal extends software.amazon.jsii.JsiiOb
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public void visible() {
         this.jsiiCall("visible", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsInterfaceWithInternalSubclass")
 public class ImplementsInterfaceWithInternalSubclass extends software.amazon.jsii.tests.calculator.ImplementsInterfaceWithInternal {
     protected ImplementsInterfaceWithInternalSubclass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsPrivateInterface")
 public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject {
     protected ImplementsPrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject 
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getPrivate() {
         return this.jsiiGet("private", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setPrivate(final java.lang.String value) {
         this.jsiiSet("private", java.util.Objects.requireNonNull(value, "private is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -1,12 +1,21 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.base.BaseProps {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.time.Instant getGoo();
 
     /**
      * @return a {@link Builder} of {@link ImplictBaseOfBase}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -14,6 +23,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
     /**
      * A builder for {@link ImplictBaseOfBase}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.time.Instant _goo;
         private java.lang.String _bar;
@@ -24,6 +34,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withGoo(final java.time.Instant value) {
             this._goo = java.util.Objects.requireNonNull(value, "goo is required");
             return this;
@@ -52,6 +63,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
          * @return a new instance of {@link ImplictBaseOfBase}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public ImplictBaseOfBase build() {
             return new ImplictBaseOfBase() {
                 private final java.time.Instant $goo = java.util.Objects.requireNonNull(_goo, "goo is required");
@@ -94,7 +106,11 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.time.Instant getGoo() {
             return this.jsiiGet("goo", java.time.Instant.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.InbetweenClass")
 public class InbetweenClass extends software.amazon.jsii.tests.calculator.PublicClass implements software.amazon.jsii.tests.calculator.IPublicInterface2 {
     protected InbetweenClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class InbetweenClass extends software.amazon.jsii.tests.calculator.Public
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String ciao() {
         return this.jsiiCall("ciao", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo")
 public class Foo extends software.amazon.jsii.JsiiObject {
     protected Foo(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,11 +15,19 @@ public class Foo extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.String getBar() {
         return this.jsiiGet("bar", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setBar(@javax.annotation.Nullable final java.lang.String value) {
         this.jsiiSet("bar", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -1,12 +1,21 @@
 package software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Hello extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getFoo();
 
     /**
      * @return a {@link Builder} of {@link Hello}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -14,6 +23,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link Hello}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.lang.Number _foo;
 
@@ -22,6 +32,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withFoo(final java.lang.Number value) {
             this._foo = java.util.Objects.requireNonNull(value, "foo is required");
             return this;
@@ -32,6 +43,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link Hello}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Hello build() {
             return new Hello() {
                 private final java.lang.Number $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
@@ -60,7 +72,11 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -1,12 +1,21 @@
 package software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Hello extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getFoo();
 
     /**
      * @return a {@link Builder} of {@link Hello}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -14,6 +23,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link Hello}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.lang.Number _foo;
 
@@ -22,6 +32,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withFoo(final java.lang.Number value) {
             this._foo = java.util.Objects.requireNonNull(value, "foo is required");
             return this;
@@ -32,6 +43,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link Hello}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Hello build() {
             return new Hello() {
                 private final java.lang.Number $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
@@ -60,7 +72,11 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -1,24 +1,44 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSII417Derived")
 public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase {
     protected JSII417Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public JSII417Derived(final java.lang.String property) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(property, "property is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void bar() {
         this.jsiiCall("bar", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void baz() {
         this.jsiiCall("baz", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     protected java.lang.String getProperty() {
         return this.jsiiGet("property", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSII417PublicBaseOfBase")
 public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
     protected JSII417PublicBaseOfBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,14 +15,26 @@ public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase makeInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase.class, "makeInstance", software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void foo() {
         this.jsiiCall("foo", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean getHasRoot() {
         return this.jsiiGet("hasRoot", java.lang.Boolean.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralForInterface")
 public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject {
     protected JSObjectLiteralForInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.IFriendly giveMeFriendly() {
         return this.jsiiCall("giveMeFriendly", software.amazon.jsii.tests.calculator.lib.IFriendly.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator giveMeFriendlyGenerator() {
         return this.jsiiCall("giveMeFriendlyGenerator", software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralToNative")
 public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
     protected JSObjectLiteralToNative(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass returnLiteral() {
         return this.jsiiCall("returnLiteral", software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralToNativeClass")
 public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObject {
     protected JSObjectLiteralToNativeClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,18 +15,34 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getPropA() {
         return this.jsiiGet("propA", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setPropA(final java.lang.String value) {
         this.jsiiSet("propA", java.util.Objects.requireNonNull(value, "propA is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getPropB() {
         return this.jsiiGet("propB", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setPropB(final java.lang.Number value) {
         this.jsiiSet("propB", java.util.Objects.requireNonNull(value, "propB is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JavaReservedWords")
 public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
     protected JavaReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,218 +15,434 @@ public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void abstract_() {
         this.jsiiCall("abstract", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void assert_() {
         this.jsiiCall("assert", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void boolean_() {
         this.jsiiCall("boolean", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void break_() {
         this.jsiiCall("break", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void byte_() {
         this.jsiiCall("byte", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void case_() {
         this.jsiiCall("case", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void catch_() {
         this.jsiiCall("catch", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void char_() {
         this.jsiiCall("char", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void class_() {
         this.jsiiCall("class", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void const_() {
         this.jsiiCall("const", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void continue_() {
         this.jsiiCall("continue", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void default_() {
         this.jsiiCall("default", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void do_() {
         this.jsiiCall("do", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void double_() {
         this.jsiiCall("double", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void else_() {
         this.jsiiCall("else", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void enum_() {
         this.jsiiCall("enum", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void extends_() {
         this.jsiiCall("extends", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void false_() {
         this.jsiiCall("false", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void final_() {
         this.jsiiCall("final", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void finally_() {
         this.jsiiCall("finally", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void float_() {
         this.jsiiCall("float", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void for_() {
         this.jsiiCall("for", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void goto_() {
         this.jsiiCall("goto", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void if_() {
         this.jsiiCall("if", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void implements_() {
         this.jsiiCall("implements", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void import_() {
         this.jsiiCall("import", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void instanceof_() {
         this.jsiiCall("instanceof", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void int_() {
         this.jsiiCall("int", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void interface_() {
         this.jsiiCall("interface", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void long_() {
         this.jsiiCall("long", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void native_() {
         this.jsiiCall("native", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void new_() {
         this.jsiiCall("new", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void null_() {
         this.jsiiCall("null", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void package_() {
         this.jsiiCall("package", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void private_() {
         this.jsiiCall("private", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void protected_() {
         this.jsiiCall("protected", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void public_() {
         this.jsiiCall("public", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void return_() {
         this.jsiiCall("return", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void short_() {
         this.jsiiCall("short", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void static_() {
         this.jsiiCall("static", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void strictfp_() {
         this.jsiiCall("strictfp", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void super_() {
         this.jsiiCall("super", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void switch_() {
         this.jsiiCall("switch", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void synchronized_() {
         this.jsiiCall("synchronized", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void this_() {
         this.jsiiCall("this", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void throw_() {
         this.jsiiCall("throw", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void throws_() {
         this.jsiiCall("throws", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void transient_() {
         this.jsiiCall("transient", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void true_() {
         this.jsiiCall("true", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void try_() {
         this.jsiiCall("try", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void void_() {
         this.jsiiCall("void", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void volatile_() {
         this.jsiiCall("volatile", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getWhile() {
         return this.jsiiGet("while", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setWhile(final java.lang.String value) {
         this.jsiiSet("while", java.util.Objects.requireNonNull(value, "while is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii487Derived")
 public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External2,software.amazon.jsii.tests.calculator.IJsii487External {
     protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii496Derived")
 public class Jsii496Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii496 {
     protected Jsii496Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Host runtime version should be set via JSII_AGENT.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JsiiAgent")
 public class JsiiAgent extends software.amazon.jsii.JsiiObject {
     protected JsiiAgent(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -16,7 +19,10 @@ public class JsiiAgent extends software.amazon.jsii.JsiiObject {
 
     /**
      * Returns the value of the JSII_AGENT environment variable.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public static java.lang.String getJsiiAgent() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.JsiiAgent.class, "jsiiAgent", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * jsii#298: show default values in sphinx documentation, and respect newlines.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.JsiiSerializable {
     /**
      * The container port of the application load balancer attached to your Fargate service.
@@ -11,7 +14,10 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * Corresponds to container port mapping.
      * 
      * Default: 80
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getContainerPort();
     /**
      * The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
@@ -19,7 +25,10 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * This default is set in the underlying FargateTaskDefinition construct.
      * 
      * Default: 256
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getCpu();
     /**
      * The amount (in MiB) of memory used by the task.
@@ -40,24 +49,34 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * This default is set in the underlying FargateTaskDefinition construct.
      * 
      * Default: 512
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getMemoryMiB();
     /**
      * Determines whether the Application Load Balancer will be internet-facing.
      * 
      * Default: true
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getPublicLoadBalancer();
     /**
      * Determines whether your Fargate Service will be assigned a public IP address.
      * 
      * Default: false
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getPublicTasks();
 
     /**
      * @return a {@link Builder} of {@link LoadBalancedFargateServiceProps}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -65,6 +84,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
     /**
      * A builder for {@link LoadBalancedFargateServiceProps}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.Number _containerPort;
@@ -82,6 +102,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @param value The container port of the application load balancer attached to your Fargate service.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withContainerPort(@javax.annotation.Nullable final java.lang.Number value) {
             this._containerPort = value;
             return this;
@@ -91,6 +112,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @param value The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withCpu(@javax.annotation.Nullable final java.lang.String value) {
             this._cpu = value;
             return this;
@@ -100,6 +122,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @param value The amount (in MiB) of memory used by the task.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withMemoryMiB(@javax.annotation.Nullable final java.lang.String value) {
             this._memoryMiB = value;
             return this;
@@ -109,6 +132,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @param value Determines whether the Application Load Balancer will be internet-facing.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withPublicLoadBalancer(@javax.annotation.Nullable final java.lang.Boolean value) {
             this._publicLoadBalancer = value;
             return this;
@@ -118,6 +142,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @param value Determines whether your Fargate Service will be assigned a public IP address.
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withPublicTasks(@javax.annotation.Nullable final java.lang.Boolean value) {
             this._publicTasks = value;
             return this;
@@ -128,6 +153,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @return a new instance of {@link LoadBalancedFargateServiceProps}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public LoadBalancedFargateServiceProps build() {
             return new LoadBalancedFargateServiceProps() {
                 @javax.annotation.Nullable
@@ -195,8 +221,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * Corresponds to container port mapping.
          * 
          * Default: 80
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Number getContainerPort() {
             return this.jsiiGet("containerPort", java.lang.Number.class);
@@ -208,8 +237,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * This default is set in the underlying FargateTaskDefinition construct.
          * 
          * Default: 256
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getCpu() {
             return this.jsiiGet("cpu", java.lang.String.class);
@@ -234,8 +266,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * This default is set in the underlying FargateTaskDefinition construct.
          * 
          * Default: 512
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getMemoryMiB() {
             return this.jsiiGet("memoryMiB", java.lang.String.class);
@@ -245,8 +280,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * Determines whether the Application Load Balancer will be internet-facing.
          * 
          * Default: true
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Boolean getPublicLoadBalancer() {
             return this.jsiiGet("publicLoadBalancer", java.lang.Boolean.class);
@@ -256,8 +294,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * Determines whether your Fargate Service will be assigned a public IP address.
          * 
          * Default: false
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Boolean getPublicTasks() {
             return this.jsiiGet("publicTasks", java.lang.Boolean.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * The "*" binary operation.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Multiply")
 public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperation implements software.amazon.jsii.tests.calculator.IFriendlier,software.amazon.jsii.tests.calculator.IRandomNumberGenerator {
     protected Multiply(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,9 +15,12 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
     /**
      * Creates a BinaryOperation.
      * 
+     * EXPERIMENTAL
+     * 
      * @param lhs Left-hand side operand.
      * @param rhs Right-hand side operand.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Multiply(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
@@ -22,7 +28,10 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
 
     /**
      * Say farewell.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
@@ -30,7 +39,10 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
 
     /**
      * Say goodbye.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
@@ -38,7 +50,10 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
 
     /**
      * Returns another random number.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);
@@ -46,7 +61,10 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
 
     /**
      * String representation of the value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
@@ -54,8 +72,11 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
 
     /**
      * The value.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -2,13 +2,20 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * The negation operation ("-value").
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Negate")
 public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation implements software.amazon.jsii.tests.calculator.IFriendlier {
     protected Negate(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Negate(final software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
@@ -16,7 +23,10 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * Say farewell.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
@@ -24,7 +34,10 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * Say goodbye.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
@@ -32,7 +45,10 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * Say hello!
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
@@ -40,7 +56,10 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * String representation of the value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
@@ -48,8 +67,11 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * The value.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Test fixture to verify that jsii modules can use the node standard library.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NodeStandardLibrary")
 public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     protected NodeStandardLibrary(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -17,8 +20,11 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     /**
      * Uses node.js "crypto" module to calculate sha256 of a string.
      * 
+     * EXPERIMENTAL
+     * 
      * @return "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String cryptoSha256() {
         return this.jsiiCall("cryptoSha256", java.lang.String.class);
     }
@@ -26,8 +32,11 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     /**
      * Reads a local resource file (resource.txt) asynchronously.
      * 
+     * EXPERIMENTAL
+     * 
      * @return "Hello, resource!"
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String fsReadFile() {
         return this.jsiiAsyncCall("fsReadFile", java.lang.String.class);
     }
@@ -35,15 +44,21 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     /**
      * Sync version of fsReadFile.
      * 
+     * EXPERIMENTAL
+     * 
      * @return "Hello, resource! SYNC!"
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String fsReadFileSync() {
         return this.jsiiCall("fsReadFileSync", java.lang.String.class);
     }
 
     /**
      * Returns the current os.platform() from the "os" node module.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getOsPlatform() {
         return this.jsiiGet("osPlatform", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -2,43 +2,78 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * jsii#282, aws-cdk#157: null should be treated as "undefined".
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NullShouldBeTreatedAsUndefined")
 public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObject {
     protected NullShouldBeTreatedAsUndefined(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, @javax.annotation.Nullable final java.lang.Object optional) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void giveMeUndefined(@javax.annotation.Nullable final java.lang.Object value) {
         this.jsiiCall("giveMeUndefined", Void.class, new Object[] { value });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void giveMeUndefined() {
         this.jsiiCall("giveMeUndefined", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void giveMeUndefinedInsideAnObject(final software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData input) {
         this.jsiiCall("giveMeUndefinedInsideAnObject", Void.class, new Object[] { java.util.Objects.requireNonNull(input, "input is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void verifyPropertyIsUndefined() {
         this.jsiiCall("verifyPropertyIsUndefined", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.String getChangeMeToUndefined() {
         return this.jsiiGet("changeMeToUndefined", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setChangeMeToUndefined(@javax.annotation.Nullable final java.lang.String value) {
         this.jsiiSet("changeMeToUndefined", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -1,13 +1,26 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getThisShouldBeUndefined();
 
     /**
      * @return a {@link Builder} of {@link NullShouldBeTreatedAsUndefinedData}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -15,6 +28,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
     /**
      * A builder for {@link NullShouldBeTreatedAsUndefinedData}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.util.List<java.lang.Object> _arrayWithThreeElementsAndUndefinedAsSecondArgument;
         @javax.annotation.Nullable
@@ -25,6 +39,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withArrayWithThreeElementsAndUndefinedAsSecondArgument(final java.util.List<java.lang.Object> value) {
             this._arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(value, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
             return this;
@@ -34,6 +49,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withThisShouldBeUndefined(@javax.annotation.Nullable final java.lang.Object value) {
             this._thisShouldBeUndefined = value;
             return this;
@@ -44,6 +60,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          * @return a new instance of {@link NullShouldBeTreatedAsUndefinedData}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public NullShouldBeTreatedAsUndefinedData build() {
             return new NullShouldBeTreatedAsUndefinedData() {
                 private final java.util.List<java.lang.Object> $arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(_arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
@@ -80,12 +97,20 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument() {
             return this.jsiiGet("arrayWithThreeElementsAndUndefinedAsSecondArgument", java.util.List.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Object getThisShouldBeUndefined() {
             return this.jsiiGet("thisShouldBeUndefined", java.lang.Object.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -2,30 +2,53 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * This allows us to test that a reference can be stored for objects that implement interfaces.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NumberGenerator")
 public class NumberGenerator extends software.amazon.jsii.JsiiObject {
     protected NumberGenerator(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NumberGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(generator, "generator is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean isSameGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {
         return this.jsiiCall("isSameGenerator", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(gen, "gen is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number nextTimes100() {
         return this.jsiiCall("nextTimes100", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IRandomNumberGenerator getGenerator() {
         return this.jsiiGet("generator", software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator value) {
         this.jsiiSet("generator", java.util.Objects.requireNonNull(value, "generator is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Verify that object references can be passed inside collections.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ObjectRefsInCollections")
 public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
     protected ObjectRefsInCollections(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -16,14 +19,20 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
 
     /**
      * Returns the sum of all values.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumFromArray(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
         return this.jsiiCall("sumFromArray", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }
 
     /**
      * Returns the sum of all values in a map.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumFromMap(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> values) {
         return this.jsiiCall("sumFromMap", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
@@ -21,6 +21,8 @@ public class Old extends software.amazon.jsii.JsiiObject {
     /**
      * Doo wop that thing.
      */
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public void doAThing() {
         this.jsiiCall("doAThing", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -1,28 +1,52 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalConstructorArgument")
 public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject {
     protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getArg1() {
         return this.jsiiGet("arg1", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getArg2() {
         return this.jsiiGet("arg2", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -1,12 +1,21 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getField();
 
     /**
      * @return a {@link Builder} of {@link OptionalStruct}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -14,6 +23,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link OptionalStruct}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         @javax.annotation.Nullable
         private java.lang.String _field;
@@ -23,6 +33,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withField(@javax.annotation.Nullable final java.lang.String value) {
             this._field = value;
             return this;
@@ -33,6 +44,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link OptionalStruct}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public OptionalStruct build() {
             return new OptionalStruct() {
                 @javax.annotation.Nullable
@@ -62,7 +74,11 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.String getField() {
             return this.jsiiGet("field", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -1,24 +1,44 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalStructConsumer")
 public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
     protected OptionalStructConsumer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalStructConsumer(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct });
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalStructConsumer() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean getParameterWasUndefined() {
         return this.jsiiGet("parameterWasUndefined", java.lang.Boolean.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.String getFieldValue() {
         return this.jsiiGet("fieldValue", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OverrideReturnsObject")
 public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
     protected OverrideReturnsObject(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number test(final software.amazon.jsii.tests.calculator.IReturnsNumber obj) {
         return this.jsiiCall("test", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PartiallyInitializedThisConsumer")
 public abstract class PartiallyInitializedThisConsumer extends software.amazon.jsii.JsiiObject {
     protected PartiallyInitializedThisConsumer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public abstract java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev);
 
     /**
@@ -21,6 +29,10 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         public java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev) {
             return this.jsiiCall("consumePartiallyInitializedThis", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required"), java.util.Objects.requireNonNull(dt, "dt is required"), java.util.Objects.requireNonNull(ev, "ev is required") });

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Polymorphism")
 public class Polymorphism extends software.amazon.jsii.JsiiObject {
     protected Polymorphism(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String sayHello(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
         return this.jsiiCall("sayHello", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * The power operation.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Power")
 public class Power extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
     protected Power(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,9 +15,12 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
     /**
      * Creates a Power operation.
      * 
+     * EXPERIMENTAL
+     * 
      * @param base The base of the power.
      * @param pow The number of times to multiply.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Power(final software.amazon.jsii.tests.calculator.lib.Value base, final software.amazon.jsii.tests.calculator.lib.Value pow) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(base, "base is required"), java.util.Objects.requireNonNull(pow, "pow is required") });
@@ -22,22 +28,31 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
 
     /**
      * The base of the power.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getBase() {
         return this.jsiiGet("base", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * The expression that this operation consists of. Must be implemented by derived classes.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * The number of times to multiply.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getPow() {
         return this.jsiiGet("pow", software.amazon.jsii.tests.calculator.lib.Value.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PublicClass")
 public class PublicClass extends software.amazon.jsii.JsiiObject {
     protected PublicClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class PublicClass extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void hello() {
         this.jsiiCall("hello", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PythonReservedWords")
 public class PythonReservedWords extends software.amazon.jsii.JsiiObject {
     protected PythonReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,130 +15,258 @@ public class PythonReservedWords extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void and() {
         this.jsiiCall("and", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void as() {
         this.jsiiCall("as", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void assert_() {
         this.jsiiCall("assert", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void async() {
         this.jsiiCall("async", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void await() {
         this.jsiiCall("await", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void break_() {
         this.jsiiCall("break", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void class_() {
         this.jsiiCall("class", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void continue_() {
         this.jsiiCall("continue", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void def() {
         this.jsiiCall("def", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void del() {
         this.jsiiCall("del", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void elif() {
         this.jsiiCall("elif", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void else_() {
         this.jsiiCall("else", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void except() {
         this.jsiiCall("except", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void finally_() {
         this.jsiiCall("finally", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void for_() {
         this.jsiiCall("for", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void from() {
         this.jsiiCall("from", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void global() {
         this.jsiiCall("global", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void if_() {
         this.jsiiCall("if", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void import_() {
         this.jsiiCall("import", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void in() {
         this.jsiiCall("in", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void is() {
         this.jsiiCall("is", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void lambda() {
         this.jsiiCall("lambda", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void nonlocal() {
         this.jsiiCall("nonlocal", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void not() {
         this.jsiiCall("not", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void or() {
         this.jsiiCall("or", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void pass() {
         this.jsiiCall("pass", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void raise() {
         this.jsiiCall("raise", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void return_() {
         this.jsiiCall("return", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void try_() {
         this.jsiiCall("try", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void while_() {
         this.jsiiCall("while", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void with() {
         this.jsiiCall("with", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void yield() {
         this.jsiiCall("yield", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * See awslabs/jsii#138.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ReferenceEnumFromScopedPackage")
 public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObject {
     protected ReferenceEnumFromScopedPackage(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -14,20 +17,36 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule loadFoo() {
         return this.jsiiCall("loadFoo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void saveFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiCall("saveFoo", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule getFoo() {
         return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setFoo(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiSet("foo", value);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
@@ -3,10 +3,13 @@ package software.amazon.jsii.tests.calculator;
 /**
  * Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
  * 
+ * EXPERIMENTAL
+ * 
  * @return an instance of an un-exported class that extends `ExportedBaseClass`, declared as `IPrivatelyImplemented`.
  * @see https://github.com/awslabs/jsii/issues/320
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ReturnsPrivateImplementationOfInterface")
 public class ReturnsPrivateImplementationOfInterface extends software.amazon.jsii.JsiiObject {
     protected ReturnsPrivateImplementationOfInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -17,6 +20,10 @@ public class ReturnsPrivateImplementationOfInterface extends software.amazon.jsi
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IPrivatelyImplemented getPrivateImplementation() {
         return this.jsiiGet("privateImplementation", software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.RuntimeTypeChecking")
 public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
     protected RuntimeTypeChecking(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,40 +15,70 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2, arg3 });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2 });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1 });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments() {
         this.jsiiCall("methodWithDefaultedArguments", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalAnyArgument(@javax.annotation.Nullable final java.lang.Object arg) {
         this.jsiiCall("methodWithOptionalAnyArgument", Void.class, new Object[] { arg });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalAnyArgument() {
         this.jsiiCall("methodWithOptionalAnyArgument", Void.class);
     }
 
     /**
      * Used to verify verification of number of method arguments.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
         this.jsiiCall("methodWithOptionalArguments", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
 
     /**
      * Used to verify verification of number of method arguments.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2) {
         this.jsiiCall("methodWithOptionalArguments", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
@@ -6,8 +6,11 @@ package software.amazon.jsii.tests.calculator;
  * JSII clients can instantiate 2 different strongly-typed wrappers for the same
  * object. Unfortunately, this will break object equality, but if we didn't do
  * this it would break runtime type checks in the JVM or CLR.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingleInstanceTwoTypes")
 public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
     protected SingleInstanceTwoTypes(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -18,10 +21,18 @@ public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.InbetweenClass interface1() {
         return this.jsiiCall("interface1", software.amazon.jsii.tests.calculator.InbetweenClass.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IPublicInterface interface2() {
         return this.jsiiCall("interface2", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
@@ -4,22 +4,37 @@ package software.amazon.jsii.tests.calculator;
  * This is used to validate the ability to use `this` from within a static context.
  * 
  * https://github.com/awslabs/aws-cdk/issues/2304
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StaticContext")
 public class StaticContext extends software.amazon.jsii.JsiiObject {
     protected StaticContext(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.Boolean canAccessStaticContext() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StaticContext.class, "canAccessStaticContext", java.lang.Boolean.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.Boolean getStaticVariable() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.StaticContext.class, "staticVariable", java.lang.Boolean.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static void setStaticVariable(final java.lang.Boolean value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.StaticContext.class, "staticVariable", java.util.Objects.requireNonNull(value, "staticVariable is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Statics")
 public class Statics extends software.amazon.jsii.JsiiObject {
     protected Statics(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -12,6 +16,10 @@ public class Statics extends software.amazon.jsii.JsiiObject {
         FOO = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "Foo", java.lang.String.class);
         ZOO_BAR = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "zooBar", java.util.Map.class);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Statics(final java.lang.String value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
@@ -20,51 +28,89 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     /**
      * Jsdocs for static method.
      * 
+     * EXPERIMENTAL
+     * 
      * @param name The name of the person to say hello to.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.String staticMethod(final java.lang.String name) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Statics.class, "staticMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String justMethod() {
         return this.jsiiCall("justMethod", java.lang.String.class);
     }
     /**
      * Constants may also use all-caps.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static java.lang.Number BAR;
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static software.amazon.jsii.tests.calculator.DoubleTrouble CONST_OBJ;
     /**
      * Jsdocs for static property.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static java.lang.String FOO;
     /**
      * Constants can also use camelCase.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static java.util.Map<java.lang.String, java.lang.String> ZOO_BAR;
 
     /**
      * Jsdocs for static getter. Jsdocs for static setter.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.Statics getInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "instance", software.amazon.jsii.tests.calculator.Statics.class);
     }
 
     /**
      * Jsdocs for static getter. Jsdocs for static setter.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static void setInstance(final software.amazon.jsii.tests.calculator.Statics value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "instance", java.util.Objects.requireNonNull(value, "instance is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.Number getNonConstStatic() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static void setNonConstStatic(final java.lang.Number value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.util.Objects.requireNonNull(value, "nonConstStatic is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getValue() {
         return this.jsiiGet("value", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StringEnum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StringEnum.java
@@ -1,9 +1,25 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StringEnum")
 public enum StringEnum {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     A,
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     B,
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     C,
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StripInternal")
 public class StripInternal extends software.amazon.jsii.JsiiObject {
     protected StripInternal(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,10 +15,18 @@ public class StripInternal extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getYouSeeMe() {
         return this.jsiiGet("youSeeMe", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setYouSeeMe(final java.lang.String value) {
         this.jsiiSet("youSeeMe", java.util.Objects.requireNonNull(value, "youSeeMe is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
@@ -2,13 +2,20 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * An operation that sums multiple values.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Sum")
 public class Sum extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
     protected Sum(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Sum() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
@@ -16,22 +23,31 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
 
     /**
      * The expression that this operation consists of. Must be implemented by derived classes.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * The parts to sum.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getParts() {
         return this.jsiiGet("parts", java.util.List.class);
     }
 
     /**
      * The parts to sum.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setParts(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> value) {
         this.jsiiSet("parts", java.util.Objects.requireNonNull(value, "parts is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SyncVirtualMethods")
 public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     protected SyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,86 +15,170 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number callerIsAsync() {
         return this.jsiiAsyncCall("callerIsAsync", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number callerIsMethod() {
         return this.jsiiCall("callerIsMethod", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void modifyOtherProperty(final java.lang.String value) {
         this.jsiiCall("modifyOtherProperty", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void modifyValueOfTheProperty(final java.lang.String value) {
         this.jsiiCall("modifyValueOfTheProperty", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number readA() {
         return this.jsiiCall("readA", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String retrieveOtherProperty() {
         return this.jsiiCall("retrieveOtherProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String retrieveReadOnlyProperty() {
         return this.jsiiCall("retrieveReadOnlyProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String retrieveValueOfTheProperty() {
         return this.jsiiCall("retrieveValueOfTheProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number virtualMethod(final java.lang.Number n) {
         return this.jsiiCall("virtualMethod", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(n, "n is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void writeA(final java.lang.Number value) {
         this.jsiiCall("writeA", Void.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getA() {
         return this.jsiiGet("a", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setA(final java.lang.Number value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getCallerIsProperty() {
         return this.jsiiGet("callerIsProperty", java.lang.Number.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setCallerIsProperty(final java.lang.Number value) {
         this.jsiiSet("callerIsProperty", java.util.Objects.requireNonNull(value, "callerIsProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getOtherProperty() {
         return this.jsiiGet("otherProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setOtherProperty(final java.lang.String value) {
         this.jsiiSet("otherProperty", java.util.Objects.requireNonNull(value, "otherProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getTheProperty() {
         return this.jsiiGet("theProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setTheProperty(final java.lang.String value) {
         this.jsiiSet("theProperty", java.util.Objects.requireNonNull(value, "theProperty is required"));
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getValueOfOtherProperty() {
         return this.jsiiGet("valueOfOtherProperty", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setValueOfOtherProperty(final java.lang.String value) {
         this.jsiiSet("valueOfOtherProperty", java.util.Objects.requireNonNull(value, "valueOfOtherProperty is required"));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Thrower")
 public class Thrower extends software.amazon.jsii.JsiiObject {
     protected Thrower(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class Thrower extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void throwError() {
         this.jsiiCall("throwError", Void.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -2,18 +2,29 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * An operation on a single operand.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UnaryOperation")
 public abstract class UnaryOperation extends software.amazon.jsii.tests.calculator.lib.Operation {
     protected UnaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getOperand() {
         return this.jsiiGet("operand", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
@@ -30,6 +41,8 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
          * The value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
@@ -37,6 +50,8 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
         /**
          * String representation of the value.
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -1,13 +1,26 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getBar();
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getFoo();
 
     /**
      * @return a {@link Builder} of {@link UnionProperties}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     static Builder builder() {
         return new Builder();
     }
@@ -15,6 +28,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link UnionProperties}
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
         private java.lang.Object _bar;
         @javax.annotation.Nullable
@@ -25,6 +39,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withBar(final java.lang.String value) {
             this._bar = java.util.Objects.requireNonNull(value, "bar is required");
             return this;
@@ -34,6 +49,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withBar(final java.lang.Number value) {
             this._bar = java.util.Objects.requireNonNull(value, "bar is required");
             return this;
@@ -43,6 +59,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withBar(final software.amazon.jsii.tests.calculator.AllTypes value) {
             this._bar = java.util.Objects.requireNonNull(value, "bar is required");
             return this;
@@ -52,6 +69,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withFoo(@javax.annotation.Nullable final java.lang.String value) {
             this._foo = value;
             return this;
@@ -61,6 +79,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @param value the value to be set
          * @return {@code this}
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder withFoo(@javax.annotation.Nullable final java.lang.Number value) {
             this._foo = value;
             return this;
@@ -71,6 +90,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link UnionProperties}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public UnionProperties build() {
             return new UnionProperties() {
                 private final java.lang.Object $bar = java.util.Objects.requireNonNull(_bar, "bar is required");
@@ -107,12 +127,20 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Object getBar() {
             return this.jsiiGet("bar", java.lang.Object.class);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @javax.annotation.Nullable
         public java.lang.Object getFoo() {
             return this.jsiiGet("foo", java.lang.Object.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UseBundledDependency")
 public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
     protected UseBundledDependency(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,6 +15,10 @@ public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @javax.annotation.Nullable
     public java.lang.Object value() {
         return this.jsiiCall("value", java.lang.Object.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator;
 
 /**
  * Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UseCalcBase")
 public class UseCalcBase extends software.amazon.jsii.JsiiObject {
     protected UseCalcBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -14,6 +17,10 @@ public class UseCalcBase extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.base.Base hello() {
         return this.jsiiCall("hello", software.amazon.jsii.tests.calculator.base.Base.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -1,28 +1,52 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UsesInterfaceWithProperties")
 public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject {
     protected UsesInterfaceWithProperties(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public UsesInterfaceWithProperties(final software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String justRead() {
         return this.jsiiCall("justRead", java.lang.String.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String readStringAndNumber(final software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
         return this.jsiiCall("readStringAndNumber", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(ext, "ext is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String writeAndRead(final java.lang.String value) {
         return this.jsiiCall("writeAndRead", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.IInterfaceWithProperties getObj() {
         return this.jsiiGet("obj", software.amazon.jsii.tests.calculator.IInterfaceWithProperties.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -1,23 +1,33 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VariadicMethod")
 public class VariadicMethod extends software.amazon.jsii.JsiiObject {
     protected VariadicMethod(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
         super(mode);
     }
     /**
+     * EXPERIMENTAL
+     * 
      * @param prefix a prefix that will be use for all values returned by `#asArray`.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public VariadicMethod(final java.lang.Number... prefix) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(prefix).toArray(Object[]::new));
     }
 
     /**
+     * EXPERIMENTAL
+     * 
      * @param first the first element of the array to be returned (after the `prefix` provided at construction time).
      * @param others other elements to be included in the array.
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {
         return this.jsiiCall("asArray", java.util.List.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(first, "first is required") }), java.util.Arrays.<Object>stream(others)).toArray(Object[]::new));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -1,6 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
+/**
+ * EXPERIMENTAL
+ */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VirtualMethodPlayground")
 public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
     protected VirtualMethodPlayground(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -11,22 +15,42 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMeAsync(final java.lang.Number index) {
         return this.jsiiAsyncCall("overrideMeAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMeSync(final java.lang.Number index) {
         return this.jsiiCall("overrideMeSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number parallelSumAsync(final java.lang.Number count) {
         return this.jsiiAsyncCall("parallelSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number serialSumAsync(final java.lang.Number count) {
         return this.jsiiAsyncCall("serialSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumSync(final java.lang.Number count) {
         return this.jsiiCall("sumSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
@@ -6,8 +6,11 @@ package software.amazon.jsii.tests.calculator;
  * - Implement `overrideMe` (method does not have to do anything).
  * - Invoke `callMe`
  * - Verify that `methodWasCalled` is `true`.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VoidCallback")
 public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
     protected VoidCallback(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -18,12 +21,24 @@ public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void callMe() {
         this.jsiiCall("callMe", Void.class);
     }
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     protected abstract void overrideMe();
 
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean getMethodWasCalled() {
         return this.jsiiGet("methodWasCalled", java.lang.Boolean.class);
     }
@@ -36,6 +51,10 @@ public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
             super(mode);
         }
 
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
         protected void overrideMe() {
             this.jsiiCall("overrideMe", Void.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -2,8 +2,11 @@ package software.amazon.jsii.tests.calculator.composition;
 
 /**
  * Abstract operation composed from an expression of other operations.
+ * 
+ * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.composition.CompositeOperation")
 public abstract class CompositeOperation extends software.amazon.jsii.tests.calculator.lib.Operation {
     protected CompositeOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -16,7 +19,10 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
 
     /**
      * String representation of the value.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
     public java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
@@ -24,72 +30,105 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
 
     /**
      * The expression that this operation consists of. Must be implemented by derived classes.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
     /**
      * The value.
+     * 
+     * EXPERIMENTAL
      */
     @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 
     /**
      * A set of postfixes to include in a decorated .toString().
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getDecorationPostfixes() {
         return this.jsiiGet("decorationPostfixes", java.util.List.class);
     }
 
     /**
      * A set of postfixes to include in a decorated .toString().
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setDecorationPostfixes(final java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPostfixes", java.util.Objects.requireNonNull(value, "decorationPostfixes is required"));
     }
 
     /**
      * A set of prefixes to include in a decorated .toString().
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getDecorationPrefixes() {
         return this.jsiiGet("decorationPrefixes", java.util.List.class);
     }
 
     /**
      * A set of prefixes to include in a decorated .toString().
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setDecorationPrefixes(final java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPrefixes", java.util.Objects.requireNonNull(value, "decorationPrefixes is required"));
     }
 
     /**
      * The .toString() style.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle getStringStyle() {
         return this.jsiiGet("stringStyle", software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle.class);
     }
 
     /**
      * The .toString() style.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setStringStyle(final software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle value) {
         this.jsiiSet("stringStyle", java.util.Objects.requireNonNull(value, "stringStyle is required"));
     }
     /**
      * Style of .toString() output for CompositeOperation.
+     * 
+     * EXPERIMENTAL
      */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.composition.CompositeOperation.CompositionStringStyle")
     public enum CompositionStringStyle {
         /**
          * Normal string expression.
+         * 
+         * EXPERIMENTAL
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         Normal,
         /**
          * Decorated string expression.
+         * 
+         * EXPERIMENTAL
          */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         Decorated,
     }
 
@@ -103,8 +142,11 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
 
         /**
          * The expression that this operation consists of. Must be implemented by derived classes.
+         * 
+         * EXPERIMENTAL
          */
         @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
             return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
         }
@@ -113,6 +155,8 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
          * The value.
          */
         @Override
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
@@ -120,6 +164,8 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
         /**
          * String representation of the value.
          */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Override
         public java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -14,6 +14,10 @@ import scope.jsii_calc_base_of_base
 import scope.jsii_calc_lib
 __jsii_assembly__ = jsii.JSIIAssembly.load("jsii-calc", "0.11.0", __name__, "jsii-calc@0.11.0.jsii.tgz")
 class AbstractClassBase(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.AbstractClassBase"):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _AbstractClassBaseProxy
@@ -25,6 +29,10 @@ class AbstractClassBase(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.A
     @jsii.member(jsii_name="abstractProperty")
     @abc.abstractmethod
     def abstract_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
@@ -32,24 +40,44 @@ class _AbstractClassBaseProxy(AbstractClassBase):
     @property
     @jsii.member(jsii_name="abstractProperty")
     def abstract_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "abstractProperty")
 
 
 class AbstractClassReturner(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AbstractClassReturner"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(AbstractClassReturner, self, [])
 
     @jsii.member(jsii_name="giveMeAbstract")
     def give_me_abstract(self) -> "AbstractClass":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "giveMeAbstract", [])
 
     @jsii.member(jsii_name="giveMeInterface")
     def give_me_interface(self) -> "IInterfaceImplementedByAbstractClass":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "giveMeInterface", [])
 
     @property
     @jsii.member(jsii_name="returnAbstractFromProperty")
     def return_abstract_from_property(self) -> "AbstractClassBase":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "returnAbstractFromProperty")
 
 
@@ -58,6 +86,9 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
 
     The setters will validate
     that the value set is of the expected type and throw otherwise.
+
+    Stability:
+        experimental
     """
     def __init__(self) -> None:
         jsii.create(AllTypes, self, [])
@@ -67,11 +98,18 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
         """
         Arguments:
             inp: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "anyIn", [inp])
 
     @jsii.member(jsii_name="anyOut")
     def any_out(self) -> typing.Any:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "anyOut", [])
 
     @jsii.member(jsii_name="enumMethod")
@@ -79,17 +117,28 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "enumMethod", [value])
 
     @property
     @jsii.member(jsii_name="enumPropertyValue")
     def enum_property_value(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "enumPropertyValue")
 
     @property
     @jsii.member(jsii_name="anyArrayProperty")
     def any_array_property(self) -> typing.List[typing.Any]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "anyArrayProperty")
 
     @any_array_property.setter
@@ -99,6 +148,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="anyMapProperty")
     def any_map_property(self) -> typing.Mapping[str,typing.Any]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "anyMapProperty")
 
     @any_map_property.setter
@@ -108,6 +161,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="anyProperty")
     def any_property(self) -> typing.Any:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "anyProperty")
 
     @any_property.setter
@@ -117,6 +174,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="arrayProperty")
     def array_property(self) -> typing.List[str]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arrayProperty")
 
     @array_property.setter
@@ -126,6 +187,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="booleanProperty")
     def boolean_property(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "booleanProperty")
 
     @boolean_property.setter
@@ -135,6 +200,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="dateProperty")
     def date_property(self) -> datetime.datetime:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "dateProperty")
 
     @date_property.setter
@@ -144,6 +213,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="enumProperty")
     def enum_property(self) -> "AllTypesEnum":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "enumProperty")
 
     @enum_property.setter
@@ -153,6 +226,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="jsonProperty")
     def json_property(self) -> typing.Mapping[typing.Any, typing.Any]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "jsonProperty")
 
     @json_property.setter
@@ -162,6 +239,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="mapProperty")
     def map_property(self) -> typing.Mapping[str,scope.jsii_calc_lib.Number]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "mapProperty")
 
     @map_property.setter
@@ -171,6 +252,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="numberProperty")
     def number_property(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "numberProperty")
 
     @number_property.setter
@@ -180,6 +265,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="stringProperty")
     def string_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "stringProperty")
 
     @string_property.setter
@@ -189,6 +278,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unionArrayProperty")
     def union_array_property(self) -> typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.Value]]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unionArrayProperty")
 
     @union_array_property.setter
@@ -198,6 +291,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unionMapProperty")
     def union_map_property(self) -> typing.Mapping[str,typing.Union[str, jsii.Number, scope.jsii_calc_lib.Number]]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unionMapProperty")
 
     @union_map_property.setter
@@ -207,6 +304,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unionProperty")
     def union_property(self) -> typing.Union[str, jsii.Number, "Multiply", scope.jsii_calc_lib.Number]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unionProperty")
 
     @union_property.setter
@@ -216,6 +317,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unknownArrayProperty")
     def unknown_array_property(self) -> typing.List[typing.Any]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unknownArrayProperty")
 
     @unknown_array_property.setter
@@ -225,6 +330,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unknownMapProperty")
     def unknown_map_property(self) -> typing.Mapping[str,typing.Any]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unknownMapProperty")
 
     @unknown_map_property.setter
@@ -234,6 +343,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="unknownProperty")
     def unknown_property(self) -> typing.Any:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unknownProperty")
 
     @unknown_property.setter
@@ -243,6 +356,10 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @property
     @jsii.member(jsii_name="optionalEnumValue")
     def optional_enum_value(self) -> typing.Optional["StringEnum"]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "optionalEnumValue")
 
     @optional_enum_value.setter
@@ -252,11 +369,31 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
 
 @jsii.enum(jsii_type="jsii-calc.AllTypesEnum")
 class AllTypesEnum(enum.Enum):
+    """
+    Stability:
+        experimental
+    """
     MyEnumValue = "MyEnumValue"
+    """
+    Stability:
+        experimental
+    """
     YourEnumValue = "YourEnumValue"
+    """
+    Stability:
+        experimental
+    """
     ThisIsGreat = "ThisIsGreat"
+    """
+    Stability:
+        experimental
+    """
 
 class AllowedMethodNames(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllowedMethodNames"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(AllowedMethodNames, self, [])
 
@@ -266,6 +403,9 @@ class AllowedMethodNames(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllowedMe
         Arguments:
             _p1: -
             _p2: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "getBar", [_p1, _p2])
 
@@ -275,6 +415,9 @@ class AllowedMethodNames(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllowedMe
 
         Arguments:
             withParam: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "getFoo", [with_param])
 
@@ -285,6 +428,9 @@ class AllowedMethodNames(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllowedMe
             _x: -
             _y: -
             _z: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "setBar", [_x, _y, _z])
 
@@ -295,21 +441,36 @@ class AllowedMethodNames(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllowedMe
         Arguments:
             _x: -
             _y: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "setFoo", [_x, _y])
 
 
 class AsyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AsyncVirtualMethods"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(AsyncVirtualMethods, self, [])
 
     @jsii.member(jsii_name="callMe")
     def call_me(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.ainvoke(self, "callMe", [])
 
     @jsii.member(jsii_name="callMe2")
     def call_me2(self) -> jsii.Number:
-        """Just calls "overrideMeToo"."""
+        """Just calls "overrideMeToo".
+
+        Stability:
+            experimental
+        """
         return jsii.ainvoke(self, "callMe2", [])
 
     @jsii.member(jsii_name="callMeDoublePromise")
@@ -319,11 +480,18 @@ class AsyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AsyncVir
         This is a "double promise" situation, which
         means that callbacks are not going to be available immediate, but only
         after an "immediates" cycle.
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "callMeDoublePromise", [])
 
     @jsii.member(jsii_name="dontOverrideMe")
     def dont_override_me(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "dontOverrideMe", [])
 
     @jsii.member(jsii_name="overrideMe")
@@ -331,30 +499,53 @@ class AsyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AsyncVir
         """
         Arguments:
             mult: -
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "overrideMe", [mult])
 
     @jsii.member(jsii_name="overrideMeToo")
     def override_me_too(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.ainvoke(self, "overrideMeToo", [])
 
 
 class AugmentableClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AugmentableClass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(AugmentableClass, self, [])
 
     @jsii.member(jsii_name="methodOne")
     def method_one(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "methodOne", [])
 
     @jsii.member(jsii_name="methodTwo")
     def method_two(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "methodTwo", [])
 
 
 @jsii.implements(scope.jsii_calc_lib.IFriendly)
 class BinaryOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.BinaryOperation"):
-    """Represents an operation with two operands."""
+    """Represents an operation with two operands.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _BinaryOperationProxy
@@ -365,24 +556,39 @@ class BinaryOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstract
         Arguments:
             lhs: Left-hand side operand.
             rhs: Right-hand side operand.
+
+        Stability:
+            experimental
         """
         jsii.create(BinaryOperation, self, [lhs, rhs])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> str:
-        """Say hello!"""
+        """Say hello!
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "hello", [])
 
     @property
     @jsii.member(jsii_name="lhs")
     def lhs(self) -> scope.jsii_calc_lib.Value:
-        """Left-hand side operand."""
+        """Left-hand side operand.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "lhs")
 
     @property
     @jsii.member(jsii_name="rhs")
     def rhs(self) -> scope.jsii_calc_lib.Value:
-        """Right-hand side operand."""
+        """Right-hand side operand.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "rhs")
 
 
@@ -390,34 +596,61 @@ class _BinaryOperationProxy(BinaryOperation, jsii.proxy_for(scope.jsii_calc_lib.
     pass
 
 class Add(BinaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Add"):
-    """The "+" binary operation."""
+    """The "+" binary operation.
+
+    Stability:
+        experimental
+    """
     def __init__(self, lhs: scope.jsii_calc_lib.Value, rhs: scope.jsii_calc_lib.Value) -> None:
         """Creates a BinaryOperation.
 
         Arguments:
             lhs: Left-hand side operand.
             rhs: Right-hand side operand.
+
+        Stability:
+            experimental
         """
         jsii.create(Add, self, [lhs, rhs])
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "toString", [])
 
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """The value."""
+        """The value.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
 
 @jsii.data_type(jsii_type="jsii-calc.CalculatorProps", jsii_struct_bases=[])
 class CalculatorProps(jsii.compat.TypedDict, total=False):
-    """Properties for Calculator."""
+    """Properties for Calculator.
+
+    Stability:
+        experimental
+    """
     initialValue: jsii.Number
+    """
+    Stability:
+        experimental
+    """
 
     maximumValue: jsii.Number
+    """
+    Stability:
+        experimental
+    """
 
 class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"):
     """This class has docs.
@@ -440,12 +673,20 @@ class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"
 
 
 class ClassWithMutableObjectLiteralProperty(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithMutableObjectLiteralProperty"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ClassWithMutableObjectLiteralProperty, self, [])
 
     @property
     @jsii.member(jsii_name="mutableObject")
     def mutable_object(self) -> "IMutableObjectLiteral":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "mutableObject")
 
     @mutable_object.setter
@@ -454,55 +695,98 @@ class ClassWithMutableObjectLiteralProperty(metaclass=jsii.JSIIMeta, jsii_type="
 
 
 class ConstructorPassesThisOut(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ConstructorPassesThisOut"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
         """
         Arguments:
             consumer: -
+
+        Stability:
+            experimental
         """
         jsii.create(ConstructorPassesThisOut, self, [consumer])
 
 
 class Constructors(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Constructors"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(Constructors, self, [])
 
     @jsii.member(jsii_name="hiddenInterface")
     @classmethod
     def hidden_interface(cls) -> "IPublicInterface":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "hiddenInterface", [])
 
     @jsii.member(jsii_name="hiddenInterfaces")
     @classmethod
     def hidden_interfaces(cls) -> typing.List["IPublicInterface"]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "hiddenInterfaces", [])
 
     @jsii.member(jsii_name="hiddenSubInterfaces")
     @classmethod
     def hidden_sub_interfaces(cls) -> typing.List["IPublicInterface"]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "hiddenSubInterfaces", [])
 
     @jsii.member(jsii_name="makeClass")
     @classmethod
     def make_class(cls) -> "PublicClass":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "makeClass", [])
 
     @jsii.member(jsii_name="makeInterface")
     @classmethod
     def make_interface(cls) -> "IPublicInterface":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "makeInterface", [])
 
     @jsii.member(jsii_name="makeInterface2")
     @classmethod
     def make_interface2(cls) -> "IPublicInterface2":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "makeInterface2", [])
 
     @jsii.member(jsii_name="makeInterfaces")
     @classmethod
     def make_interfaces(cls) -> typing.List["IPublicInterface"]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "makeInterfaces", [])
 
 
 class ConsumersOfThisCrazyTypeSystem(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ConsumersOfThisCrazyTypeSystem"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ConsumersOfThisCrazyTypeSystem, self, [])
 
@@ -511,6 +795,9 @@ class ConsumersOfThisCrazyTypeSystem(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
         """
         Arguments:
             obj: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "consumeAnotherPublicInterface", [obj])
 
@@ -519,33 +806,55 @@ class ConsumersOfThisCrazyTypeSystem(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
         """
         Arguments:
             obj: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "consumeNonInternalInterface", [obj])
 
 
 class DefaultedConstructorArgument(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DefaultedConstructorArgument"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, arg1: typing.Optional[jsii.Number]=None, arg2: typing.Optional[str]=None, arg3: typing.Optional[datetime.datetime]=None) -> None:
         """
         Arguments:
             arg1: -
             arg2: -
             arg3: -
+
+        Stability:
+            experimental
         """
         jsii.create(DefaultedConstructorArgument, self, [arg1, arg2, arg3])
 
     @property
     @jsii.member(jsii_name="arg1")
     def arg1(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg1")
 
     @property
     @jsii.member(jsii_name="arg3")
     def arg3(self) -> datetime.datetime:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg3")
 
     @property
     @jsii.member(jsii_name="arg2")
     def arg2(self) -> typing.Optional[str]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg2")
 
 
@@ -657,12 +966,20 @@ class DeprecatedStruct(jsii.compat.TypedDict):
 
 class DerivedClassHasNoProperties:
     class Base(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DerivedClassHasNoProperties.Base"):
+        """
+        Stability:
+            experimental
+        """
         def __init__(self) -> None:
             jsii.create(DerivedClassHasNoProperties.Base, self, [])
 
         @property
         @jsii.member(jsii_name="prop")
         def prop(self) -> str:
+            """
+            Stability:
+                experimental
+            """
             return jsii.get(self, "prop")
 
         @prop.setter
@@ -671,6 +988,10 @@ class DerivedClassHasNoProperties:
 
 
     class Derived(Base, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DerivedClassHasNoProperties.Derived"):
+        """
+        Stability:
+            experimental
+        """
         def __init__(self) -> None:
             jsii.create(DerivedClassHasNoProperties.Derived, self, [])
 
@@ -679,21 +1000,53 @@ class DerivedClassHasNoProperties:
 @jsii.data_type_optionals(jsii_struct_bases=[scope.jsii_calc_lib.MyFirstStruct])
 class _DerivedStruct(scope.jsii_calc_lib.MyFirstStruct, jsii.compat.TypedDict, total=False):
     anotherOptional: typing.Mapping[str,scope.jsii_calc_lib.Value]
-    """This is optional."""
+    """This is optional.
+
+    Stability:
+        experimental
+    """
     optionalAny: typing.Any
+    """
+    Stability:
+        experimental
+    """
     optionalArray: typing.List[str]
+    """
+    Stability:
+        experimental
+    """
 
 @jsii.data_type(jsii_type="jsii-calc.DerivedStruct", jsii_struct_bases=[_DerivedStruct])
 class DerivedStruct(_DerivedStruct):
-    """A struct which derives from another struct."""
+    """A struct which derives from another struct.
+
+    Stability:
+        experimental
+    """
     anotherRequired: datetime.datetime
+    """
+    Stability:
+        experimental
+    """
 
     bool: bool
+    """
+    Stability:
+        experimental
+    """
 
     nonPrimitive: "DoubleTrouble"
-    """An example of a non primitive property."""
+    """An example of a non primitive property.
+
+    Stability:
+        experimental
+    """
 
 class DoNotOverridePrivates(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoNotOverridePrivates"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(DoNotOverridePrivates, self, [])
 
@@ -702,20 +1055,35 @@ class DoNotOverridePrivates(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoNotO
         """
         Arguments:
             newValue: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "changePrivatePropertyValue", [new_value])
 
     @jsii.member(jsii_name="privateMethodValue")
     def private_method_value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "privateMethodValue", [])
 
     @jsii.member(jsii_name="privatePropertyValue")
     def private_property_value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "privatePropertyValue", [])
 
 
 class DoNotRecognizeAnyAsOptional(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoNotRecognizeAnyAsOptional"):
-    """jsii#284: do not recognize "any" as an optional argument."""
+    """jsii#284: do not recognize "any" as an optional argument.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(DoNotRecognizeAnyAsOptional, self, [])
 
@@ -726,6 +1094,9 @@ class DoNotRecognizeAnyAsOptional(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.
             _requiredAny: -
             _optionalAny: -
             _optionalString: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "method", [_required_any, _optional_any, _optional_string])
 
@@ -757,6 +1128,9 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
         Returns:
             A number that everyone knows very well
+
+        Stability:
+            stable
         """
         greetee: Greetee = {}
 
@@ -776,6 +1150,10 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
 
 class DontComplainAboutVariadicAfterOptional(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DontComplainAboutVariadicAfterOptional"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(DontComplainAboutVariadicAfterOptional, self, [])
 
@@ -785,11 +1163,18 @@ class DontComplainAboutVariadicAfterOptional(metaclass=jsii.JSIIMeta, jsii_type=
         Arguments:
             optional: -
             things: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "optionalAndVariadic", [optional, *things])
 
 
 class EraseUndefinedHashValues(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.EraseUndefinedHashValues"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(EraseUndefinedHashValues, self, [])
 
@@ -804,27 +1189,50 @@ class EraseUndefinedHashValues(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Era
         Arguments:
             opts: -
             key: -
+
+        Stability:
+            experimental
         """
         return jsii.sinvoke(cls, "doesKeyExist", [opts, key])
 
     @jsii.member(jsii_name="prop1IsNull")
     @classmethod
     def prop1_is_null(cls) -> typing.Any:
-        """We expect "prop1" to be erased."""
+        """We expect "prop1" to be erased.
+
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "prop1IsNull", [])
 
     @jsii.member(jsii_name="prop2IsUndefined")
     @classmethod
     def prop2_is_undefined(cls) -> typing.Any:
-        """We expect "prop2" to be erased."""
+        """We expect "prop2" to be erased.
+
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "prop2IsUndefined", [])
 
 
 @jsii.data_type(jsii_type="jsii-calc.EraseUndefinedHashValuesOptions", jsii_struct_bases=[])
 class EraseUndefinedHashValuesOptions(jsii.compat.TypedDict, total=False):
+    """
+    Stability:
+        experimental
+    """
     option1: str
+    """
+    Stability:
+        experimental
+    """
 
     option2: str
+    """
+    Stability:
+        experimental
+    """
 
 class ExperimentalClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ExperimentalClass"):
     """
@@ -903,26 +1311,53 @@ class ExperimentalStruct(jsii.compat.TypedDict):
     """
 
 class ExportedBaseClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ExportedBaseClass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, success: bool) -> None:
         """
         Arguments:
             success: -
+
+        Stability:
+            experimental
         """
         jsii.create(ExportedBaseClass, self, [success])
 
     @property
     @jsii.member(jsii_name="success")
     def success(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "success")
 
 
 @jsii.data_type(jsii_type="jsii-calc.ExtendsInternalInterface", jsii_struct_bases=[])
 class ExtendsInternalInterface(jsii.compat.TypedDict):
+    """
+    Stability:
+        experimental
+    """
     boom: bool
+    """
+    Stability:
+        experimental
+    """
 
     prop: str
+    """
+    Stability:
+        experimental
+    """
 
 class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(GiveMeStructs, self, [])
 
@@ -932,15 +1367,18 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
 
         Arguments:
             derived: -
-            anotherRequired: -
-            bool: -
+            anotherRequired: 
+            bool: 
             nonPrimitive: An example of a non primitive property.
             anotherOptional: This is optional.
-            optionalAny: -
-            optionalArray: -
+            optionalAny: 
+            optionalArray: 
             anumber: An awesome number value.
             astring: A string value.
-            firstOptional: -
+            firstOptional: 
+
+        Stability:
+            experimental
         """
         derived: DerivedStruct = {"anotherRequired": another_required, "bool": bool, "nonPrimitive": non_primitive, "anumber": anumber, "astring": astring}
 
@@ -964,15 +1402,18 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
 
         Arguments:
             derived: -
-            anotherRequired: -
-            bool: -
+            anotherRequired: 
+            bool: 
             nonPrimitive: An example of a non primitive property.
             anotherOptional: This is optional.
-            optionalAny: -
-            optionalArray: -
+            optionalAny: 
+            optionalArray: 
             anumber: An awesome number value.
             astring: A string value.
-            firstOptional: -
+            firstOptional: 
+
+        Stability:
+            experimental
         """
         derived: DerivedStruct = {"anotherRequired": another_required, "bool": bool, "nonPrimitive": non_primitive, "anumber": anumber, "astring": astring}
 
@@ -998,7 +1439,10 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
             first: -
             anumber: An awesome number value.
             astring: A string value.
-            firstOptional: -
+            firstOptional: 
+
+        Stability:
+            experimental
         """
         first: scope.jsii_calc_lib.MyFirstStruct = {"anumber": anumber, "astring": astring}
 
@@ -1010,20 +1454,35 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
     @property
     @jsii.member(jsii_name="structLiteral")
     def struct_literal(self) -> scope.jsii_calc_lib.StructWithOnlyOptionals:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "structLiteral")
 
 
 @jsii.data_type(jsii_type="jsii-calc.Greetee", jsii_struct_bases=[])
 class Greetee(jsii.compat.TypedDict, total=False):
-    """These are some arguments you can pass to a method."""
+    """These are some arguments you can pass to a method.
+
+    Stability:
+        experimental
+    """
     name: str
     """The name of the greetee.
 
     Default:
         world
+
+    Stability:
+        experimental
     """
 
 class GreetingAugmenter(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GreetingAugmenter"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(GreetingAugmenter, self, [])
 
@@ -1032,12 +1491,19 @@ class GreetingAugmenter(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GreetingAu
         """
         Arguments:
             friendly: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "betterGreeting", [friendly])
 
 
 @jsii.interface(jsii_type="jsii-calc.IAnotherPublicInterface")
 class IAnotherPublicInterface(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IAnotherPublicInterfaceProxy
@@ -1045,6 +1511,10 @@ class IAnotherPublicInterface(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="a")
     def a(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @a.setter
@@ -1053,10 +1523,18 @@ class IAnotherPublicInterface(jsii.compat.Protocol):
 
 
 class _IAnotherPublicInterfaceProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IAnotherPublicInterface"
     @property
     @jsii.member(jsii_name="a")
     def a(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "a")
 
     @a.setter
@@ -1204,6 +1682,10 @@ class _IExperimentalInterfaceProxy():
 
 @jsii.interface(jsii_type="jsii-calc.IExtendsPrivateInterface")
 class IExtendsPrivateInterface(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IExtendsPrivateInterfaceProxy
@@ -1211,11 +1693,19 @@ class IExtendsPrivateInterface(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="moreThings")
     def more_things(self) -> typing.List[str]:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @property
     @jsii.member(jsii_name="private")
     def private(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @private.setter
@@ -1224,15 +1714,27 @@ class IExtendsPrivateInterface(jsii.compat.Protocol):
 
 
 class _IExtendsPrivateInterfaceProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IExtendsPrivateInterface"
     @property
     @jsii.member(jsii_name="moreThings")
     def more_things(self) -> typing.List[str]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "moreThings")
 
     @property
     @jsii.member(jsii_name="private")
     def private(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "private")
 
     @private.setter
@@ -1242,14 +1744,22 @@ class _IExtendsPrivateInterfaceProxy():
 
 @jsii.interface(jsii_type="jsii-calc.IFriendlier")
 class IFriendlier(scope.jsii_calc_lib.IFriendly, jsii.compat.Protocol):
-    """Even friendlier classes can implement this interface."""
+    """Even friendlier classes can implement this interface.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IFriendlierProxy
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> str:
-        """Say farewell."""
+        """Say farewell.
+
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="goodbye")
@@ -1258,16 +1768,27 @@ class IFriendlier(scope.jsii_calc_lib.IFriendly, jsii.compat.Protocol):
 
         Returns:
             A goodbye blessing.
+
+        Stability:
+            experimental
         """
         ...
 
 
 class _IFriendlierProxy(jsii.proxy_for(scope.jsii_calc_lib.IFriendly)):
-    """Even friendlier classes can implement this interface."""
+    """Even friendlier classes can implement this interface.
+
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IFriendlier"
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> str:
-        """Say farewell."""
+        """Say farewell.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "farewell", [])
 
     @jsii.member(jsii_name="goodbye")
@@ -1276,13 +1797,20 @@ class _IFriendlierProxy(jsii.proxy_for(scope.jsii_calc_lib.IFriendly)):
 
         Returns:
             A goodbye blessing.
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "goodbye", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceImplementedByAbstractClass")
 class IInterfaceImplementedByAbstractClass(jsii.compat.Protocol):
-    """awslabs/jsii#220 Abstract return type."""
+    """awslabs/jsii#220 Abstract return type.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceImplementedByAbstractClassProxy
@@ -1290,20 +1818,36 @@ class IInterfaceImplementedByAbstractClass(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="propFromInterface")
     def prop_from_interface(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IInterfaceImplementedByAbstractClassProxy():
-    """awslabs/jsii#220 Abstract return type."""
+    """awslabs/jsii#220 Abstract return type.
+
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceImplementedByAbstractClass"
     @property
     @jsii.member(jsii_name="propFromInterface")
     def prop_from_interface(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "propFromInterface")
 
 
 @jsii.implements(IInterfaceImplementedByAbstractClass)
 class AbstractClass(AbstractClassBase, metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.AbstractClass"):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _AbstractClassProxy
@@ -1317,16 +1861,27 @@ class AbstractClass(AbstractClassBase, metaclass=jsii.JSIIAbstractClass, jsii_ty
         """
         Arguments:
             name: -
+
+        Stability:
+            experimental
         """
         ...
 
     @jsii.member(jsii_name="nonAbstractMethod")
     def non_abstract_method(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "nonAbstractMethod", [])
 
     @property
     @jsii.member(jsii_name="propFromInterface")
     def prop_from_interface(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "propFromInterface")
 
 
@@ -1336,30 +1891,53 @@ class _AbstractClassProxy(AbstractClass, jsii.proxy_for(AbstractClassBase)):
         """
         Arguments:
             name: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "abstractMethod", [name])
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithInternal")
 class IInterfaceWithInternal(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceWithInternalProxy
 
     @jsii.member(jsii_name="visible")
     def visible(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IInterfaceWithInternalProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceWithInternal"
     @jsii.member(jsii_name="visible")
     def visible(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "visible", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithMethods")
 class IInterfaceWithMethods(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceWithMethodsProxy
@@ -1367,28 +1945,52 @@ class IInterfaceWithMethods(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="doThings")
     def do_things(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IInterfaceWithMethodsProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceWithMethods"
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
     @jsii.member(jsii_name="doThings")
     def do_things(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "doThings", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceThatShouldNotBeADataType")
 class IInterfaceThatShouldNotBeADataType(IInterfaceWithMethods, jsii.compat.Protocol):
-    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."""
+    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceThatShouldNotBeADataTypeProxy
@@ -1396,21 +1998,37 @@ class IInterfaceThatShouldNotBeADataType(IInterfaceWithMethods, jsii.compat.Prot
     @property
     @jsii.member(jsii_name="otherValue")
     def other_value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IInterfaceThatShouldNotBeADataTypeProxy(jsii.proxy_for(IInterfaceWithMethods)):
-    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."""
+    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceThatShouldNotBeADataType"
     @property
     @jsii.member(jsii_name="otherValue")
     def other_value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "otherValue")
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithOptionalMethodArguments")
 class IInterfaceWithOptionalMethodArguments(jsii.compat.Protocol):
-    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."""
+    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceWithOptionalMethodArgumentsProxy
@@ -1421,12 +2039,19 @@ class IInterfaceWithOptionalMethodArguments(jsii.compat.Protocol):
         Arguments:
             arg1: -
             arg2: -
+
+        Stability:
+            experimental
         """
         ...
 
 
 class _IInterfaceWithOptionalMethodArgumentsProxy():
-    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."""
+    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
+
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceWithOptionalMethodArguments"
     @jsii.member(jsii_name="hello")
     def hello(self, arg1: str, arg2: typing.Optional[jsii.Number]=None) -> None:
@@ -1434,12 +2059,19 @@ class _IInterfaceWithOptionalMethodArgumentsProxy():
         Arguments:
             arg1: -
             arg2: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "hello", [arg1, arg2])
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithProperties")
 class IInterfaceWithProperties(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceWithPropertiesProxy
@@ -1447,11 +2079,19 @@ class IInterfaceWithProperties(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="readOnlyString")
     def read_only_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @property
     @jsii.member(jsii_name="readWriteString")
     def read_write_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @read_write_string.setter
@@ -1460,15 +2100,27 @@ class IInterfaceWithProperties(jsii.compat.Protocol):
 
 
 class _IInterfaceWithPropertiesProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceWithProperties"
     @property
     @jsii.member(jsii_name="readOnlyString")
     def read_only_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "readOnlyString")
 
     @property
     @jsii.member(jsii_name="readWriteString")
     def read_write_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "readWriteString")
 
     @read_write_string.setter
@@ -1478,7 +2130,11 @@ class _IInterfaceWithPropertiesProxy():
 
 @jsii.implements(IInterfaceWithProperties)
 class ClassWithPrivateConstructorAndAutomaticProperties(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties"):
-    """Class that implements interface properties automatically, but using a private constructor."""
+    """Class that implements interface properties automatically, but using a private constructor.
+
+    Stability:
+        experimental
+    """
     @jsii.member(jsii_name="create")
     @classmethod
     def create(cls, read_only_string: str, read_write_string: str) -> "ClassWithPrivateConstructorAndAutomaticProperties":
@@ -1486,17 +2142,28 @@ class ClassWithPrivateConstructorAndAutomaticProperties(metaclass=jsii.JSIIMeta,
         Arguments:
             readOnlyString: -
             readWriteString: -
+
+        Stability:
+            experimental
         """
         return jsii.sinvoke(cls, "create", [read_only_string, read_write_string])
 
     @property
     @jsii.member(jsii_name="readOnlyString")
     def read_only_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "readOnlyString")
 
     @property
     @jsii.member(jsii_name="readWriteString")
     def read_write_string(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "readWriteString")
 
     @read_write_string.setter
@@ -1506,6 +2173,10 @@ class ClassWithPrivateConstructorAndAutomaticProperties(metaclass=jsii.JSIIMeta,
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithPropertiesExtension")
 class IInterfaceWithPropertiesExtension(IInterfaceWithProperties, jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IInterfaceWithPropertiesExtensionProxy
@@ -1513,6 +2184,10 @@ class IInterfaceWithPropertiesExtension(IInterfaceWithProperties, jsii.compat.Pr
     @property
     @jsii.member(jsii_name="foo")
     def foo(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @foo.setter
@@ -1521,10 +2196,18 @@ class IInterfaceWithPropertiesExtension(IInterfaceWithProperties, jsii.compat.Pr
 
 
 class _IInterfaceWithPropertiesExtensionProxy(jsii.proxy_for(IInterfaceWithProperties)):
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IInterfaceWithPropertiesExtension"
     @property
     @jsii.member(jsii_name="foo")
     def foo(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "foo")
 
     @foo.setter
@@ -1534,6 +2217,10 @@ class _IInterfaceWithPropertiesExtensionProxy(jsii.proxy_for(IInterfaceWithPrope
 
 @jsii.interface(jsii_type="jsii-calc.IJSII417PublicBaseOfBase")
 class IJSII417PublicBaseOfBase(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IJSII417PublicBaseOfBaseProxy
@@ -1541,27 +2228,51 @@ class IJSII417PublicBaseOfBase(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="hasRoot")
     def has_root(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="foo")
     def foo(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IJSII417PublicBaseOfBaseProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IJSII417PublicBaseOfBase"
     @property
     @jsii.member(jsii_name="hasRoot")
     def has_root(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "hasRoot")
 
     @jsii.member(jsii_name="foo")
     def foo(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "foo", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IJSII417Derived")
 class IJSII417Derived(IJSII417PublicBaseOfBase, jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IJSII417DerivedProxy
@@ -1569,35 +2280,67 @@ class IJSII417Derived(IJSII417PublicBaseOfBase, jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="property")
     def property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="bar")
     def bar(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IJSII417DerivedProxy(jsii.proxy_for(IJSII417PublicBaseOfBase)):
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IJSII417Derived"
     @property
     @jsii.member(jsii_name="property")
     def property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "property")
 
     @jsii.member(jsii_name="bar")
     def bar(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "bar", [])
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "baz", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IJsii487External")
 class IJsii487External(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IJsii487ExternalProxy
@@ -1605,11 +2348,19 @@ class IJsii487External(jsii.compat.Protocol):
     pass
 
 class _IJsii487ExternalProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IJsii487External"
     pass
 
 @jsii.interface(jsii_type="jsii-calc.IJsii487External2")
 class IJsii487External2(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IJsii487External2Proxy
@@ -1617,11 +2368,19 @@ class IJsii487External2(jsii.compat.Protocol):
     pass
 
 class _IJsii487External2Proxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IJsii487External2"
     pass
 
 @jsii.interface(jsii_type="jsii-calc.IJsii496")
 class IJsii496(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IJsii496Proxy
@@ -1629,11 +2388,19 @@ class IJsii496(jsii.compat.Protocol):
     pass
 
 class _IJsii496Proxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IJsii496"
     pass
 
 @jsii.interface(jsii_type="jsii-calc.IMutableObjectLiteral")
 class IMutableObjectLiteral(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IMutableObjectLiteralProxy
@@ -1641,6 +2408,10 @@ class IMutableObjectLiteral(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @value.setter
@@ -1649,10 +2420,18 @@ class IMutableObjectLiteral(jsii.compat.Protocol):
 
 
 class _IMutableObjectLiteralProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IMutableObjectLiteral"
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
     @value.setter
@@ -1662,6 +2441,10 @@ class _IMutableObjectLiteralProxy():
 
 @jsii.interface(jsii_type="jsii-calc.INonInternalInterface")
 class INonInternalInterface(IAnotherPublicInterface, jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _INonInternalInterfaceProxy
@@ -1669,6 +2452,10 @@ class INonInternalInterface(IAnotherPublicInterface, jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="b")
     def b(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @b.setter
@@ -1678,6 +2465,10 @@ class INonInternalInterface(IAnotherPublicInterface, jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="c")
     def c(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @c.setter
@@ -1686,10 +2477,18 @@ class INonInternalInterface(IAnotherPublicInterface, jsii.compat.Protocol):
 
 
 class _INonInternalInterfaceProxy(jsii.proxy_for(IAnotherPublicInterface)):
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.INonInternalInterface"
     @property
     @jsii.member(jsii_name="b")
     def b(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "b")
 
     @b.setter
@@ -1699,6 +2498,10 @@ class _INonInternalInterfaceProxy(jsii.proxy_for(IAnotherPublicInterface)):
     @property
     @jsii.member(jsii_name="c")
     def c(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "c")
 
     @c.setter
@@ -1708,12 +2511,20 @@ class _INonInternalInterfaceProxy(jsii.proxy_for(IAnotherPublicInterface)):
 
 @jsii.implements(INonInternalInterface)
 class ClassThatImplementsTheInternalInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassThatImplementsTheInternalInterface"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ClassThatImplementsTheInternalInterface, self, [])
 
     @property
     @jsii.member(jsii_name="a")
     def a(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "a")
 
     @a.setter
@@ -1723,6 +2534,10 @@ class ClassThatImplementsTheInternalInterface(metaclass=jsii.JSIIMeta, jsii_type
     @property
     @jsii.member(jsii_name="b")
     def b(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "b")
 
     @b.setter
@@ -1732,6 +2547,10 @@ class ClassThatImplementsTheInternalInterface(metaclass=jsii.JSIIMeta, jsii_type
     @property
     @jsii.member(jsii_name="c")
     def c(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "c")
 
     @c.setter
@@ -1741,6 +2560,10 @@ class ClassThatImplementsTheInternalInterface(metaclass=jsii.JSIIMeta, jsii_type
     @property
     @jsii.member(jsii_name="d")
     def d(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "d")
 
     @d.setter
@@ -1750,12 +2573,20 @@ class ClassThatImplementsTheInternalInterface(metaclass=jsii.JSIIMeta, jsii_type
 
 @jsii.implements(INonInternalInterface)
 class ClassThatImplementsThePrivateInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassThatImplementsThePrivateInterface"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ClassThatImplementsThePrivateInterface, self, [])
 
     @property
     @jsii.member(jsii_name="a")
     def a(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "a")
 
     @a.setter
@@ -1765,6 +2596,10 @@ class ClassThatImplementsThePrivateInterface(metaclass=jsii.JSIIMeta, jsii_type=
     @property
     @jsii.member(jsii_name="b")
     def b(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "b")
 
     @b.setter
@@ -1774,6 +2609,10 @@ class ClassThatImplementsThePrivateInterface(metaclass=jsii.JSIIMeta, jsii_type=
     @property
     @jsii.member(jsii_name="c")
     def c(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "c")
 
     @c.setter
@@ -1783,6 +2622,10 @@ class ClassThatImplementsThePrivateInterface(metaclass=jsii.JSIIMeta, jsii_type=
     @property
     @jsii.member(jsii_name="e")
     def e(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "e")
 
     @e.setter
@@ -1792,6 +2635,10 @@ class ClassThatImplementsThePrivateInterface(metaclass=jsii.JSIIMeta, jsii_type=
 
 @jsii.interface(jsii_type="jsii-calc.IPrivatelyImplemented")
 class IPrivatelyImplemented(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IPrivatelyImplementedProxy
@@ -1799,56 +2646,104 @@ class IPrivatelyImplemented(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="success")
     def success(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IPrivatelyImplementedProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IPrivatelyImplemented"
     @property
     @jsii.member(jsii_name="success")
     def success(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "success")
 
 
 @jsii.interface(jsii_type="jsii-calc.IPublicInterface")
 class IPublicInterface(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IPublicInterfaceProxy
 
     @jsii.member(jsii_name="bye")
     def bye(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IPublicInterfaceProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IPublicInterface"
     @jsii.member(jsii_name="bye")
     def bye(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "bye", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IPublicInterface2")
 class IPublicInterface2(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IPublicInterface2Proxy
 
     @jsii.member(jsii_name="ciao")
     def ciao(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IPublicInterface2Proxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IPublicInterface2"
     @jsii.member(jsii_name="ciao")
     def ciao(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "ciao", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IRandomNumberGenerator")
 class IRandomNumberGenerator(jsii.compat.Protocol):
-    """Generates random numbers."""
+    """Generates random numbers.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IRandomNumberGeneratorProxy
@@ -1859,12 +2754,19 @@ class IRandomNumberGenerator(jsii.compat.Protocol):
 
         Returns:
             A random number.
+
+        Stability:
+            experimental
         """
         ...
 
 
 class _IRandomNumberGeneratorProxy():
-    """Generates random numbers."""
+    """Generates random numbers.
+
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IRandomNumberGenerator"
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
@@ -1872,12 +2774,19 @@ class _IRandomNumberGeneratorProxy():
 
         Returns:
             A random number.
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "next", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IFriendlyRandomGenerator")
 class IFriendlyRandomGenerator(IRandomNumberGenerator, scope.jsii_calc_lib.IFriendly, jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IFriendlyRandomGeneratorProxy
@@ -1885,27 +2794,47 @@ class IFriendlyRandomGenerator(IRandomNumberGenerator, scope.jsii_calc_lib.IFrie
     pass
 
 class _IFriendlyRandomGeneratorProxy(jsii.proxy_for(IRandomNumberGenerator), jsii.proxy_for(scope.jsii_calc_lib.IFriendly)):
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IFriendlyRandomGenerator"
     pass
 
 @jsii.implements(IFriendlyRandomGenerator)
 class DoubleTrouble(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoubleTrouble"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(DoubleTrouble, self, [])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> str:
-        """Say hello!"""
+        """Say hello!
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "hello", [])
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number."""
+        """Returns another random number.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "next", [])
 
 
 @jsii.interface(jsii_type="jsii-calc.IReturnsNumber")
 class IReturnsNumber(jsii.compat.Protocol):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _IReturnsNumberProxy
@@ -1913,22 +2842,42 @@ class IReturnsNumber(jsii.compat.Protocol):
     @property
     @jsii.member(jsii_name="numberProp")
     def number_prop(self) -> scope.jsii_calc_lib.Number:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @jsii.member(jsii_name="obtainNumber")
     def obtain_number(self) -> scope.jsii_calc_lib.IDoublable:
+        """
+        Stability:
+            experimental
+        """
         ...
 
 
 class _IReturnsNumberProxy():
+    """
+    Stability:
+        experimental
+    """
     __jsii_type__ = "jsii-calc.IReturnsNumber"
     @property
     @jsii.member(jsii_name="numberProp")
     def number_prop(self) -> scope.jsii_calc_lib.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "numberProp")
 
     @jsii.member(jsii_name="obtainNumber")
     def obtain_number(self) -> scope.jsii_calc_lib.IDoublable:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "obtainNumber", [])
 
 
@@ -1993,12 +2942,20 @@ class _IStableInterfaceProxy():
 
 
 class ImplementInternalInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ImplementInternalInterface"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ImplementInternalInterface, self, [])
 
     @property
     @jsii.member(jsii_name="prop")
     def prop(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "prop")
 
     @prop.setter
@@ -2008,26 +2965,46 @@ class ImplementInternalInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.I
 
 @jsii.implements(IInterfaceWithInternal)
 class ImplementsInterfaceWithInternal(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ImplementsInterfaceWithInternal"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ImplementsInterfaceWithInternal, self, [])
 
     @jsii.member(jsii_name="visible")
     def visible(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "visible", [])
 
 
 class ImplementsInterfaceWithInternalSubclass(ImplementsInterfaceWithInternal, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ImplementsInterfaceWithInternalSubclass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ImplementsInterfaceWithInternalSubclass, self, [])
 
 
 class ImplementsPrivateInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ImplementsPrivateInterface"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ImplementsPrivateInterface, self, [])
 
     @property
     @jsii.member(jsii_name="private")
     def private(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "private")
 
     @private.setter
@@ -2037,16 +3014,32 @@ class ImplementsPrivateInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.I
 
 @jsii.data_type(jsii_type="jsii-calc.ImplictBaseOfBase", jsii_struct_bases=[scope.jsii_calc_base.BaseProps])
 class ImplictBaseOfBase(scope.jsii_calc_base.BaseProps, jsii.compat.TypedDict):
+    """
+    Stability:
+        experimental
+    """
     goo: datetime.datetime
+    """
+    Stability:
+        experimental
+    """
 
 class InterfaceInNamespaceIncludesClasses:
     class Foo(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InterfaceInNamespaceIncludesClasses.Foo"):
+        """
+        Stability:
+            experimental
+        """
         def __init__(self) -> None:
             jsii.create(InterfaceInNamespaceIncludesClasses.Foo, self, [])
 
         @property
         @jsii.member(jsii_name="bar")
         def bar(self) -> typing.Optional[str]:
+            """
+            Stability:
+                experimental
+            """
             return jsii.get(self, "bar")
 
         @bar.setter
@@ -2056,85 +3049,164 @@ class InterfaceInNamespaceIncludesClasses:
 
     @jsii.data_type(jsii_type="jsii-calc.InterfaceInNamespaceIncludesClasses.Hello", jsii_struct_bases=[])
     class Hello(jsii.compat.TypedDict):
+        """
+        Stability:
+            experimental
+        """
         foo: jsii.Number
+        """
+        Stability:
+            experimental
+        """
 
 
 class InterfaceInNamespaceOnlyInterface:
     @jsii.data_type(jsii_type="jsii-calc.InterfaceInNamespaceOnlyInterface.Hello", jsii_struct_bases=[])
     class Hello(jsii.compat.TypedDict):
+        """
+        Stability:
+            experimental
+        """
         foo: jsii.Number
+        """
+        Stability:
+            experimental
+        """
 
 
 class JSII417PublicBaseOfBase(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSII417PublicBaseOfBase"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JSII417PublicBaseOfBase, self, [])
 
     @jsii.member(jsii_name="makeInstance")
     @classmethod
     def make_instance(cls) -> "JSII417PublicBaseOfBase":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "makeInstance", [])
 
     @jsii.member(jsii_name="foo")
     def foo(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "foo", [])
 
     @property
     @jsii.member(jsii_name="hasRoot")
     def has_root(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "hasRoot")
 
 
 class JSII417Derived(JSII417PublicBaseOfBase, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSII417Derived"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, property: str) -> None:
         """
         Arguments:
             property: -
+
+        Stability:
+            experimental
         """
         jsii.create(JSII417Derived, self, [property])
 
     @jsii.member(jsii_name="bar")
     def bar(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "bar", [])
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "baz", [])
 
     @property
     @jsii.member(jsii_name="property")
     def _property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "property")
 
 
 class JSObjectLiteralForInterface(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSObjectLiteralForInterface"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JSObjectLiteralForInterface, self, [])
 
     @jsii.member(jsii_name="giveMeFriendly")
     def give_me_friendly(self) -> scope.jsii_calc_lib.IFriendly:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "giveMeFriendly", [])
 
     @jsii.member(jsii_name="giveMeFriendlyGenerator")
     def give_me_friendly_generator(self) -> "IFriendlyRandomGenerator":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "giveMeFriendlyGenerator", [])
 
 
 class JSObjectLiteralToNative(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSObjectLiteralToNative"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JSObjectLiteralToNative, self, [])
 
     @jsii.member(jsii_name="returnLiteral")
     def return_literal(self) -> "JSObjectLiteralToNativeClass":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "returnLiteral", [])
 
 
 class JSObjectLiteralToNativeClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSObjectLiteralToNativeClass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JSObjectLiteralToNativeClass, self, [])
 
     @property
     @jsii.member(jsii_name="propA")
     def prop_a(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "propA")
 
     @prop_a.setter
@@ -2144,6 +3216,10 @@ class JSObjectLiteralToNativeClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc
     @property
     @jsii.member(jsii_name="propB")
     def prop_b(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "propB")
 
     @prop_b.setter
@@ -2152,220 +3228,436 @@ class JSObjectLiteralToNativeClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc
 
 
 class JavaReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JavaReservedWords"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JavaReservedWords, self, [])
 
     @jsii.member(jsii_name="abstract")
     def abstract(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "abstract", [])
 
     @jsii.member(jsii_name="assert")
     def assert_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "assert", [])
 
     @jsii.member(jsii_name="boolean")
     def boolean(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "boolean", [])
 
     @jsii.member(jsii_name="break")
     def break_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "break", [])
 
     @jsii.member(jsii_name="byte")
     def byte(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "byte", [])
 
     @jsii.member(jsii_name="case")
     def case(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "case", [])
 
     @jsii.member(jsii_name="catch")
     def catch(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "catch", [])
 
     @jsii.member(jsii_name="char")
     def char(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "char", [])
 
     @jsii.member(jsii_name="class")
     def class_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "class", [])
 
     @jsii.member(jsii_name="const")
     def const(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "const", [])
 
     @jsii.member(jsii_name="continue")
     def continue_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "continue", [])
 
     @jsii.member(jsii_name="default")
     def default(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "default", [])
 
     @jsii.member(jsii_name="do")
     def do(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "do", [])
 
     @jsii.member(jsii_name="double")
     def double(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "double", [])
 
     @jsii.member(jsii_name="else")
     def else_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "else", [])
 
     @jsii.member(jsii_name="enum")
     def enum(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "enum", [])
 
     @jsii.member(jsii_name="extends")
     def extends(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "extends", [])
 
     @jsii.member(jsii_name="false")
     def false(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "false", [])
 
     @jsii.member(jsii_name="final")
     def final(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "final", [])
 
     @jsii.member(jsii_name="finally")
     def finally_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "finally", [])
 
     @jsii.member(jsii_name="float")
     def float(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "float", [])
 
     @jsii.member(jsii_name="for")
     def for_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "for", [])
 
     @jsii.member(jsii_name="goto")
     def goto(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "goto", [])
 
     @jsii.member(jsii_name="if")
     def if_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "if", [])
 
     @jsii.member(jsii_name="implements")
     def implements(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "implements", [])
 
     @jsii.member(jsii_name="import")
     def import_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "import", [])
 
     @jsii.member(jsii_name="instanceof")
     def instanceof(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "instanceof", [])
 
     @jsii.member(jsii_name="int")
     def int(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "int", [])
 
     @jsii.member(jsii_name="interface")
     def interface(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "interface", [])
 
     @jsii.member(jsii_name="long")
     def long(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "long", [])
 
     @jsii.member(jsii_name="native")
     def native(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "native", [])
 
     @jsii.member(jsii_name="new")
     def new(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "new", [])
 
     @jsii.member(jsii_name="null")
     def null(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "null", [])
 
     @jsii.member(jsii_name="package")
     def package(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "package", [])
 
     @jsii.member(jsii_name="private")
     def private(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "private", [])
 
     @jsii.member(jsii_name="protected")
     def protected(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "protected", [])
 
     @jsii.member(jsii_name="public")
     def public(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "public", [])
 
     @jsii.member(jsii_name="return")
     def return_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "return", [])
 
     @jsii.member(jsii_name="short")
     def short(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "short", [])
 
     @jsii.member(jsii_name="static")
     def static(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "static", [])
 
     @jsii.member(jsii_name="strictfp")
     def strictfp(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "strictfp", [])
 
     @jsii.member(jsii_name="super")
     def super(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "super", [])
 
     @jsii.member(jsii_name="switch")
     def switch(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "switch", [])
 
     @jsii.member(jsii_name="synchronized")
     def synchronized(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "synchronized", [])
 
     @jsii.member(jsii_name="this")
     def this(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "this", [])
 
     @jsii.member(jsii_name="throw")
     def throw(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "throw", [])
 
     @jsii.member(jsii_name="throws")
     def throws(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "throws", [])
 
     @jsii.member(jsii_name="transient")
     def transient(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "transient", [])
 
     @jsii.member(jsii_name="true")
     def true(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "true", [])
 
     @jsii.member(jsii_name="try")
     def try_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "try", [])
 
     @jsii.member(jsii_name="void")
     def void(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "void", [])
 
     @jsii.member(jsii_name="volatile")
     def volatile(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "volatile", [])
 
     @property
     @jsii.member(jsii_name="while")
     def while_(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "while")
 
     @while_.setter
@@ -2375,31 +3667,51 @@ class JavaReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JavaReserv
 
 @jsii.implements(IJsii487External2, IJsii487External)
 class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(Jsii487Derived, self, [])
 
 
 @jsii.implements(IJsii496)
 class Jsii496Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii496Derived"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(Jsii496Derived, self, [])
 
 
 class JsiiAgent(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsiiAgent"):
-    """Host runtime version should be set via JSII_AGENT."""
+    """Host runtime version should be set via JSII_AGENT.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(JsiiAgent, self, [])
 
     @classproperty
     @jsii.member(jsii_name="jsiiAgent")
     def jsii_agent(cls) -> typing.Optional[str]:
-        """Returns the value of the JSII_AGENT environment variable."""
+        """Returns the value of the JSII_AGENT environment variable.
+
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "jsiiAgent")
 
 
 @jsii.data_type(jsii_type="jsii-calc.LoadBalancedFargateServiceProps", jsii_struct_bases=[])
 class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
-    """jsii#298: show default values in sphinx documentation, and respect newlines."""
+    """jsii#298: show default values in sphinx documentation, and respect newlines.
+
+    Stability:
+        experimental
+    """
     containerPort: jsii.Number
     """The container port of the application load balancer attached to your Fargate service.
 
@@ -2407,6 +3719,9 @@ class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
 
     Default:
         80
+
+    Stability:
+        experimental
     """
 
     cpu: str
@@ -2416,6 +3731,9 @@ class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
 
     Default:
         256
+
+    Stability:
+        experimental
     """
 
     memoryMiB: str
@@ -2438,6 +3756,9 @@ class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
 
     Default:
         512
+
+    Stability:
+        experimental
     """
 
     publicLoadBalancer: bool
@@ -2445,6 +3766,9 @@ class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
 
     Default:
         true
+
+    Stability:
+        experimental
     """
 
     publicTasks: bool
@@ -2452,49 +3776,83 @@ class LoadBalancedFargateServiceProps(jsii.compat.TypedDict, total=False):
 
     Default:
         false
+
+    Stability:
+        experimental
     """
 
 @jsii.implements(IFriendlier, IRandomNumberGenerator)
 class Multiply(BinaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Multiply"):
-    """The "*" binary operation."""
+    """The "*" binary operation.
+
+    Stability:
+        experimental
+    """
     def __init__(self, lhs: scope.jsii_calc_lib.Value, rhs: scope.jsii_calc_lib.Value) -> None:
         """Creates a BinaryOperation.
 
         Arguments:
             lhs: Left-hand side operand.
             rhs: Right-hand side operand.
+
+        Stability:
+            experimental
         """
         jsii.create(Multiply, self, [lhs, rhs])
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> str:
-        """Say farewell."""
+        """Say farewell.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "farewell", [])
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> str:
-        """Say goodbye."""
+        """Say goodbye.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "goodbye", [])
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number."""
+        """Returns another random number.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "next", [])
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "toString", [])
 
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """The value."""
+        """The value.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
 
 class NodeStandardLibrary(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NodeStandardLibrary"):
-    """Test fixture to verify that jsii modules can use the node standard library."""
+    """Test fixture to verify that jsii modules can use the node standard library.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(NodeStandardLibrary, self, [])
 
@@ -2504,6 +3862,9 @@ class NodeStandardLibrary(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NodeStan
 
         Returns:
             "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "cryptoSha256", [])
 
@@ -2513,6 +3874,9 @@ class NodeStandardLibrary(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NodeStan
 
         Returns:
             "Hello, resource!"
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "fsReadFile", [])
 
@@ -2522,23 +3886,37 @@ class NodeStandardLibrary(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NodeStan
 
         Returns:
             "Hello, resource! SYNC!"
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "fsReadFileSync", [])
 
     @property
     @jsii.member(jsii_name="osPlatform")
     def os_platform(self) -> str:
-        """Returns the current os.platform() from the "os" node module."""
+        """Returns the current os.platform() from the "os" node module.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "osPlatform")
 
 
 class NullShouldBeTreatedAsUndefined(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NullShouldBeTreatedAsUndefined"):
-    """jsii#282, aws-cdk#157: null should be treated as "undefined"."""
+    """jsii#282, aws-cdk#157: null should be treated as "undefined".
+
+    Stability:
+        experimental
+    """
     def __init__(self, _param1: str, optional: typing.Any=None) -> None:
         """
         Arguments:
             _param1: -
             optional: -
+
+        Stability:
+            experimental
         """
         jsii.create(NullShouldBeTreatedAsUndefined, self, [_param1, optional])
 
@@ -2547,6 +3925,9 @@ class NullShouldBeTreatedAsUndefined(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "giveMeUndefined", [value])
 
@@ -2555,8 +3936,11 @@ class NullShouldBeTreatedAsUndefined(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
         """
         Arguments:
             input: -
-            arrayWithThreeElementsAndUndefinedAsSecondArgument: -
-            thisShouldBeUndefined: -
+            arrayWithThreeElementsAndUndefinedAsSecondArgument: 
+            thisShouldBeUndefined: 
+
+        Stability:
+            experimental
         """
         input: NullShouldBeTreatedAsUndefinedData = {"arrayWithThreeElementsAndUndefinedAsSecondArgument": array_with_three_elements_and_undefined_as_second_argument}
 
@@ -2567,11 +3951,19 @@ class NullShouldBeTreatedAsUndefined(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
 
     @jsii.member(jsii_name="verifyPropertyIsUndefined")
     def verify_property_is_undefined(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "verifyPropertyIsUndefined", [])
 
     @property
     @jsii.member(jsii_name="changeMeToUndefined")
     def change_me_to_undefined(self) -> typing.Optional[str]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "changeMeToUndefined")
 
     @change_me_to_undefined.setter
@@ -2582,17 +3974,36 @@ class NullShouldBeTreatedAsUndefined(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
 @jsii.data_type_optionals(jsii_struct_bases=[])
 class _NullShouldBeTreatedAsUndefinedData(jsii.compat.TypedDict, total=False):
     thisShouldBeUndefined: typing.Any
+    """
+    Stability:
+        experimental
+    """
 
 @jsii.data_type(jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData", jsii_struct_bases=[_NullShouldBeTreatedAsUndefinedData])
 class NullShouldBeTreatedAsUndefinedData(_NullShouldBeTreatedAsUndefinedData):
+    """
+    Stability:
+        experimental
+    """
     arrayWithThreeElementsAndUndefinedAsSecondArgument: typing.List[typing.Any]
+    """
+    Stability:
+        experimental
+    """
 
 class NumberGenerator(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NumberGenerator"):
-    """This allows us to test that a reference can be stored for objects that implement interfaces."""
+    """This allows us to test that a reference can be stored for objects that implement interfaces.
+
+    Stability:
+        experimental
+    """
     def __init__(self, generator: "IRandomNumberGenerator") -> None:
         """
         Arguments:
             generator: -
+
+        Stability:
+            experimental
         """
         jsii.create(NumberGenerator, self, [generator])
 
@@ -2601,16 +4012,27 @@ class NumberGenerator(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NumberGenera
         """
         Arguments:
             gen: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "isSameGenerator", [gen])
 
     @jsii.member(jsii_name="nextTimes100")
     def next_times100(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "nextTimes100", [])
 
     @property
     @jsii.member(jsii_name="generator")
     def generator(self) -> "IRandomNumberGenerator":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "generator")
 
     @generator.setter
@@ -2619,7 +4041,11 @@ class NumberGenerator(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NumberGenera
 
 
 class ObjectRefsInCollections(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ObjectRefsInCollections"):
-    """Verify that object references can be passed inside collections."""
+    """Verify that object references can be passed inside collections.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ObjectRefsInCollections, self, [])
 
@@ -2629,6 +4055,9 @@ class ObjectRefsInCollections(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Obje
 
         Arguments:
             values: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "sumFromArray", [values])
 
@@ -2638,6 +4067,9 @@ class ObjectRefsInCollections(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Obje
 
         Arguments:
             values: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "sumFromMap", [values])
 
@@ -2656,46 +4088,84 @@ class Old(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Old"):
 
     @jsii.member(jsii_name="doAThing")
     def do_a_thing(self) -> None:
-        """Doo wop that thing."""
+        """Doo wop that thing.
+
+        Stability:
+            deprecated
+        """
         return jsii.invoke(self, "doAThing", [])
 
 
 class OptionalConstructorArgument(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.OptionalConstructorArgument"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, arg1: jsii.Number, arg2: str, arg3: typing.Optional[datetime.datetime]=None) -> None:
         """
         Arguments:
             arg1: -
             arg2: -
             arg3: -
+
+        Stability:
+            experimental
         """
         jsii.create(OptionalConstructorArgument, self, [arg1, arg2, arg3])
 
     @property
     @jsii.member(jsii_name="arg1")
     def arg1(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg1")
 
     @property
     @jsii.member(jsii_name="arg2")
     def arg2(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg2")
 
     @property
     @jsii.member(jsii_name="arg3")
     def arg3(self) -> typing.Optional[datetime.datetime]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "arg3")
 
 
 @jsii.data_type(jsii_type="jsii-calc.OptionalStruct", jsii_struct_bases=[])
 class OptionalStruct(jsii.compat.TypedDict, total=False):
+    """
+    Stability:
+        experimental
+    """
     field: str
+    """
+    Stability:
+        experimental
+    """
 
 class OptionalStructConsumer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.OptionalStructConsumer"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, *, field: typing.Optional[str]=None) -> None:
         """
         Arguments:
             optionalStruct: -
-            field: -
+            field: 
+
+        Stability:
+            experimental
         """
         optional_struct: OptionalStruct = {}
 
@@ -2707,15 +4177,27 @@ class OptionalStructConsumer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Optio
     @property
     @jsii.member(jsii_name="parameterWasUndefined")
     def parameter_was_undefined(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "parameterWasUndefined")
 
     @property
     @jsii.member(jsii_name="fieldValue")
     def field_value(self) -> typing.Optional[str]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "fieldValue")
 
 
 class OverrideReturnsObject(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.OverrideReturnsObject"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(OverrideReturnsObject, self, [])
 
@@ -2724,11 +4206,18 @@ class OverrideReturnsObject(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Overri
         """
         Arguments:
             obj: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "test", [obj])
 
 
 class PartiallyInitializedThisConsumer(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.PartiallyInitializedThisConsumer"):
+    """
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _PartiallyInitializedThisConsumerProxy
@@ -2744,6 +4233,9 @@ class PartiallyInitializedThisConsumer(metaclass=jsii.JSIIAbstractClass, jsii_ty
             obj: -
             dt: -
             ev: -
+
+        Stability:
+            experimental
         """
         ...
 
@@ -2756,11 +4248,18 @@ class _PartiallyInitializedThisConsumerProxy(PartiallyInitializedThisConsumer):
             obj: -
             dt: -
             ev: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "consumePartiallyInitializedThis", [obj, dt, ev])
 
 
 class Polymorphism(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Polymorphism"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(Polymorphism, self, [])
 
@@ -2769,169 +4268,328 @@ class Polymorphism(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Polymorphism"):
         """
         Arguments:
             friendly: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "sayHello", [friendly])
 
 
 class PublicClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.PublicClass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(PublicClass, self, [])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "hello", [])
 
 
 @jsii.implements(IPublicInterface2)
 class InbetweenClass(PublicClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InbetweenClass"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(InbetweenClass, self, [])
 
     @jsii.member(jsii_name="ciao")
     def ciao(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "ciao", [])
 
 
 class PythonReservedWords(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.PythonReservedWords"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(PythonReservedWords, self, [])
 
     @jsii.member(jsii_name="and")
     def and_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "and", [])
 
     @jsii.member(jsii_name="as")
     def as_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "as", [])
 
     @jsii.member(jsii_name="assert")
     def assert_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "assert", [])
 
     @jsii.member(jsii_name="async")
     def async_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "async", [])
 
     @jsii.member(jsii_name="await")
     def await_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "await", [])
 
     @jsii.member(jsii_name="break")
     def break_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "break", [])
 
     @jsii.member(jsii_name="class")
     def class_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "class", [])
 
     @jsii.member(jsii_name="continue")
     def continue_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "continue", [])
 
     @jsii.member(jsii_name="def")
     def def_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "def", [])
 
     @jsii.member(jsii_name="del")
     def del_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "del", [])
 
     @jsii.member(jsii_name="elif")
     def elif_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "elif", [])
 
     @jsii.member(jsii_name="else")
     def else_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "else", [])
 
     @jsii.member(jsii_name="except")
     def except_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "except", [])
 
     @jsii.member(jsii_name="finally")
     def finally_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "finally", [])
 
     @jsii.member(jsii_name="for")
     def for_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "for", [])
 
     @jsii.member(jsii_name="from")
     def from_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "from", [])
 
     @jsii.member(jsii_name="global")
     def global_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "global", [])
 
     @jsii.member(jsii_name="if")
     def if_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "if", [])
 
     @jsii.member(jsii_name="import")
     def import_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "import", [])
 
     @jsii.member(jsii_name="in")
     def in_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "in", [])
 
     @jsii.member(jsii_name="is")
     def is_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "is", [])
 
     @jsii.member(jsii_name="lambda")
     def lambda_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "lambda", [])
 
     @jsii.member(jsii_name="nonlocal")
     def nonlocal_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "nonlocal", [])
 
     @jsii.member(jsii_name="not")
     def not_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "not", [])
 
     @jsii.member(jsii_name="or")
     def or_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "or", [])
 
     @jsii.member(jsii_name="pass")
     def pass_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "pass", [])
 
     @jsii.member(jsii_name="raise")
     def raise_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "raise", [])
 
     @jsii.member(jsii_name="return")
     def return_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "return", [])
 
     @jsii.member(jsii_name="try")
     def try_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "try", [])
 
     @jsii.member(jsii_name="while")
     def while_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "while", [])
 
     @jsii.member(jsii_name="with")
     def with_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "with", [])
 
     @jsii.member(jsii_name="yield")
     def yield_(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "yield", [])
 
 
 class ReferenceEnumFromScopedPackage(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ReferenceEnumFromScopedPackage"):
-    """See awslabs/jsii#138."""
+    """See awslabs/jsii#138.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(ReferenceEnumFromScopedPackage, self, [])
 
     @jsii.member(jsii_name="loadFoo")
     def load_foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "loadFoo", [])
 
     @jsii.member(jsii_name="saveFoo")
@@ -2939,12 +4597,19 @@ class ReferenceEnumFromScopedPackage(metaclass=jsii.JSIIMeta, jsii_type="jsii-ca
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "saveFoo", [value])
 
     @property
     @jsii.member(jsii_name="foo")
     def foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "foo")
 
     @foo.setter
@@ -2960,6 +4625,8 @@ class ReturnsPrivateImplementationOfInterface(metaclass=jsii.JSIIMeta, jsii_type
 
     See:
         https://github.com/awslabs/jsii/issues/320
+    Stability:
+        experimental
     """
     def __init__(self) -> None:
         jsii.create(ReturnsPrivateImplementationOfInterface, self, [])
@@ -2967,10 +4634,18 @@ class ReturnsPrivateImplementationOfInterface(metaclass=jsii.JSIIMeta, jsii_type
     @property
     @jsii.member(jsii_name="privateImplementation")
     def private_implementation(self) -> "IPrivatelyImplemented":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "privateImplementation")
 
 
 class RuntimeTypeChecking(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.RuntimeTypeChecking"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(RuntimeTypeChecking, self, [])
 
@@ -2981,6 +4656,9 @@ class RuntimeTypeChecking(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.RuntimeT
             arg1: -
             arg2: -
             arg3: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "methodWithDefaultedArguments", [arg1, arg2, arg3])
 
@@ -2989,6 +4667,9 @@ class RuntimeTypeChecking(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.RuntimeT
         """
         Arguments:
             arg: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "methodWithOptionalAnyArgument", [arg])
 
@@ -3000,6 +4681,9 @@ class RuntimeTypeChecking(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.RuntimeT
             arg1: -
             arg2: -
             arg3: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "methodWithOptionalArguments", [arg1, arg2, arg3])
 
@@ -3010,16 +4694,27 @@ class SingleInstanceTwoTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Singl
     JSII clients can instantiate 2 different strongly-typed wrappers for the same
     object. Unfortunately, this will break object equality, but if we didn't do
     this it would break runtime type checks in the JVM or CLR.
+
+    Stability:
+        experimental
     """
     def __init__(self) -> None:
         jsii.create(SingleInstanceTwoTypes, self, [])
 
     @jsii.member(jsii_name="interface1")
     def interface1(self) -> "InbetweenClass":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "interface1", [])
 
     @jsii.member(jsii_name="interface2")
     def interface2(self) -> "IPublicInterface":
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "interface2", [])
 
 
@@ -3103,15 +4798,26 @@ class StaticContext(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StaticContext"
     """This is used to validate the ability to use ``this`` from within a static context.
 
     https://github.com/awslabs/aws-cdk/issues/2304
+
+    Stability:
+        experimental
     """
     @jsii.member(jsii_name="canAccessStaticContext")
     @classmethod
     def can_access_static_context(cls) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sinvoke(cls, "canAccessStaticContext", [])
 
     @classproperty
     @jsii.member(jsii_name="staticVariable")
     def static_variable(cls) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "staticVariable")
 
     @static_variable.setter
@@ -3120,10 +4826,17 @@ class StaticContext(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StaticContext"
 
 
 class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, value: str) -> None:
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         jsii.create(Statics, self, [value])
 
@@ -3134,40 +4847,67 @@ class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
 
         Arguments:
             name: The name of the person to say hello to.
+
+        Stability:
+            experimental
         """
         return jsii.sinvoke(cls, "staticMethod", [name])
 
     @jsii.member(jsii_name="justMethod")
     def just_method(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "justMethod", [])
 
     @classproperty
     @jsii.member(jsii_name="BAR")
     def BAR(cls) -> jsii.Number:
-        """Constants may also use all-caps."""
+        """Constants may also use all-caps.
+
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "BAR")
 
     @classproperty
     @jsii.member(jsii_name="ConstObj")
     def CONST_OBJ(cls) -> "DoubleTrouble":
+        """
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "ConstObj")
 
     @classproperty
     @jsii.member(jsii_name="Foo")
     def FOO(cls) -> str:
-        """Jsdocs for static property."""
+        """Jsdocs for static property.
+
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "Foo")
 
     @classproperty
     @jsii.member(jsii_name="zooBar")
     def ZOO_BAR(cls) -> typing.Mapping[str,str]:
-        """Constants can also use camelCase."""
+        """Constants can also use camelCase.
+
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "zooBar")
 
     @classproperty
     @jsii.member(jsii_name="instance")
     def instance(cls) -> "Statics":
-        """Jsdocs for static getter. Jsdocs for static setter."""
+        """Jsdocs for static getter. Jsdocs for static setter.
+
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "instance")
 
     @instance.setter
@@ -3177,6 +4917,10 @@ class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
     @classproperty
     @jsii.member(jsii_name="nonConstStatic")
     def non_const_static(cls) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.sget(cls, "nonConstStatic")
 
     @non_const_static.setter
@@ -3186,22 +4930,50 @@ class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
 
 @jsii.enum(jsii_type="jsii-calc.StringEnum")
 class StringEnum(enum.Enum):
+    """
+    Stability:
+        experimental
+    """
     A = "A"
+    """
+    Stability:
+        experimental
+    """
     B = "B"
+    """
+    Stability:
+        experimental
+    """
     C = "C"
+    """
+    Stability:
+        experimental
+    """
 
 class StripInternal(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StripInternal"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(StripInternal, self, [])
 
     @property
     @jsii.member(jsii_name="youSeeMe")
     def you_see_me(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "youSeeMe")
 
     @you_see_me.setter
@@ -3210,15 +4982,27 @@ class StripInternal(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StripInternal"
 
 
 class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtualMethods"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(SyncVirtualMethods, self, [])
 
     @jsii.member(jsii_name="callerIsAsync")
     def caller_is_async(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.ainvoke(self, "callerIsAsync", [])
 
     @jsii.member(jsii_name="callerIsMethod")
     def caller_is_method(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "callerIsMethod", [])
 
     @jsii.member(jsii_name="modifyOtherProperty")
@@ -3226,6 +5010,9 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "modifyOtherProperty", [value])
 
@@ -3234,23 +5021,42 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "modifyValueOfTheProperty", [value])
 
     @jsii.member(jsii_name="readA")
     def read_a(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "readA", [])
 
     @jsii.member(jsii_name="retrieveOtherProperty")
     def retrieve_other_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "retrieveOtherProperty", [])
 
     @jsii.member(jsii_name="retrieveReadOnlyProperty")
     def retrieve_read_only_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "retrieveReadOnlyProperty", [])
 
     @jsii.member(jsii_name="retrieveValueOfTheProperty")
     def retrieve_value_of_the_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "retrieveValueOfTheProperty", [])
 
     @jsii.member(jsii_name="virtualMethod")
@@ -3258,6 +5064,9 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
         """
         Arguments:
             n: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "virtualMethod", [n])
 
@@ -3266,17 +5075,28 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "writeA", [value])
 
     @property
     @jsii.member(jsii_name="readonlyProperty")
     def readonly_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "readonlyProperty")
 
     @property
     @jsii.member(jsii_name="a")
     def a(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "a")
 
     @a.setter
@@ -3286,6 +5106,10 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
     @property
     @jsii.member(jsii_name="callerIsProperty")
     def caller_is_property(self) -> jsii.Number:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "callerIsProperty")
 
     @caller_is_property.setter
@@ -3295,6 +5119,10 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
     @property
     @jsii.member(jsii_name="otherProperty")
     def other_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "otherProperty")
 
     @other_property.setter
@@ -3304,6 +5132,10 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
     @property
     @jsii.member(jsii_name="theProperty")
     def the_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "theProperty")
 
     @the_property.setter
@@ -3313,6 +5145,10 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
     @property
     @jsii.member(jsii_name="valueOfOtherProperty")
     def value_of_other_property(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "valueOfOtherProperty")
 
     @value_of_other_property.setter
@@ -3321,16 +5157,28 @@ class SyncVirtualMethods(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SyncVirtu
 
 
 class Thrower(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Thrower"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(Thrower, self, [])
 
     @jsii.member(jsii_name="throwError")
     def throw_error(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "throwError", [])
 
 
 class UnaryOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.UnaryOperation"):
-    """An operation on a single operand."""
+    """An operation on a single operand.
+
+    Stability:
+        experimental
+    """
     @staticmethod
     def __jsii_proxy_class__():
         return _UnaryOperationProxy
@@ -3339,12 +5187,19 @@ class UnaryOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstractC
         """
         Arguments:
             operand: -
+
+        Stability:
+            experimental
         """
         jsii.create(UnaryOperation, self, [operand])
 
     @property
     @jsii.member(jsii_name="operand")
     def operand(self) -> scope.jsii_calc_lib.Value:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "operand")
 
 
@@ -3353,78 +5208,144 @@ class _UnaryOperationProxy(UnaryOperation, jsii.proxy_for(scope.jsii_calc_lib.Op
 
 @jsii.implements(IFriendlier)
 class Negate(UnaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Negate"):
-    """The negation operation ("-value")."""
+    """The negation operation ("-value").
+
+    Stability:
+        experimental
+    """
     def __init__(self, operand: scope.jsii_calc_lib.Value) -> None:
         """
         Arguments:
             operand: -
+
+        Stability:
+            experimental
         """
         jsii.create(Negate, self, [operand])
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> str:
-        """Say farewell."""
+        """Say farewell.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "farewell", [])
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> str:
-        """Say goodbye."""
+        """Say goodbye.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "goodbye", [])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> str:
-        """Say hello!"""
+        """Say hello!
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "hello", [])
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> str:
-        """String representation of the value."""
+        """String representation of the value.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "toString", [])
 
     @property
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """The value."""
+        """The value.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "value")
 
 
 @jsii.data_type_optionals(jsii_struct_bases=[])
 class _UnionProperties(jsii.compat.TypedDict, total=False):
     foo: typing.Union[str, jsii.Number]
+    """
+    Stability:
+        experimental
+    """
 
 @jsii.data_type(jsii_type="jsii-calc.UnionProperties", jsii_struct_bases=[_UnionProperties])
 class UnionProperties(_UnionProperties):
+    """
+    Stability:
+        experimental
+    """
     bar: typing.Union[str, jsii.Number, "AllTypes"]
+    """
+    Stability:
+        experimental
+    """
 
 class UseBundledDependency(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UseBundledDependency"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(UseBundledDependency, self, [])
 
     @jsii.member(jsii_name="value")
     def value(self) -> typing.Any:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "value", [])
 
 
 class UseCalcBase(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UseCalcBase"):
-    """Depend on a type from jsii-calc-base as a test for awslabs/jsii#128."""
+    """Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(UseCalcBase, self, [])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> scope.jsii_calc_base.Base:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "hello", [])
 
 
 class UsesInterfaceWithProperties(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UsesInterfaceWithProperties"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, obj: "IInterfaceWithProperties") -> None:
         """
         Arguments:
             obj: -
+
+        Stability:
+            experimental
         """
         jsii.create(UsesInterfaceWithProperties, self, [obj])
 
     @jsii.member(jsii_name="justRead")
     def just_read(self) -> str:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "justRead", [])
 
     @jsii.member(jsii_name="readStringAndNumber")
@@ -3432,6 +5353,9 @@ class UsesInterfaceWithProperties(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.
         """
         Arguments:
             ext: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "readStringAndNumber", [ext])
 
@@ -3440,20 +5364,34 @@ class UsesInterfaceWithProperties(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.
         """
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "writeAndRead", [value])
 
     @property
     @jsii.member(jsii_name="obj")
     def obj(self) -> "IInterfaceWithProperties":
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "obj")
 
 
 class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMethod"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self, *prefix: jsii.Number) -> None:
         """
         Arguments:
             prefix: a prefix that will be use for all values returned by ``#asArray``.
+
+        Stability:
+            experimental
         """
         jsii.create(VariadicMethod, self, [*prefix])
 
@@ -3463,11 +5401,18 @@ class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMetho
         Arguments:
             first: the first element of the array to be returned (after the ``prefix`` provided at construction time).
             others: other elements to be included in the array.
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "asArray", [first, *others])
 
 
 class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VirtualMethodPlayground"):
+    """
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
         jsii.create(VirtualMethodPlayground, self, [])
 
@@ -3476,6 +5421,9 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         """
         Arguments:
             index: -
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "overrideMeAsync", [index])
 
@@ -3484,6 +5432,9 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         """
         Arguments:
             index: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "overrideMeSync", [index])
 
@@ -3492,6 +5443,9 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         """
         Arguments:
             count: -
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "parallelSumAsync", [count])
 
@@ -3500,6 +5454,9 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         """
         Arguments:
             count: -
+
+        Stability:
+            experimental
         """
         return jsii.ainvoke(self, "serialSumAsync", [count])
 
@@ -3508,6 +5465,9 @@ class VirtualMethodPlayground(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Virt
         """
         Arguments:
             count: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "sumSync", [count])
 
@@ -3518,6 +5478,9 @@ class VoidCallback(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.VoidCa
     - Implement ``overrideMe`` (method does not have to do anything).
     - Invoke ``callMe``
     - Verify that ``methodWasCalled`` is ``true``.
+
+    Stability:
+        experimental
     """
     @staticmethod
     def __jsii_proxy_class__():
@@ -3528,28 +5491,48 @@ class VoidCallback(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.VoidCa
 
     @jsii.member(jsii_name="callMe")
     def call_me(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "callMe", [])
 
     @jsii.member(jsii_name="overrideMe")
     @abc.abstractmethod
     def _override_me(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         ...
 
     @property
     @jsii.member(jsii_name="methodWasCalled")
     def method_was_called(self) -> bool:
+        """
+        Stability:
+            experimental
+        """
         return jsii.get(self, "methodWasCalled")
 
 
 class _VoidCallbackProxy(VoidCallback):
     @jsii.member(jsii_name="overrideMe")
     def _override_me(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "overrideMe", [])
 
 
 class composition:
     class CompositeOperation(scope.jsii_calc_lib.Operation, metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.composition.CompositeOperation"):
-        """Abstract operation composed from an expression of other operations."""
+        """Abstract operation composed from an expression of other operations.
+
+        Stability:
+            experimental
+        """
         @staticmethod
         def __jsii_proxy_class__():
             return _CompositeOperationProxy
@@ -3559,26 +5542,42 @@ class composition:
 
         @jsii.member(jsii_name="toString")
         def to_string(self) -> str:
-            """String representation of the value."""
+            """String representation of the value.
+
+            Stability:
+                experimental
+            """
             return jsii.invoke(self, "toString", [])
 
         @property
         @jsii.member(jsii_name="expression")
         @abc.abstractmethod
         def expression(self) -> scope.jsii_calc_lib.Value:
-            """The expression that this operation consists of. Must be implemented by derived classes."""
+            """The expression that this operation consists of. Must be implemented by derived classes.
+
+            Stability:
+                experimental
+            """
             ...
 
         @property
         @jsii.member(jsii_name="value")
         def value(self) -> jsii.Number:
-            """The value."""
+            """The value.
+
+            Stability:
+                experimental
+            """
             return jsii.get(self, "value")
 
         @property
         @jsii.member(jsii_name="decorationPostfixes")
         def decoration_postfixes(self) -> typing.List[str]:
-            """A set of postfixes to include in a decorated .toString()."""
+            """A set of postfixes to include in a decorated .toString().
+
+            Stability:
+                experimental
+            """
             return jsii.get(self, "decorationPostfixes")
 
         @decoration_postfixes.setter
@@ -3588,7 +5587,11 @@ class composition:
         @property
         @jsii.member(jsii_name="decorationPrefixes")
         def decoration_prefixes(self) -> typing.List[str]:
-            """A set of prefixes to include in a decorated .toString()."""
+            """A set of prefixes to include in a decorated .toString().
+
+            Stability:
+                experimental
+            """
             return jsii.get(self, "decorationPrefixes")
 
         @decoration_prefixes.setter
@@ -3598,7 +5601,11 @@ class composition:
         @property
         @jsii.member(jsii_name="stringStyle")
         def string_style(self) -> "CompositionStringStyle":
-            """The .toString() style."""
+            """The .toString() style.
+
+            Stability:
+                experimental
+            """
             return jsii.get(self, "stringStyle")
 
         @string_style.setter
@@ -3607,31 +5614,54 @@ class composition:
 
         @jsii.enum(jsii_type="jsii-calc.composition.CompositeOperation.CompositionStringStyle")
         class CompositionStringStyle(enum.Enum):
-            """Style of .toString() output for CompositeOperation."""
+            """Style of .toString() output for CompositeOperation.
+
+            Stability:
+                experimental
+            """
             Normal = "Normal"
-            """Normal string expression."""
+            """Normal string expression.
+
+            Stability:
+                experimental
+            """
             Decorated = "Decorated"
-            """Decorated string expression."""
+            """Decorated string expression.
+
+            Stability:
+                experimental
+            """
 
 
     class _CompositeOperationProxy(CompositeOperation, jsii.proxy_for(scope.jsii_calc_lib.Operation)):
         @property
         @jsii.member(jsii_name="expression")
         def expression(self) -> scope.jsii_calc_lib.Value:
-            """The expression that this operation consists of. Must be implemented by derived classes."""
+            """The expression that this operation consists of. Must be implemented by derived classes.
+
+            Stability:
+                experimental
+            """
             return jsii.get(self, "expression")
 
 
 
 class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Calculator"):
-    """A calculator which maintains a current value and allows adding operations."""
+    """A calculator which maintains a current value and allows adding operations.
+
+    Stability:
+        experimental
+    """
     def __init__(self, *, initial_value: typing.Optional[jsii.Number]=None, maximum_value: typing.Optional[jsii.Number]=None) -> None:
         """Creates a Calculator object.
 
         Arguments:
             props: Initialization properties.
-            initialValue: -
-            maximumValue: -
+            initialValue: 
+            maximumValue: 
+
+        Stability:
+            experimental
         """
         props: CalculatorProps = {}
 
@@ -3649,6 +5679,9 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
 
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "add", [value])
 
@@ -3658,12 +5691,19 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
 
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "mul", [value])
 
     @jsii.member(jsii_name="neg")
     def neg(self) -> None:
-        """Negates the current value."""
+        """Negates the current value.
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "neg", [])
 
     @jsii.member(jsii_name="pow")
@@ -3672,36 +5712,59 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
 
         Arguments:
             value: -
+
+        Stability:
+            experimental
         """
         return jsii.invoke(self, "pow", [value])
 
     @jsii.member(jsii_name="readUnionValue")
     def read_union_value(self) -> jsii.Number:
-        """Returns teh value of the union property (if defined)."""
+        """Returns teh value of the union property (if defined).
+
+        Stability:
+            experimental
+        """
         return jsii.invoke(self, "readUnionValue", [])
 
     @property
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.Value:
-        """Returns the expression."""
+        """Returns the expression.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "expression")
 
     @property
     @jsii.member(jsii_name="operationsLog")
     def operations_log(self) -> typing.List[scope.jsii_calc_lib.Value]:
-        """A log of all operations."""
+        """A log of all operations.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "operationsLog")
 
     @property
     @jsii.member(jsii_name="operationsMap")
     def operations_map(self) -> typing.Mapping[str,typing.List[scope.jsii_calc_lib.Value]]:
-        """A map of per operation name of all operations performed."""
+        """A map of per operation name of all operations performed.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "operationsMap")
 
     @property
     @jsii.member(jsii_name="curr")
     def curr(self) -> scope.jsii_calc_lib.Value:
-        """The current value."""
+        """The current value.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "curr")
 
     @curr.setter
@@ -3711,7 +5774,11 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
     @property
     @jsii.member(jsii_name="maxValue")
     def max_value(self) -> typing.Optional[jsii.Number]:
-        """The maximum value allows in this calculator."""
+        """The maximum value allows in this calculator.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "maxValue")
 
     @max_value.setter
@@ -3721,7 +5788,11 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
     @property
     @jsii.member(jsii_name="unionProperty")
     def union_property(self) -> typing.Optional[typing.Union[typing.Optional["Add"], typing.Optional["Multiply"], typing.Optional["Power"]]]:
-        """Example of a property that accepts a union of types."""
+        """Example of a property that accepts a union of types.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "unionProperty")
 
     @union_property.setter
@@ -3730,50 +5801,85 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
 
 
 class Power(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Power"):
-    """The power operation."""
+    """The power operation.
+
+    Stability:
+        experimental
+    """
     def __init__(self, base: scope.jsii_calc_lib.Value, pow: scope.jsii_calc_lib.Value) -> None:
         """Creates a Power operation.
 
         Arguments:
             base: The base of the power.
             pow: The number of times to multiply.
+
+        Stability:
+            experimental
         """
         jsii.create(Power, self, [base, pow])
 
     @property
     @jsii.member(jsii_name="base")
     def base(self) -> scope.jsii_calc_lib.Value:
-        """The base of the power."""
+        """The base of the power.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "base")
 
     @property
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.Value:
-        """The expression that this operation consists of. Must be implemented by derived classes."""
+        """The expression that this operation consists of. Must be implemented by derived classes.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "expression")
 
     @property
     @jsii.member(jsii_name="pow")
     def pow(self) -> scope.jsii_calc_lib.Value:
-        """The number of times to multiply."""
+        """The number of times to multiply.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "pow")
 
 
 class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Sum"):
-    """An operation that sums multiple values."""
+    """An operation that sums multiple values.
+
+    Stability:
+        experimental
+    """
     def __init__(self) -> None:
+        """
+        Stability:
+            experimental
+        """
         jsii.create(Sum, self, [])
 
     @property
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.Value:
-        """The expression that this operation consists of. Must be implemented by derived classes."""
+        """The expression that this operation consists of. Must be implemented by derived classes.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "expression")
 
     @property
     @jsii.member(jsii_name="parts")
     def parts(self) -> typing.List[scope.jsii_calc_lib.Value]:
-        """The parts to sum."""
+        """The parts to sum.
+
+        Stability:
+            experimental
+        """
         return jsii.get(self, "parts")
 
     @parts.setter


### PR DESCRIPTION
The JSII compiler now propagates an entity's own stability to it's
members that are not decorated with an explicit stability. Un-annotated
types get the stability of the assembly, un-annotated type members
(methods, properties, constructors, ...) get the stability of their
declaring type.

Note: Overridden members do not derogate! It is the responsibility of
      the overriding entity to ensure an appropriate stability is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
