### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,3 @@
 *                               @awslabs/aws-cdk-team
 /docs/                          @awslabs/aws-cdk-team @Doug-AWS
 /packages/*-dotnet-*/           @awslabs/aws-cdk-team @costleya
-/packages/*-python-*/           @awslabs/aws-cdk-team @dstufft


### PR DESCRIPTION
I'm not directly following day to day development anymore, so being CC'd on every change is very noisy. It's possible this should be @garnaat instead? In either case, it shouldn't be me (though I am of course available to be manually pulled in when needed).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
