### PR TITLE
fix(jsii): Correctly handle singleton enums

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1692,3 +1692,37 @@ export class WithPrivatePropertyInConstructor {
         return this.privateField === 'Success!';
     }
 }
+
+/**
+ * Verifies that singleton enums are handled correctly
+ *
+ * https://github.com/awslabs/jsii/issues/231
+ */
+export class SingletonString {
+    private constructor() { }
+
+    public isSingletonString(value: string): boolean {
+        return value === SingletonStringEnum.SingletonString;
+    }
+}
+/** A singleton string */
+export enum SingletonStringEnum {
+    /** 1337 */
+    SingletonString = '3L1T3!'
+}
+/**
+ * Verifies that singleton enums are handled correctly
+ *
+ * https://github.com/awslabs/jsii/issues/231
+ */
+export class SingletonInt {
+    private constructor() { }
+    public isSingletonInt(value: number): boolean {
+        return value === SingletonIntEnum.SingletonInt;
+    }
+}
+/** A singleton integer. */
+export enum SingletonIntEnum {
+    /** Elite! */
+    SingletonInt = 1337
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -7121,6 +7121,132 @@
       ],
       "name": "SingleInstanceTwoTypes"
     },
+    "jsii-calc.SingletonInt": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "https://github.com/awslabs/jsii/issues/231",
+        "stability": "experimental",
+        "summary": "Verifies that singleton enums are handled correctly."
+      },
+      "fqn": "jsii-calc.SingletonInt",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1718
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1720
+          },
+          "name": "isSingletonInt",
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "primitive": "number"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          }
+        }
+      ],
+      "name": "SingletonInt"
+    },
+    "jsii-calc.SingletonIntEnum": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "A singleton integer."
+      },
+      "fqn": "jsii-calc.SingletonIntEnum",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1725
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Elite!"
+          },
+          "name": "SingletonInt"
+        }
+      ],
+      "name": "SingletonIntEnum"
+    },
+    "jsii-calc.SingletonString": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "https://github.com/awslabs/jsii/issues/231",
+        "stability": "experimental",
+        "summary": "Verifies that singleton enums are handled correctly."
+      },
+      "fqn": "jsii-calc.SingletonString",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1701
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1704
+          },
+          "name": "isSingletonString",
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          }
+        }
+      ],
+      "name": "SingletonString"
+    },
+    "jsii-calc.SingletonStringEnum": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "A singleton string."
+      },
+      "fqn": "jsii-calc.SingletonStringEnum",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1709
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "1337."
+          },
+          "name": "SingletonString"
+        }
+      ],
+      "name": "SingletonStringEnum"
+    },
     "jsii-calc.StableClass": {
       "assembly": "jsii-calc",
       "docs": {
@@ -8648,5 +8774,5 @@
     }
   },
   "version": "0.11.2",
-  "fingerprint": "eQpFH3EHC2GlCSnThymTxnuO9HyZBFvsvddZqu1Fy+8="
+  "fingerprint": "5TwMNffhxUueZQEAGZG6+JIfS6jcTwCJWc9vixH5aLc="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -7121,6 +7121,132 @@
       ],
       "name": "SingleInstanceTwoTypes"
     },
+    "jsii-calc.SingletonInt": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "https://github.com/awslabs/jsii/issues/231",
+        "stability": "experimental",
+        "summary": "Verifies that singleton enums are handled correctly."
+      },
+      "fqn": "jsii-calc.SingletonInt",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1718
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1720
+          },
+          "name": "isSingletonInt",
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "primitive": "number"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          }
+        }
+      ],
+      "name": "SingletonInt"
+    },
+    "jsii-calc.SingletonIntEnum": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "A singleton integer."
+      },
+      "fqn": "jsii-calc.SingletonIntEnum",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1725
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Elite!"
+          },
+          "name": "SingletonInt"
+        }
+      ],
+      "name": "SingletonIntEnum"
+    },
+    "jsii-calc.SingletonString": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "https://github.com/awslabs/jsii/issues/231",
+        "stability": "experimental",
+        "summary": "Verifies that singleton enums are handled correctly."
+      },
+      "fqn": "jsii-calc.SingletonString",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1701
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1704
+          },
+          "name": "isSingletonString",
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          }
+        }
+      ],
+      "name": "SingletonString"
+    },
+    "jsii-calc.SingletonStringEnum": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "A singleton string."
+      },
+      "fqn": "jsii-calc.SingletonStringEnum",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1709
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "1337."
+          },
+          "name": "SingletonString"
+        }
+      ],
+      "name": "SingletonStringEnum"
+    },
     "jsii-calc.StableClass": {
       "assembly": "jsii-calc",
       "docs": {
@@ -8648,5 +8774,5 @@
     }
   },
   "version": "0.11.2",
