### PR TITLE
feat(jsii-diff): extend reporting options

### DIFF
--- a/packages/jsii-diff/lib/diagnostics.ts
+++ b/packages/jsii-diff/lib/diagnostics.ts
@@ -1,0 +1,48 @@
+import { Stability } from "jsii-spec";
+import { ApiMismatch, Mismatches } from "./types";
+
+export enum DiagLevel {
+  Error = 0,
+  Warning = 1,
+  Skipped = 2,
+}
+
+const LEVEL_PREFIX = {
+  [DiagLevel.Error]: 'err ',
+  [DiagLevel.Warning]: 'warn',
+  [DiagLevel.Skipped]: 'skip',
+};
+
+export interface Diagnostic {
+  level: DiagLevel;
+  message: string;
+  suppressionKey: string;
+}
+
+export function formatDiagnostic(diag: Diagnostic, includeSuppressionKey = false) {
+  return [
+    LEVEL_PREFIX[diag.level],
+    '-',
+    diag.message,
+    ...(includeSuppressionKey ? [`[${diag.suppressionKey}]`] : []),
+  ].join(' ');
+}
+
+export function hasErrors(diags: Diagnostic[]) {
+  return diags.some(diag => diag.level === DiagLevel.Error);
+}
+
+/**
+ * Classify API mismatches into a set of warnings and errors
+ */
+export function classifyDiagnostics(mismatches: Mismatches, experimentalErrors: boolean, skipFilter: Set<string>): Diagnostic[] {
+  const ret = mismatches.mismatches.map(mis => ({ level: level(mis), message: mis.message, suppressionKey: mis.violationKey }));
+  ret.sort((a, b) => a.level - b.level);
+  return ret;
+
+  function level(mis: ApiMismatch) {
+    if (skipFilter.has(mis.violationKey)) { return DiagLevel.Skipped; }
+    if (mis.stability === Stability.Stable || (mis.stability === Stability.Experimental && experimentalErrors)) { return DiagLevel.Error; }
+    return DiagLevel.Warning;
+  }
+}

--- a/packages/jsii-diff/lib/enums.ts
+++ b/packages/jsii-diff/lib/enums.ts
@@ -1,11 +1,15 @@
 import reflect = require('jsii-reflect');
