### PR TITLE
fix(pacmak): fix .NET generated .csproj files using incorrect version for Amazon.JSII.Runtime

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -88,7 +88,9 @@ export class FileGenerator {
         const packageReference = itemGroup2.ele("PackageReference");
         packageReference.att("Include", "Amazon.JSII.Runtime");
 
-        packageReference.att("Version", assembly.version);
+        // Strip " (build abcdef)" from the jsii version
+        const jsiiVersionSimple = assembly.jsiiVersion.replace(/ .*$/, '');
+        packageReference.att("Version", jsiiVersionSimple);
 
         dependencies.forEach((value: DotNetDependency) => {
             const dependencyReference = itemGroup2.ele("PackageReference");


### PR DESCRIPTION
The generated .csproj file is currently using the same version for Package Version and the
version for Amazon.JSII.Runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