-  "fingerprint": "eQpFH3EHC2GlCSnThymTxnuO9HyZBFvsvddZqu1Fy+8="
+  "fingerprint": "5TwMNffhxUueZQEAGZG6+JIfS6jcTwCJWc9vixH5aLc="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonInt.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonInt.cs
@@ -1,0 +1,28 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Verifies that singleton enums are handled correctly.</summary>
+    /// <remarks>
+    /// https://github.com/awslabs/jsii/issues/231
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(SingletonInt), fullyQualifiedName: "jsii-calc.SingletonInt")]
+    public class SingletonInt : DeputyBase
+    {
+        protected SingletonInt(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected SingletonInt(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>stability: Experimental</remarks>
+        [JsiiMethod(name: "isSingletonInt", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
+        public virtual bool IsSingletonInt(double value)
+        {
+            return InvokeInstanceMethod<bool>(new object[]{value});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonIntEnum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonIntEnum.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>A singleton integer.</summary>
+    /// <remarks>stability: Experimental</remarks>
+    [JsiiEnum(nativeType: typeof(SingletonIntEnum), fullyQualifiedName: "jsii-calc.SingletonIntEnum")]
+    public enum SingletonIntEnum
+    {
+        /// <summary>Elite!</summary>
+        /// <remarks>stability: Experimental</remarks>
+        [JsiiEnumMember(name: "SingletonInt")]
+        SingletonInt
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonString.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonString.cs
@@ -1,0 +1,28 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Verifies that singleton enums are handled correctly.</summary>
+    /// <remarks>
+    /// https://github.com/awslabs/jsii/issues/231
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(SingletonString), fullyQualifiedName: "jsii-calc.SingletonString")]
+    public class SingletonString : DeputyBase
+    {
+        protected SingletonString(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected SingletonString(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>stability: Experimental</remarks>
+        [JsiiMethod(name: "isSingletonString", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"string\"}}]")]
+        public virtual bool IsSingletonString(string value)
+        {
+            return InvokeInstanceMethod<bool>(new object[]{value});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonStringEnum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingletonStringEnum.cs
@@ -1,0 +1,15 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>A singleton string.</summary>
+    /// <remarks>stability: Experimental</remarks>
+    [JsiiEnum(nativeType: typeof(SingletonStringEnum), fullyQualifiedName: "jsii-calc.SingletonStringEnum")]
+    public enum SingletonStringEnum
+    {
+        /// <summary>1337.</summary>
+        /// <remarks>stability: Experimental</remarks>
+        [JsiiEnumMember(name: "SingletonString")]
+        SingletonString
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -126,6 +126,10 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.ReturnsPrivateImplementationOfInterface": return software.amazon.jsii.tests.calculator.ReturnsPrivateImplementationOfInterface.class;
             case "jsii-calc.RuntimeTypeChecking": return software.amazon.jsii.tests.calculator.RuntimeTypeChecking.class;
             case "jsii-calc.SingleInstanceTwoTypes": return software.amazon.jsii.tests.calculator.SingleInstanceTwoTypes.class;
+            case "jsii-calc.SingletonInt": return software.amazon.jsii.tests.calculator.SingletonInt.class;
+            case "jsii-calc.SingletonIntEnum": return software.amazon.jsii.tests.calculator.SingletonIntEnum.class;
+            case "jsii-calc.SingletonString": return software.amazon.jsii.tests.calculator.SingletonString.class;
+            case "jsii-calc.SingletonStringEnum": return software.amazon.jsii.tests.calculator.SingletonStringEnum.class;
             case "jsii-calc.StableClass": return software.amazon.jsii.tests.calculator.StableClass.class;
             case "jsii-calc.StableEnum": return software.amazon.jsii.tests.calculator.StableEnum.class;
             case "jsii-calc.StableStruct": return software.amazon.jsii.tests.calculator.StableStruct.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
@@ -1,0 +1,25 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Verifies that singleton enums are handled correctly.
+ * 
+ * https://github.com/awslabs/jsii/issues/231
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonInt")
+public class SingletonInt extends software.amazon.jsii.JsiiObject {
+    protected SingletonInt(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public java.lang.Boolean isSingletonInt(final java.lang.Number value) {
+        return this.jsiiCall("isSingletonInt", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonIntEnum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonIntEnum.java
@@ -1,0 +1,19 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * A singleton integer.
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonIntEnum")
+public enum SingletonIntEnum {
+    /**
+     * Elite!
+     * 
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    SingletonInt,
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
@@ -1,0 +1,25 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Verifies that singleton enums are handled correctly.
+ * 
+ * https://github.com/awslabs/jsii/issues/231
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonString")
+public class SingletonString extends software.amazon.jsii.JsiiObject {
+    protected SingletonString(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
+        super(mode);
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public java.lang.Boolean isSingletonString(final java.lang.String value) {
+        return this.jsiiCall("isSingletonString", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonStringEnum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonStringEnum.java
@@ -1,0 +1,19 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * A singleton string.
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonStringEnum")
+public enum SingletonStringEnum {
+    /**
+     * 1337.
+     * 
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    SingletonString,
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -4718,6 +4718,74 @@ class SingleInstanceTwoTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Singl
         return jsii.invoke(self, "interface2", [])
 
 
+class SingletonInt(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SingletonInt"):
+    """Verifies that singleton enums are handled correctly.
+
+    https://github.com/awslabs/jsii/issues/231
+
+    Stability:
+        experimental
+    """
+    @jsii.member(jsii_name="isSingletonInt")
+    def is_singleton_int(self, value: jsii.Number) -> bool:
+        """
+        Arguments:
+            value: -
+
+        Stability:
+            experimental
+        """
+        return jsii.invoke(self, "isSingletonInt", [value])
+
+
+@jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
+class SingletonIntEnum(enum.Enum):
+    """A singleton integer.
+
+    Stability:
+        experimental
+    """
+    SingletonInt = "SingletonInt"
+    """Elite!
+
+    Stability:
+        experimental
+    """
+
+class SingletonString(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SingletonString"):
+    """Verifies that singleton enums are handled correctly.
+
+    https://github.com/awslabs/jsii/issues/231
+
+    Stability:
+        experimental
+    """
+    @jsii.member(jsii_name="isSingletonString")
+    def is_singleton_string(self, value: str) -> bool:
+        """
+        Arguments:
+            value: -
+
+        Stability:
+            experimental
+        """
+        return jsii.invoke(self, "isSingletonString", [value])
+
+
+@jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
+class SingletonStringEnum(enum.Enum):
+    """A singleton string.
+
+    Stability:
+        experimental
+    """
+    SingletonString = "SingletonString"
+    """1337.
+
+    Stability:
+        experimental
+    """
+
 class StableClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StableClass"):
     """
     Stability:
@@ -5913,6 +5981,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "Sum", "SyncVirtualMethods", "Thrower", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -5831,6 +5831,168 @@ SingleInstanceTwoTypes
       :rtype: :py:class:`~jsii-calc.IPublicInterface`\ 
 
 
+SingletonInt
+^^^^^^^^^^^^
+
+.. py:class:: SingletonInt
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.SingletonInt;
+
+      .. code-tab:: javascript
+
+         const { SingletonInt } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { SingletonInt } from 'jsii-calc';
+
+
+
+   Verifies that singleton enums are handled correctly.
+
+   
+
+   https://github.com/awslabs/jsii/issues/231
+
+
+
+
+   .. py:method:: isSingletonInt(value) -> boolean
+
+      :param value: 
+      :type value: number
+      :rtype: boolean
+
+
+SingletonIntEnum (enum)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: SingletonIntEnum
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.SingletonIntEnum;
+
+      .. code-tab:: javascript
+
+         const { SingletonIntEnum } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { SingletonIntEnum } from 'jsii-calc';
+
+
+
+   A singleton integer.
+
+
+
+   .. py:data:: SingletonInt
+
+   Elite!
+
+
+
+
+SingletonString
+^^^^^^^^^^^^^^^
+
+.. py:class:: SingletonString
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.SingletonString;
+
+      .. code-tab:: javascript
+
+         const { SingletonString } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { SingletonString } from 'jsii-calc';
+
+
+
+   Verifies that singleton enums are handled correctly.
+
+   
+
+   https://github.com/awslabs/jsii/issues/231
+
+
+
+
+   .. py:method:: isSingletonString(value) -> boolean
+
+      :param value: 
+      :type value: string
+      :rtype: boolean
+
+
+SingletonStringEnum (enum)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: SingletonStringEnum
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.SingletonStringEnum;
+
+      .. code-tab:: javascript
+
+         const { SingletonStringEnum } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { SingletonStringEnum } from 'jsii-calc';
+
+
+
+   A singleton string.
+
+
+
+   .. py:data:: SingletonString
+
+   1337.
+
+
+
+
 StableClass
 ^^^^^^^^^^^
 

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -68,6 +68,8 @@ ReferenceEnumFromScopedPackage
 ReturnsPrivateImplementationOfInterface
 RuntimeTypeChecking
 SingleInstanceTwoTypes
+SingletonInt
+SingletonString
 StableClass
 StaticContext
 Statics

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -988,6 +988,20 @@ assemblies
  │   │   │ └── returns: jsii-calc.InbetweenClass
  │   │   └─┬ interface2() method
  │   │     └── returns: jsii-calc.IPublicInterface
+ │   ├─┬ class SingletonInt
+ │   │ └─┬ members
+ │   │   └─┬ isSingletonInt(value) method
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ value
+ │   │     │   └── type: number
+ │   │     └── returns: boolean
+ │   ├─┬ class SingletonString
+ │   │ └─┬ members
+ │   │   └─┬ isSingletonString(value) method
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ value
+ │   │     │   └── type: string
+ │   │     └── returns: boolean
  │   ├─┬ class StableClass
  │   │ └─┬ members
  │   │   ├─┬ <initializer>(readonlyString,mutableNumber) initializer
@@ -1588,6 +1602,10 @@ assemblies
  │   ├─┬ enum ExperimentalEnum
  │   │ ├── OptionA
  │   │ └── OptionB
+ │   ├─┬ enum SingletonIntEnum
+ │   │ └── SingletonInt
+ │   ├─┬ enum SingletonStringEnum
+ │   │ └── SingletonString
  │   ├─┬ enum StableEnum
  │   │ ├── OptionA
  │   │ └── OptionB

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -90,6 +90,8 @@ assemblies
  │   ├── class ReturnsPrivateImplementationOfInterface
  │   ├── class RuntimeTypeChecking
  │   ├── class SingleInstanceTwoTypes
+ │   ├── class SingletonInt
+ │   ├── class SingletonString
  │   ├── class StableClass
  │   ├── class StaticContext
  │   ├── class Statics
@@ -170,6 +172,8 @@ assemblies
  │   ├── enum AllTypesEnum
  │   ├── enum DeprecatedEnum
  │   ├── enum ExperimentalEnum
+ │   ├── enum SingletonIntEnum
+ │   ├── enum SingletonStringEnum
  │   ├── enum StableEnum
  │   ├── enum StringEnum
  │   └── enum CompositionStringStyle

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -451,6 +451,12 @@ assemblies
  │   │   ├── <initializer>() initializer
  │   │   ├── interface1() method
  │   │   └── interface2() method
+ │   ├─┬ class SingletonInt
+ │   │ └─┬ members
+ │   │   └── isSingletonInt(value) method
+ │   ├─┬ class SingletonString
+ │   │ └─┬ members
+ │   │   └── isSingletonString(value) method
  │   ├─┬ class StableClass
  │   │ └─┬ members
  │   │   ├── <initializer>(readonlyString,mutableNumber) initializer
@@ -710,6 +716,10 @@ assemblies
  │   ├─┬ enum ExperimentalEnum
  │   │ ├── OptionA
  │   │ └── OptionB
+ │   ├─┬ enum SingletonIntEnum
+ │   │ └── SingletonInt
+ │   ├─┬ enum SingletonStringEnum
+ │   │ └── SingletonString
  │   ├─┬ enum StableEnum
  │   │ ├── OptionA
  │   │ └── OptionB

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -67,6 +67,8 @@ assemblies
  │   ├── class ReturnsPrivateImplementationOfInterface
  │   ├── class RuntimeTypeChecking
  │   ├── class SingleInstanceTwoTypes
+ │   ├── class SingletonInt
+ │   ├── class SingletonString
  │   ├── class StableClass
  │   ├── class StaticContext
  │   ├── class Statics
@@ -127,6 +129,8 @@ assemblies
  │   ├── enum AllTypesEnum
  │   ├── enum DeprecatedEnum
  │   ├── enum ExperimentalEnum
+ │   ├── enum SingletonIntEnum
+ │   ├── enum SingletonStringEnum
  │   ├── enum StableEnum
  │   ├── enum StringEnum
  │   └── enum CompositionStringStyle


### PR DESCRIPTION
When an enum has only one option, TypeScript handles it in a special way
and tries very hard to hide the enum declaration in favor of the sole
member. This caused incorrect type names and kinds to be emitted in the
JSII assembly, resulting in incorrect behavior.

This uses a non-public part of the TSC API (possibly an omission from
the hand-written type model), so it includes an additional guard check
to fail explicitly in case the API's behavior happens to change in a
breaking way.

Fixes #231

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
