### PR TITLE
fix(jsii-diff): handle recursive types

### DIFF
--- a/packages/jsii-diff/test/test.structs.ts
+++ b/packages/jsii-diff/test/test.structs.ts
@@ -249,4 +249,76 @@ export = {
 
     test.done();
   },
+
+  // ----------------------------------------------------------------------
+
+  async 'can handle recursive type references'(test: Test) {
+    await expectNoError(test,
+      `
+      export interface LinkedList {
+        readonly name: string;
+        readonly next?: LinkedList;
+      }
+
+      export class UseIt {
+        public main(list: LinkedList) {
+          Array.isArray(list);
+        }
+      }
+    `, `
+      export interface LinkedList {
+        readonly name: string;
+        readonly next?: LinkedList;
+      }
+
+      export class UseIt {
+        public main(list: LinkedList) {
+          Array.isArray(list);
+        }
+      }
+    `);
+
+    test.done();
+  },
+
+  // ----------------------------------------------------------------------
+
+  async 'can handle mutually recursive type references'(test: Test) {
+    await expectNoError(test,
+      `
+      export interface A {
+        readonly name: string;
+        readonly next?: B;
+      }
+
+      export interface B {
+        readonly name: string;
+        readonly next?: A;
+      }
+
+      export class UseIt {
+        public main(list: A) {
+          Array.isArray(list);
+        }
+      }
+    `, `
+      export interface A {
+        readonly name: string;
+        readonly next?: B;
+      }
+
+      export interface B {
+        readonly name: string;
+        readonly next?: A;
+      }
+
+      export class UseIt {
+        public main(list: A) {
+          Array.isArray(list);
+        }
+      }
+    `);
+
+    test.done();
+  },
 };

--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -142,9 +142,14 @@ export class TypeSystem {
   }
 
   public findAssembly(name: string) {
-    if (!(name in this._assemblyLookup)) {
+    const ret = this.tryFindAssembly(name);
+    if (!ret) {
       throw new Error(`Assembly "${name}" not found`);
     }
+    return ret;
+  }
+
+  public tryFindAssembly(name: string): Assembly | undefined {
     return this._assemblyLookup[name];
   }
 
@@ -156,8 +161,8 @@ export class TypeSystem {
 
   public tryFindFqn(fqn: string): Type | undefined {
     const [ assembly ] = fqn.split('.');
-    const asm = this.findAssembly(assembly);
-    return asm.tryFindType(fqn);
+    const asm = this.tryFindAssembly(assembly);
+    return asm && asm.tryFindType(fqn);
   }
 
   public findClass(fqn: string): ClassType {


### PR DESCRIPTION
Structural type checking would recurse endlessly if a struct had a
member with the same type as itself, or the same type as a struct that
contained itself.

Add a cache to prevent infinite recursion.

Also in this commit: `tryFindFqn` no longer explodes if the referenced
assembly couldn't be found, but simply returns `undefined` as it should.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
