### PR TITLE
fix(kernel): Correct null handling in JSON types

### DIFF
--- a/packages/jsii-kernel/lib/serialization.ts
+++ b/packages/jsii-kernel/lib/serialization.ts
@@ -170,6 +170,7 @@ export const SERIALIZERS: {[k: string]: Serializer} = {
       return value;
     },
     deserialize(value, optionalValue) {
+      // /!\ Top-level "null" will turn to underfined, but any null nested in the value is valid JSON, so it'll stay!
       if (nullAndOk(value, optionalValue)) { return undefined; }
       return value;
     },

--- a/packages/jsii-kernel/lib/serialization.ts
+++ b/packages/jsii-kernel/lib/serialization.ts
@@ -169,7 +169,8 @@ export const SERIALIZERS: {[k: string]: Serializer} = {
       // Just whatever. Dates will automatically serialize themselves to strings.
       return value;
     },
-    deserialize(value) {
+    deserialize(value, optionalValue) {
+      if (nullAndOk(value, optionalValue)) { return undefined; }
       return value;
     },
   },

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -890,7 +890,9 @@ class JavaGenerator extends Generator {
         this.code.line(`com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();`);
 
         for (const prop of props) {
+            if (prop.nullable) { this.code.openBlock(`if (this.get${prop.propName}() != null)`); }
             this.code.line(`obj.set(\"${prop.spec.name}\", om.valueToTree(this.get${prop.propName}()));`);
+            if (prop.nullable) { this.code.closeBlock(); }
         }
 
         this.code.line(`return obj;`);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -113,7 +113,9 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
                     obj.set("anumber", om.valueToTree(this.getAnumber()));
                     obj.set("astring", om.valueToTree(this.getAstring()));
-                    obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                    if (this.getFirstOptional() != null) {
+                        obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -114,9 +114,15 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("optional1", om.valueToTree(this.getOptional1()));
-                    obj.set("optional2", om.valueToTree(this.getOptional2()));
-                    obj.set("optional3", om.valueToTree(this.getOptional3()));
+                    if (this.getOptional1() != null) {
+                        obj.set("optional1", om.valueToTree(this.getOptional1()));
+                    }
+                    if (this.getOptional2() != null) {
+                        obj.set("optional2", om.valueToTree(this.getOptional2()));
+                    }
+                    if (this.getOptional3() != null) {
+                        obj.set("optional3", om.valueToTree(this.getOptional3()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -84,8 +84,12 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("initialValue", om.valueToTree(this.getInitialValue()));
-                    obj.set("maximumValue", om.valueToTree(this.getMaximumValue()));
+                    if (this.getInitialValue() != null) {
+                        obj.set("initialValue", om.valueToTree(this.getInitialValue()));
+                    }
+                    if (this.getMaximumValue() != null) {
+                        obj.set("maximumValue", om.valueToTree(this.getMaximumValue()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -237,12 +237,20 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
                     obj.set("anotherRequired", om.valueToTree(this.getAnotherRequired()));
                     obj.set("bool", om.valueToTree(this.getBool()));
                     obj.set("nonPrimitive", om.valueToTree(this.getNonPrimitive()));
-                    obj.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
-                    obj.set("optionalAny", om.valueToTree(this.getOptionalAny()));
-                    obj.set("optionalArray", om.valueToTree(this.getOptionalArray()));
+                    if (this.getAnotherOptional() != null) {
+                        obj.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
+                    }
+                    if (this.getOptionalAny() != null) {
+                        obj.set("optionalAny", om.valueToTree(this.getOptionalAny()));
+                    }
+                    if (this.getOptionalArray() != null) {
+                        obj.set("optionalArray", om.valueToTree(this.getOptionalArray()));
+                    }
                     obj.set("anumber", om.valueToTree(this.getAnumber()));
                     obj.set("astring", om.valueToTree(this.getAstring()));
-                    obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                    if (this.getFirstOptional() != null) {
+                        obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -82,8 +82,12 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("option1", om.valueToTree(this.getOption1()));
-                    obj.set("option2", om.valueToTree(this.getOption2()));
+                    if (this.getOption1() != null) {
+                        obj.set("option1", om.valueToTree(this.getOption1()));
+                    }
+                    if (this.getOption2() != null) {
+                        obj.set("option2", om.valueToTree(this.getOption2()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -64,7 +64,9 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("name", om.valueToTree(this.getName()));
+                    if (this.getName() != null) {
+                        obj.set("name", om.valueToTree(this.getName()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -195,11 +195,21 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("containerPort", om.valueToTree(this.getContainerPort()));
-                    obj.set("cpu", om.valueToTree(this.getCpu()));
-                    obj.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
-                    obj.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
-                    obj.set("publicTasks", om.valueToTree(this.getPublicTasks()));
+                    if (this.getContainerPort() != null) {
+                        obj.set("containerPort", om.valueToTree(this.getContainerPort()));
+                    }
+                    if (this.getCpu() != null) {
+                        obj.set("cpu", om.valueToTree(this.getCpu()));
+                    }
+                    if (this.getMemoryMiB() != null) {
+                        obj.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
+                    }
+                    if (this.getPublicLoadBalancer() != null) {
+                        obj.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
+                    }
+                    if (this.getPublicTasks() != null) {
+                        obj.set("publicTasks", om.valueToTree(this.getPublicTasks()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -81,7 +81,9 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
                     obj.set("arrayWithThreeElementsAndUndefinedAsSecondArgument", om.valueToTree(this.getArrayWithThreeElementsAndUndefinedAsSecondArgument()));
-                    obj.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
+                    if (this.getThisShouldBeUndefined() != null) {
+                        obj.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -58,7 +58,9 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
                 public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("field", om.valueToTree(this.getField()));
+                    if (this.getField() != null) {
+                        obj.set("field", om.valueToTree(this.getField()));
+                    }
                     return obj;
                 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -111,7 +111,9 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
                     com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
                     com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
                     obj.set("bar", om.valueToTree(this.getBar()));
-                    obj.set("foo", om.valueToTree(this.getFoo()));
+                    if (this.getFoo() != null) {
+                        obj.set("foo", om.valueToTree(this.getFoo()));
+                    }
                     return obj;
                 }
 


### PR DESCRIPTION
The JSON types were serialized "as-is" without touch, meaning if the
value was `null`, it would be forwarded as `null`, instead of `undefined`.
This caused some CDK usage patterns to crash at runtime. This changes
the behavior so that top-level `null`s in JSON types turn into `undefined`,
while `null`s nested in the JSON value will be preserved (they are valid
JSON after all!).

Additionally, tuned the Java code generator a little:
The serialization of structs creates a jackson ObjectNode to pass down
to the serialization layer, however those are turned to JSON without
processing and are not honoring the inclusion setting to ignore nulls.
Added some code in the Java generator to stop adding null values into
the ObjectNode.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
