### PR TITLE
feat(reflect): Expose Assembly metadata field

### DIFF
--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -37,6 +37,13 @@ export class Assembly {
   }
 
   /**
+   * The metadata associated with the assembly, if any.
+   */
+  public get metadata(): { readonly [key: string]: any } | undefined {
+    return this.spec.metadata;
+  }
+
+  /**
    * The url to the project homepage. Maps to "homepage" from package.json.
    */
   public get homepage(): string {


### PR DESCRIPTION
This enables tools that use `jsii-reflect` to consume and reason over
the values in the metadata field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
