### PR TITLE
fix(kernel): properly deserialize structs passed in byref

### DIFF
--- a/packages/jsii-kernel/lib/serialization.ts
+++ b/packages/jsii-kernel/lib/serialization.ts
@@ -298,10 +298,9 @@ export const SERIALIZERS: {[k: string]: Serializer} = {
 
       // Similarly to other end, we might be getting a reference type where we're
       // expecting a value type. Accept this for now.
-      const prevRef = objectReference(value);
-      if (prevRef) {
+      if (isObjRef(value)) {
         host.debug('Expected value type but got reference type, accepting for now (awslabs/jsii#400)');
-        return prevRef;
+        return host.objects.findObject(value).instance;
       }
 
       const namedType = host.lookupType((optionalValue.type as spec.NamedTypeReference).fqn);

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -1158,6 +1158,14 @@ defineTest('erased base: can receive an instance of private type', async (test, 
     test.deepEqual(objref.result, { [api.TOKEN_REF]: 'jsii-calc.JSII417PublicBaseOfBase@10000' });
 });
 
+defineTest('deserialize a struct by reference', async (test, sandbox) => {
+    sandbox.callbackHandler = makeSyncCallbackHandler(() => 'xoxoxox');
+    const objref = sandbox.create({ fqn: 'Object', overrides: [ { property: 'field' } ] });
+    const consumer = sandbox.create({ fqn: 'jsii-calc.OptionalStructConsumer', args: [ objref ] });
+    const value = sandbox.get({ objref: consumer, property: 'fieldValue' });
+    test.deepEqual(value, { value: 'xoxoxox' });
+});
+
 // =================================================================================================
 
 const testNames: { [name: string]: boolean } = { };


### PR DESCRIPTION
The deserializer mistakingly used `objectReference` instead of `isObjRef` when trying to identify this case.

Test was added to verify this fix.

Fixes #553

Co-authored-by: Romain Muller <rmuller@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