-import { ComparisonContext, shouldInspect } from './types';
+import { ComparisonContext } from './types';
 
 export function compareEnum(original: reflect.EnumType, updated: reflect.EnumType, context: ComparisonContext) {
-  for (const origMember of original.members.filter(shouldInspect(context))) {
+  for (const origMember of original.members) {
     const updatedMember = updated.members.find(m => m.name === origMember.name);
     if (!updatedMember) {
-      context.mismatches.report(original, `member ${origMember.name} has been removed`);
+      context.mismatches.report({
+        ruleKey: 'removed',
+        violator: origMember,
+        message: `member ${origMember.name} has been removed`
+      });
       continue;
     }
   }

--- a/packages/jsii-diff/lib/index.ts
+++ b/packages/jsii-diff/lib/index.ts
@@ -1,8 +1,9 @@
 import reflect = require('jsii-reflect');
+import { Stability } from 'jsii-spec';
 import log4js = require('log4js');
 import { compareReferenceType, compareStruct } from './classes-ifaces';
 import { compareEnum } from './enums';
-import { ComparisonContext, ComparisonOptions, describeType, Mismatches, shouldInspect } from './types';
+import { ComparisonContext, ComparisonOptions, describeType, Mismatches } from './types';
 
 const LOG = log4js.getLogger('jsii-diff');
 
@@ -15,7 +16,9 @@ const LOG = log4js.getLogger('jsii-diff');
  * bigger) in the new API.
  */
 export function compareAssemblies(original: reflect.Assembly, updated: reflect.Assembly, options: ComparisonOptions = {}): Mismatches {
-  const mismatches = new Mismatches();
+  const mismatches = new Mismatches({
+    defaultStability: options.defaultExperimental ? Stability.Experimental : Stability.Stable
+  });
 
   const context = { ...options, mismatches };
 
@@ -35,7 +38,11 @@ export function compareClasses(original: reflect.Assembly, updated: reflect.Asse
 export function compareInterfaces(original: reflect.Assembly, updated: reflect.Assembly, context: ComparisonContext) {
   for (const [origIface, updatedIface] of typePairs(original.interfaces, updated, context)) {
     if (origIface.datatype !== updatedIface.datatype) {
-      context.mismatches.report(origIface, `used to be a ${interfaceType(origIface.datatype)}, is now a ${interfaceType(updatedIface.datatype)}.`);
+      context.mismatches.report({
+        ruleKey: 'iface-type',
+        violator: origIface,
+        message: `used to be a ${interfaceType(origIface.datatype)}, is now a ${interfaceType(updatedIface.datatype)}.`,
+      });
       continue;
     }
     if (origIface.datatype) {
@@ -53,17 +60,25 @@ export function compareEnums(original: reflect.Assembly, updated: reflect.Assemb
 }
 
 function* typePairs<T extends reflect.Type>(xs: T[], updatedAssembly: reflect.Assembly, context: ComparisonContext): IterableIterator<[T, T]> {
-  for (const origType of xs.filter(shouldInspect(context))) {
+  for (const origType of xs) {
     LOG.trace(origType.fqn);
 
     const updatedType = updatedAssembly.tryFindType(origType.fqn);
     if (!updatedType) {
-      context.mismatches.report(origType, 'has been removed');
+      context.mismatches.report({
+        ruleKey: 'removed',
+        violator: origType,
+        message: 'has been removed'
+      });
       continue;
     }
 
     if (describeType(origType) !== describeType(updatedType)) {
-      context.mismatches.report(origType, `has been turned into a ${describeType(updatedType)}`);
+      context.mismatches.report({
+        ruleKey: 'struct-change',
+        violator: origType,
+        message: `has been turned into a ${describeType(updatedType)}`
+      });
       continue;
     }
 

--- a/packages/jsii-diff/lib/types.ts
+++ b/packages/jsii-diff/lib/types.ts
@@ -1,5 +1,5 @@
 import reflect = require('jsii-reflect');
-import spec = require('jsii-spec');
+import { Stability } from 'jsii-spec';
 
 export interface ComparisonOptions {
   /**
@@ -19,25 +19,93 @@ export interface ComparisonContext extends ComparisonOptions {
 
 export interface ApiMismatch {
   message: string;
-  type: reflect.Type;
+  violationKey: string;
+  stability: Stability;
+}
+
+export type ApiElement = reflect.Type | reflect.TypeMember | reflect.EnumMember;
+
+export interface ReportOptions {
+  ruleKey: string;
+  violator: ApiElement;
+  message: string;
 }
 
 export class Mismatches {
-  public mismatches = new Array<ApiMismatch>();
+  public readonly mismatches = new Array<ApiMismatch>();
+  private readonly defaultStability: Stability;
 
-  public report(type: reflect.Type, message: string) {
-    this.mismatches.push({ message, type });
+  constructor(opts: { defaultStability: Stability }) {
+    this.defaultStability = opts.defaultStability;
+  }
+
+  public report(options: ReportOptions) {
+    const fqn = identifier(options.violator);
+    const key = `${options.ruleKey}:${fqn}`;
+
+    this.mismatches.push({
+      violationKey: key,
+      message: `${describeApiElement(options.violator)} ${fqn}: ${options.message}`,
+      stability: options.violator.docs.stability || this.defaultStability
+    });
   }
 
   public* messages() {
     for (const mis of this.mismatches) {
-      yield `${describeType(mis.type)} ${mis.type.fqn} ${mis.message}`;
+      yield mis.message;
     }
   }
 
   public get count() {
     return this.mismatches.length;
   }
+
+  public filter(pred: (x: ApiMismatch) => boolean): Mismatches {
+    const ret = new Mismatches({ defaultStability: this.defaultStability });
+    ret.mismatches.push(...this.mismatches.filter(pred));
+    return ret;
+  }
+}
+
+function identifier(apiElement: ApiElement) {
+  return dispatch(apiElement, {
+    method(x) { return `${x.parentType.fqn}.${x.name}`; },
+    init(x) { return `${x.parentType.fqn}.${x.name}`; },
+    property(x) { return `${x.parentType.fqn}.${x.name}`; },
+    enumMember(x) { return `${x.enumType.fqn}.${x.name}`; },
+    klass(x) { return `${x.fqn}`; },
+    iface(x) { return `${x.fqn}`; },
+  });
+}
+
+function describeApiElement(apiElement: ApiElement) {
+  return dispatch(apiElement, {
+    method() { return 'METHOD'; },
+    init() { return 'INITIALIZER'; },
+    property() { return 'PROP'; },
+    enumMember() { return 'ENUM'; },
+    klass() { return 'CLASS'; },
+    iface() { return 'IFACE'; },
+  });
+}
+
+function dispatch<T>(apiElement: ApiElement, fns: {
+    method(m: reflect.Method): T,
+    init(m: reflect.Initializer): T,
+    property(m: reflect.Property): T,
+    enumMember(m: reflect.EnumMember): T,
+    klass(m: reflect.ClassType): T,
+    iface(m: reflect.InterfaceType): T,
+  }) {
+
+  if (apiElement instanceof reflect.Method) { return fns.method(apiElement); }
+  if (apiElement instanceof reflect.Property) { return fns.property(apiElement); }
+  if (apiElement instanceof reflect.EnumMember) { return fns.enumMember(apiElement); }
+  if (apiElement instanceof reflect.ClassType) { return fns.klass(apiElement); }
+  if (apiElement instanceof reflect.InterfaceType) { return fns.iface(apiElement); }
+  if (apiElement instanceof reflect.Initializer) { return fns.init(apiElement); }
+
+  throw new Error(`Unrecognized violator: ${apiElement}`);
 }
 
 export function describeType(type: reflect.Type) {
@@ -45,8 +113,4 @@ export function describeType(type: reflect.Type) {
   if (type.isInterfaceType()) { return 'IFACE'; }
   if (type.isEnumType()) { return 'ENUM'; }
   return 'TYPE';
-}
-
-export function shouldInspect(context: ComparisonContext): (x: reflect.Documentable) => boolean {
-  return x => x.docs.stability === spec.Stability.Stable || (x.docs.stability === undefined && !context.defaultExperimental);
 }

--- a/packages/jsii-diff/test/test.classes.ts
+++ b/packages/jsii-diff/test/test.classes.ts
@@ -101,7 +101,7 @@ export = {
 
   async 'not allowed to change argument type to a different scalar'(test: Test) {
     await expectError(test,
-      /method foo argument arg1, takes number \(formerly string\): string is not assignable to number/,
+      /method.*foo.*argument arg1, takes number \(formerly string\): string is not assignable to number/i,
       `
       export class Foo {
         public foo(arg1: string): void {
@@ -191,7 +191,7 @@ export = {
 
   async 'cannot make a class property optional'(test: Test) {
     await expectError(test,
-      /property henk, type Optional<string> \(formerly string\): output type is now optional/,
+      /prop.*henk.*type Optional<string> \(formerly string\): output type is now optional/i,
       `
       export class Henk {
         public henk: string = 'henk';
@@ -333,7 +333,7 @@ export = {
 
   async 'change from method to property'(test: Test) {
     await expectError(test,
-      /CLASS testpkg.Boom member foo changed from method to property/,
+      /changed from method to property/,
       `
       export class Boom {
         foo() { return 12; }
@@ -351,7 +351,7 @@ export = {
 
   async 'change from method with arguments to property'(test: Test) {
     await expectError(test,
-      /CLASS testpkg.Boom member foo changed from method to property/,
+      /changed from method to property/,
       `
       export class Boom {
         foo(arg: number) { return 12 * arg; }
@@ -369,7 +369,7 @@ export = {
 
   async 'change from property to method'(test: Test) {
     await expectError(test,
-      /CLASS testpkg.Boom member foo changed from property to method/,
+      /changed from property to method/,
       `
       export class Boom {
         get foo() { return 12; }

--- a/packages/jsii-diff/test/test.diagnostics.ts
+++ b/packages/jsii-diff/test/test.diagnostics.ts
@@ -1,0 +1,59 @@
+import { Test } from 'nodeunit';
+import { classifyDiagnostics, hasErrors } from '../lib/diagnostics';
+import { compare } from './util';
+
+export = {
+  // ----------------------------------------------------------------------
+  async 'experimental elements lead to warnings'(test: Test) {
+    const mms = await compare(`
+      /** @experimental */
+      export class Foo1 { }
+    `, `
+      export class Foo2 { }
+    `);
+
+    const experimentalErrors = false;
+    const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+
+    test.equals(1, diags.length);
+    test.equals(false, hasErrors(diags));
+
+    test.done();
+  },
+
+  // ----------------------------------------------------------------------
+  async 'warnings can be turned into errors'(test: Test) {
+    const mms = await compare(`
+      /** @experimental */
+      export class Foo1 { }
+    `, `
+      export class Foo2 { }
+    `);
+
+    const experimentalErrors = true;
+    const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+
+    test.equals(1, diags.length);
+    test.equals(true, hasErrors(diags));
+
+    test.done();
+  },
+
+  // ----------------------------------------------------------------------
+  async 'errors can be skipped'(test: Test) {
+    const mms = await compare(`
+      export class Foo1 { }
+    `, `
+      export class Foo2 { }
+    `);
+
+    const experimentalErrors = true;
+    const diags = classifyDiagnostics(mms, experimentalErrors, new Set([mms.mismatches[0].violationKey]));
+
+    test.equals(1, diags.length);
+    test.equals(false, hasErrors(diags));
+
+    test.done();
+  },
+
+};

--- a/packages/jsii-diff/test/test.structs.ts
+++ b/packages/jsii-diff/test/test.structs.ts
@@ -94,7 +94,7 @@ export = {
   async 'cannot take fields away from input struct'(test: Test) {
     // Legal in TypeScript, but illegal in Java/C#
     await expectError(test,
-      /member piet has been removed/,
+      /has been removed/,
       `
       export interface Henk {
         readonly henk: string;

--- a/packages/jsii-diff/test/util.ts
+++ b/packages/jsii-diff/test/util.ts
@@ -21,7 +21,7 @@ export async function expectError(test: Test, error: RegExp, original: string, u
     test.ok(msgs.some(m => error.test(m)), `Expected error like ${error}, got ${msgs}`);
 }
 
-async function compare(original: string, updated: string): Promise<Mismatches> {
+export async function compare(original: string, updated: string): Promise<Mismatches> {
   const ass1 = await sourceToAssemblyHelper(original);
   const ts1 = new reflect.TypeSystem();
   const originalAssembly = ts1.addAssembly(new reflect.Assembly(ts1, ass1));


### PR DESCRIPTION
jsii-diff now prints all changes, can report changes over experimental
packages as errors, and has the ability to load a set of ignore rules
from a file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
